### PR TITLE
Missions: MC rounded path at next waypoint

### DIFF
--- a/en/flight_modes/mission.md
+++ b/en/flight_modes/mission.md
@@ -132,7 +132,7 @@ Note:
 PX4 expects to follow a straight line from the previous waypoint to the current target (it does not plan any other kind of path between waypoints - if you need one you can simulate this by adding additional waypoints).
 
 MC vehicles will change the *speed* when approaching or leaving a waypoint based on the [jerk-limited](../config_mc/mc_jerk_limited_type_trajectory.md#auto-mode) tuning.
-
+The vehicle will follow a smooth rounded curve towards the next waypoint (if one is defined) defined by the acceptance radius ([NAV_ACC_RAD](../advanced_config/parameter_reference.md#NAV_ACC_RAD)).
 
 Vehicles switch to the next waypoint as soon as they enter the acceptance radius. 
 - For MC this radius is defined by [NAV_ACC_RAD](../advanced_config/parameter_reference.md#NAV_ACC_RAD)


### PR DESCRIPTION
@bresch 
My imagination is that both FW and MC follow a similar curve around waypoints where they will go through the acceptance circle if that path works, but otherwise they will fly a path that touches the "acceptance radius circle" at some tanjent that makes a short tangent to the next waypoint. 
[The main difference between MC and FW being how the radius is defined]

![image](https://user-images.githubusercontent.com/5368500/93164760-a9bd5c00-f75d-11ea-8e89-5abcaedbdcfc.png)

I am not sure therefore that the current text even with this addition is correct. :
- "PX4 expects to follow a straight line from the previous waypoint to the current target," implies that the vehicle is heading center to center, while in fact it will head (presumably) towards the tanjent to the acceptance radius that produces the "best" curve to the next waypoint.
- It isn't clear whether the comment about the speed changing is still true.
- It isn't clear how the path is chosen - ie will it always go on the "inside" path, or does it look forward to multiple waypoints to work out a path.

Can you clarify?