### PR TITLE
Switch all adding_a_new_frame links from airframes/ to dev_airframes/ folder

### DIFF
--- a/de/advanced/parameters_and_configurations.md
+++ b/de/advanced/parameters_and_configurations.md
@@ -4,7 +4,7 @@ PX4 uses the *param subsystem* (a flat table of `float` and `int32_t` values) an
 
 This section discusses the *param* subsystem in detail. It covers how to list, save and load parameters, and how to define them.
 
-> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../airframes/adding_a_new_frame.md) work are detailed on other pages.
+> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../dev_airframes/adding_a_new_frame.md) work are detailed on other pages.
 
 
 ## Command Line Usage
@@ -70,7 +70,7 @@ param save
 ```
 ```sh
 # Merge the saved parameters with current parameters
-param import /fs/microsd/vtol_param_backup  
+param import /fs/microsd/vtol_param_backup
 ```
 
 
@@ -157,7 +157,7 @@ void Module::parameters_update(int parameter_update_sub, bool force)
 
     if (force || updated) {
         // If any parameter updated, call updateParams() to check if
-        // this class attributes need updating (and do so). 
+        // this class attributes need updating (and do so).
         updateParams();
     }
 }

--- a/de/concept/mixing.md
+++ b/de/concept/mixing.md
@@ -249,7 +249,7 @@ When used to mix vehicle controls, mixer group zero is the vehicle attitude cont
 
 The remaining fields on the line configure the control scaler with parameters as discussed above. Whilst the calculations are performed as floating-point operations, the values stored in the definition file are scaled by a factor of 10000; i.e. an offset of -0.5 is encoded as -5000.
 
-An example of a typical mixer file is explained [here](../airframes/adding_a_new_frame.md#mixer-file).
+An example of a typical mixer file is explained [here](../dev_airframes/adding_a_new_frame.md#mixer-file).
 
 <a id="null_mixer"></a>
 

--- a/de/concept/system_startup.md
+++ b/de/concept/system_startup.md
@@ -2,7 +2,7 @@
 
 The PX4 startup is controlled by shell scripts. On NuttX they reside in the [ROMFS/px4fmu_common/init.d](https://github.com/PX4/PX4-Autopilot/tree/master/ROMFS/px4fmu_common/init.d) folder - some of these are also used on Posix (Linux/MacOS). The scripts that are only used on Posix are located in [ROMFS/px4fmu_common/init.d-posix](https://github.com/PX4/PX4-Autopilot/tree/master/ROMFS/px4fmu_common/init.d-posix).
 
-All files starting with a number and underscore (e.g. `10000_airplane`) are predefined airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](../airframes/adding_a_new_frame.md).
+All files starting with a number and underscore (e.g. `10000_airplane`) are predefined airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](../dev_airframes/adding_a_new_frame.md).
 
 The remaining files are part of the general startup logic. The first executed file is the [init.d/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d/rcS) script (or [init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS) on Posix), which calls all other scripts.
 
@@ -55,7 +55,7 @@ In most cases customizing the default boot is the better approach, which is docu
 
 ### Customizing the System Startup
 
-The best way to customize the system startup is to introduce a [new airframe configuration](../airframes/adding_a_new_frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
+The best way to customize the system startup is to introduce a [new airframe configuration](../dev_airframes/adding_a_new_frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
 
 > **Caution** The system boot files are UNIX FILES which require UNIX LINE ENDINGS. If editing on Windows use a suitable editor.
 

--- a/en/advanced/parameters_and_configurations.md
+++ b/en/advanced/parameters_and_configurations.md
@@ -5,7 +5,7 @@ PX4 uses the *param subsystem* (a flat table of `float` and `int32_t` values) an
 This section discusses the *param* subsystem in detail.
 It covers how to list, save and load parameters, and how to define them.
 
-> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../airframes/adding_a_new_frame.md) work are detailed on other pages. 
+> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../dev_airframes/adding_a_new_frame.md) work are detailed on other pages.
 
 
 ## Command Line Usage
@@ -53,11 +53,11 @@ If provided with an argument, it will store the parameters instead to this new l
 param save /fs/microsd/vtol_param_backup
 ```
 
-There are two different commands to *load* parameters: 
+There are two different commands to *load* parameters:
 - `param load` first does a full reset of all parameters to their defaults, and then overwrites parameter values with any values stored in the file.
 - `param import` just overwrites parameter values with the values from the file and then saves the result (i.e. effectively calls `param save`).
 
-The `load` effectively resets the parameters to the state when the parameters were saved (we say "effectively" because any parameters saved in the file will be updated, but other parameters may have different firmware-defined default values than when the parameters file was created). 
+The `load` effectively resets the parameters to the state when the parameters were saved (we say "effectively" because any parameters saved in the file will be updated, but other parameters may have different firmware-defined default values than when the parameters file was created).
 
 By contrast, `import` merges the parameters in the file with the current state of the vehicle.
 This can be used, for example, to just import a parameter file containing calibration data, without overwriting the rest of the system configuration.
@@ -72,7 +72,7 @@ param save
 ```
 ```sh
 # Merge the saved parameters with current parameters
-param import /fs/microsd/vtol_param_backup  
+param import /fs/microsd/vtol_param_backup
 ```
 
 
@@ -95,15 +95,15 @@ Synchronization is important because a parameter can be changed to another value
 Your code should *always* use the current value from the parameter store.
 If getting the latest version is not possible, then a reboot will be required after the parameter is changed (set this requirement using the `@reboot_required` metadata).
 
-In addition, the C++ version has also better type-safety and less overhead in terms of RAM. 
+In addition, the C++ version has also better type-safety and less overhead in terms of RAM.
 The drawback is that the parameter name must be known at compile-time, while the C API can take a dynamically created name as a string.
 
 
 ### C++ API
 
-The C++ API provides macros to declare parameters as *class attributes*. 
+The C++ API provides macros to declare parameters as *class attributes*.
 You add some "boilerplate" code to regularly listen for changes in the [uORB Topic](../middleware/uorb.md) associated with *any* parameter update.
-Framework code then (invisibly) handles tracking uORB messages that affect your parameter attributes and keeping them in sync. 
+Framework code then (invisibly) handles tracking uORB messages that affect your parameter attributes and keeping them in sync.
 In the rest of the code you can just use the defined parameter attributes and they will always be up to date!
 
 First include **px4_platform_common/module_params.h** in the class header for your module or driver (to get the `DEFINE_PARAMETERS` macro):
@@ -140,7 +140,7 @@ First include the header to access the uORB parameter_update message:
 ```cpp
 #include <uORB/topics/parameter_update.h>
 ```
-Subscribe to the update message when the module/driver starts and un-subscribe when it is stopped. 
+Subscribe to the update message when the module/driver starts and un-subscribe when it is stopped.
 `parameter_update_sub` returned by `orb_subscribe()` is a handle we can use to refer to this particular subscription.
 ```cpp
 # Subscribe to parameter_update message
@@ -167,7 +167,7 @@ void Module::parameters_update(int parameter_update_sub, bool force)
 
 	if (force || updated) {
 		// If any parameter updated, call updateParams() to check if
-		// this class attributes need updating (and do so). 
+		// this class attributes need updating (and do so).
 		updateParams();
 	}
 }
@@ -201,9 +201,9 @@ int32_t my_param = 0;
 param_get(param_find("PARAM_NAME"), &my_param);
 ```
 
-> **Note** If `PARAM_NAME` was declared in parameter metadata then its default value will be set, and the above call to find the parameter should always succeed. 
+> **Note** If `PARAM_NAME` was declared in parameter metadata then its default value will be set, and the above call to find the parameter should always succeed.
 
-`param_find()` is an "expensive" operation, which returns a handle that can be used by `param_get()`. 
+`param_find()` is an "expensive" operation, which returns a handle that can be used by `param_get()`.
 If you're going to read the parameter multiple times, you may cache the handle and use it in `param_get()` when needed
 ```cpp
 # Get the handle to the parameter
@@ -224,7 +224,7 @@ PX4 uses an extensive parameter metadata system to drive the user-facing present
 > **Tip** Correct meta data is critical for good user experience in a ground station.
 
 Parameter metadata can be stored anywhere in the source tree as either **.c** or **.yaml** parameter definitions (the YAML definition is newer, and more flexible).
-Typically it is stored alongside its associated module. 
+Typically it is stored alongside its associated module.
 
 The build system extracts the metadata (using `make parameters_metadata`) to build the [parameter reference](../advanced_config/parameter_reference.md) and the parameter information used by ground stations.
 
@@ -292,7 +292,7 @@ The purpose of each line is given below (for more detail see [module_schema.yaml
 
 > **Note** At time of writing YAML parameter definitions cannot be used in *libraries*.
 
-YAML meta data is intended as a full replacement for the **.c** definitions. 
+YAML meta data is intended as a full replacement for the **.c** definitions.
 It supports all the same metadata, along with new features like multi-instance definitions.
 
 - The YAML parameter metadata schema is here: [validation/module_schema.yaml](https://github.com/PX4/PX4-Autopilot/blob/master/validation/module_schema.yaml).
@@ -311,7 +311,7 @@ MY_PARAM_${i}_RATE:
                 short: Maximum rate for instance ${i}
 ```
 
-The following YAML definitions provide the start and end indexes. 
+The following YAML definitions provide the start and end indexes.
 - `num_instances` (default 1): Number of instances to generate (>=1)
 - `instance_start` (default 0): First instance number. If 0, `${i}` expands to [0, N-1]`.
 

--- a/en/concept/mixing.md
+++ b/en/concept/mixing.md
@@ -207,7 +207,7 @@ See above for more information on [mixer loading](#loading_mixer).
 <a id="mixer_syntax"></a>
 ### Syntax
 
-Mixer files are text files that define one or more mixer definitions: mappings between one or more inputs and one or more outputs. 
+Mixer files are text files that define one or more mixer definitions: mappings between one or more inputs and one or more outputs.
 
 There are four types of mixers definitions: [multirotor mixer](#multirotor_mixer), [helicopter mixer](#helicopter_mixer), [summing mixer](#summing_mixer), and [null mixer](#null_mixer).
 - [Multirotor mixer](#multirotor_mixer) - Defines outputs for 4, 6, or 8 rotor vehicles with + or X geometry.
@@ -280,7 +280,7 @@ When used to mix vehicle controls, mixer group zero is the vehicle attitude cont
 The remaining fields on the line configure the control scaler with parameters as discussed above.
 Whilst the calculations are performed as floating-point operations, the values stored in the definition file are scaled by a factor of 10000; i.e. an offset of -0.5 is encoded as -5000.
 
-An example of a typical mixer file is explained [here](../airframes/adding_a_new_frame.md#mixer-file).
+An example of a typical mixer file is explained [here](../dev_airframes/adding_a_new_frame.md#mixer-file).
 
 
 <a id="null_mixer"></a>
@@ -315,7 +315,7 @@ The supported geometries include:
 * 6+ - hexacopter in + configuration
 * 8x - octocopter in X configuration
 * 8+ - octocopter in + configuration
-  
+
 Each of the roll, pitch and yaw scale values determine scaling of the roll, pitch and yaw controls relative to the thrust control.
 Whilst the calculations are performed as floating-point operations, the values stored in the definition file are scaled by a factor of 10000; i.e. an factor of 0.5 is encoded as 5000.
 

--- a/en/concept/system_startup.md
+++ b/en/concept/system_startup.md
@@ -6,7 +6,7 @@ The scripts that are only used on Posix are located in [ROMFS/px4fmu_common/init
 
 All files starting with a number and underscore (e.g. `10000_airplane`) are predefined airframe configurations.
 They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI.
-Adding a new configuration is covered [here](../airframes/adding_a_new_frame.md).
+Adding a new configuration is covered [here](../dev_airframes/adding_a_new_frame.md).
 
 The remaining files are part of the general startup logic.
 The first executed file is the [init.d/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d/rcS) script (or [init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS) on Posix), which calls all other scripts.
@@ -73,7 +73,7 @@ In most cases customizing the default boot is the better approach, which is docu
 
 ### Customizing the System Startup
 
-The best way to customize the system startup is to introduce a [new airframe configuration](../airframes/adding_a_new_frame.md).
+The best way to customize the system startup is to introduce a [new airframe configuration](../dev_airframes/adding_a_new_frame.md).
 If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
 
 > **Caution** The system boot files are UNIX FILES which require UNIX LINE ENDINGS. If editing on Windows use a suitable editor.
@@ -109,11 +109,11 @@ The following example shows how to start custom applications:
     set -e
 
     mandatory_app start     # Will abort boot if mandatory_app is unknown or fails
-    ```  
+    ```
 
 #### Starting a custom mixer
 
-By default the system loads the mixer from `/etc/mixers`. 
+By default the system loads the mixer from `/etc/mixers`.
 If a file with the same name exists in `/fs/microsd/etc/mixers` this file will be loaded instead.
 This allows to customize the mixer file without the need to recompile the Firmware.
 

--- a/ja/advanced/parameters_and_configurations.md
+++ b/ja/advanced/parameters_and_configurations.md
@@ -4,7 +4,7 @@ PX4 uses the *param subsystem* (a flat table of `float` and `int32_t` values) an
 
 This section discusses the *param* subsystem in detail. It covers how to list, save and load parameters, and how to define them.
 
-> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../airframes/adding_a_new_frame.md) work are detailed on other pages.
+> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../dev_airframes/adding_a_new_frame.md) work are detailed on other pages.
 
 
 ## Command Line Usage
@@ -70,7 +70,7 @@ param save
 ```
 ```sh
 # Merge the saved parameters with current parameters
-param import /fs/microsd/vtol_param_backup  
+param import /fs/microsd/vtol_param_backup
 ```
 
 
@@ -157,7 +157,7 @@ void Module::parameters_update(int parameter_update_sub, bool force)
 
     if (force || updated) {
         // If any parameter updated, call updateParams() to check if
-        // this class attributes need updating (and do so). 
+        // this class attributes need updating (and do so).
         updateParams();
     }
 }

--- a/ja/concept/mixing.md
+++ b/ja/concept/mixing.md
@@ -249,7 +249,7 @@ When used to mix vehicle controls, mixer group zero is the vehicle attitude cont
 
 The remaining fields on the line configure the control scaler with parameters as discussed above. Whilst the calculations are performed as floating-point operations, the values stored in the definition file are scaled by a factor of 10000; i.e. an offset of -0.5 is encoded as -5000.
 
-An example of a typical mixer file is explained [here](../airframes/adding_a_new_frame.md#mixer-file).
+An example of a typical mixer file is explained [here](../dev_airframes/adding_a_new_frame.md#mixer-file).
 
 <a id="null_mixer"></a>
 

--- a/ja/concept/system_startup.md
+++ b/ja/concept/system_startup.md
@@ -2,7 +2,7 @@
 
 The PX4 startup is controlled by shell scripts. On NuttX they reside in the [ROMFS/px4fmu_common/init.d](https://github.com/PX4/PX4-Autopilot/tree/master/ROMFS/px4fmu_common/init.d) folder - some of these are also used on Posix (Linux/MacOS). The scripts that are only used on Posix are located in [ROMFS/px4fmu_common/init.d-posix](https://github.com/PX4/PX4-Autopilot/tree/master/ROMFS/px4fmu_common/init.d-posix).
 
-All files starting with a number and underscore (e.g. `10000_airplane`) are predefined airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](../airframes/adding_a_new_frame.md).
+All files starting with a number and underscore (e.g. `10000_airplane`) are predefined airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](../dev_airframes/adding_a_new_frame.md).
 
 The remaining files are part of the general startup logic. The first executed file is the [init.d/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d/rcS) script (or [init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS) on Posix), which calls all other scripts.
 
@@ -55,7 +55,7 @@ In most cases customizing the default boot is the better approach, which is docu
 
 ### Customizing the System Startup
 
-The best way to customize the system startup is to introduce a [new airframe configuration](../airframes/adding_a_new_frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
+The best way to customize the system startup is to introduce a [new airframe configuration](../dev_airframes/adding_a_new_frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
 
 > **Caution** The system boot files are UNIX FILES which require UNIX LINE ENDINGS. If editing on Windows use a suitable editor.
 

--- a/ko/advanced/parameters_and_configurations.md
+++ b/ko/advanced/parameters_and_configurations.md
@@ -4,7 +4,7 @@ PX4 uses the *param subsystem* (a flat table of `float` and `int32_t` values) an
 
 This section discusses the *param* subsystem in detail. It covers how to list, save and load parameters, and how to define them.
 
-> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../airframes/adding_a_new_frame.md) work are detailed on other pages.
+> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../dev_airframes/adding_a_new_frame.md) work are detailed on other pages.
 
 
 ## Command Line Usage
@@ -70,7 +70,7 @@ param save
 ```
 ```sh
 # Merge the saved parameters with current parameters
-param import /fs/microsd/vtol_param_backup  
+param import /fs/microsd/vtol_param_backup
 ```
 
 
@@ -157,7 +157,7 @@ void Module::parameters_update(int parameter_update_sub, bool force)
 
     if (force || updated) {
         // If any parameter updated, call updateParams() to check if
-        // this class attributes need updating (and do so). 
+        // this class attributes need updating (and do so).
         updateParams();
     }
 }

--- a/ko/concept/mixing.md
+++ b/ko/concept/mixing.md
@@ -243,14 +243,14 @@ S: <group> <index> <-ve scale> <+ve scale> <offset> <lower limit> <upper limit>
 
 > **Note** The `S:` lines must be below the `O:` line.
 
-The `<group>` value identifies the control group from which the scaler will read, and the `<index>` value an offset within that group.  
+The `<group>` value identifies the control group from which the scaler will read, and the `<index>` value an offset within that group.
 These values are specific to the device reading the mixer definition. These values are specific to the device reading the mixer definition.
 
 When used to mix vehicle controls, mixer group zero is the vehicle attitude control group, and index values zero through three are normally roll, pitch, yaw and thrust respectively.
 
 The remaining fields on the line configure the control scaler with parameters as discussed above. Whilst the calculations are performed as floating-point operations, the values stored in the definition file are scaled by a factor of 10000; i.e. an offset of -0.5 is encoded as -5000.
 
-An example of a typical mixer file is explained [here](../airframes/adding_a_new_frame.md#mixer-file).
+An example of a typical mixer file is explained [here](../dev_airframes/adding_a_new_frame.md#mixer-file).
 
 <a id="null_mixer"></a>
 

--- a/ko/concept/system_startup.md
+++ b/ko/concept/system_startup.md
@@ -2,7 +2,7 @@
 
 The PX4 startup is controlled by shell scripts. On NuttX they reside in the [ROMFS/px4fmu_common/init.d](https://github.com/PX4/Firmware/tree/master/ROMFS/px4fmu_common/init.d) folder - some of these are also used on Posix (Linux/MacOS). The scripts that are only used on Posix are located in [ROMFS/px4fmu_common/init.d-posix](https://github.com/PX4/Firmware/tree/master/ROMFS/px4fmu_common/init.d-posix).
 
-All files starting with a number and underscore (e.g. `10000_airplane`) are canned airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](../airframes/adding_a_new_frame.md).
+All files starting with a number and underscore (e.g. `10000_airplane`) are canned airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](../dev_airframes/adding_a_new_frame.md).
 
 The remaining files are part of the general startup logic. The first executed file is the [init.d/rcS](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d/rcS) script (or [init.d-posix/rcS](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS) on Posix), which calls all other scripts.
 
@@ -55,7 +55,7 @@ In most cases customizing the default boot is the better approach, which is docu
 
 ### Customizing the System Startup
 
-The best way to customize the system startup is to introduce a [new airframe configuration](../airframes/adding_a_new_frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
+The best way to customize the system startup is to introduce a [new airframe configuration](../dev_airframes/adding_a_new_frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
 
 > **Caution** The system boot files are UNIX FILES which require UNIX LINE ENDINGS. If editing on Windows use a suitable editor.
 

--- a/ru/advanced/parameters_and_configurations.md
+++ b/ru/advanced/parameters_and_configurations.md
@@ -4,7 +4,7 @@ PX4 uses the *param subsystem* (a flat table of `float` and `int32_t` values) an
 
 This section discusses the *param* subsystem in detail. It covers how to list, save and load parameters, and how to define them.
 
-> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../airframes/adding_a_new_frame.md) work are detailed on other pages.
+> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../dev_airframes/adding_a_new_frame.md) work are detailed on other pages.
 
 
 ## Command Line Usage
@@ -70,7 +70,7 @@ param save
 ```
 ```sh
 # Merge the saved parameters with current parameters
-param import /fs/microsd/vtol_param_backup  
+param import /fs/microsd/vtol_param_backup
 ```
 
 
@@ -157,7 +157,7 @@ void Module::parameters_update(int parameter_update_sub, bool force)
 
     if (force || updated) {
         // If any parameter updated, call updateParams() to check if
-        // this class attributes need updating (and do so). 
+        // this class attributes need updating (and do so).
         updateParams();
     }
 }

--- a/ru/concept/mixing.md
+++ b/ru/concept/mixing.md
@@ -249,7 +249,7 @@ When used to mix vehicle controls, mixer group zero is the vehicle attitude cont
 
 The remaining fields on the line configure the control scaler with parameters as discussed above. Whilst the calculations are performed as floating-point operations, the values stored in the definition file are scaled by a factor of 10000; i.e. an offset of -0.5 is encoded as -5000.
 
-An example of a typical mixer file is explained [here](../airframes/adding_a_new_frame.md#mixer-file).
+An example of a typical mixer file is explained [here](../dev_airframes/adding_a_new_frame.md#mixer-file).
 
 <a id="null_mixer"></a>
 

--- a/ru/concept/system_startup.md
+++ b/ru/concept/system_startup.md
@@ -2,7 +2,7 @@
 
 The PX4 startup is controlled by shell scripts. On NuttX they reside in the [ROMFS/px4fmu_common/init.d](https://github.com/PX4/PX4-Autopilot/tree/master/ROMFS/px4fmu_common/init.d) folder - some of these are also used on Posix (Linux/MacOS). The scripts that are only used on Posix are located in [ROMFS/px4fmu_common/init.d-posix](https://github.com/PX4/PX4-Autopilot/tree/master/ROMFS/px4fmu_common/init.d-posix).
 
-All files starting with a number and underscore (e.g. `10000_airplane`) are predefined airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](../airframes/adding_a_new_frame.md).
+All files starting with a number and underscore (e.g. `10000_airplane`) are predefined airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](../dev_airframes/adding_a_new_frame.md).
 
 The remaining files are part of the general startup logic. The first executed file is the [init.d/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d/rcS) script (or [init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS) on Posix), which calls all other scripts.
 
@@ -55,7 +55,7 @@ In most cases customizing the default boot is the better approach, which is docu
 
 ### Customizing the System Startup
 
-The best way to customize the system startup is to introduce a [new airframe configuration](../airframes/adding_a_new_frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
+The best way to customize the system startup is to introduce a [new airframe configuration](../dev_airframes/adding_a_new_frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
 
 > **Caution** The system boot files are UNIX FILES which require UNIX LINE ENDINGS. If editing on Windows use a suitable editor.
 

--- a/tr/advanced/parameters_and_configurations.md
+++ b/tr/advanced/parameters_and_configurations.md
@@ -4,7 +4,7 @@ PX4 uses the *param subsystem* (a flat table of `float` and `int32_t` values) an
 
 This section discusses the *param* subsystem in detail. It covers how to list, save and load parameters, and how to define them.
 
-> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../airframes/adding_a_new_frame.md) work are detailed on other pages.
+> **Note** [System startup](../concept/system_startup.md) and the way that [airframe configurations](../dev_airframes/adding_a_new_frame.md) work are detailed on other pages.
 
 
 ## Command Line Usage
@@ -70,7 +70,7 @@ param save
 ```
 ```sh
 # Merge the saved parameters with current parameters
-param import /fs/microsd/vtol_param_backup  
+param import /fs/microsd/vtol_param_backup
 ```
 
 
@@ -157,7 +157,7 @@ void Module::parameters_update(int parameter_update_sub, bool force)
 
     if (force || updated) {
         // If any parameter updated, call updateParams() to check if
-        // this class attributes need updating (and do so). 
+        // this class attributes need updating (and do so).
         updateParams();
     }
 }

--- a/tr/concept/mixing.md
+++ b/tr/concept/mixing.md
@@ -249,7 +249,7 @@ When used to mix vehicle controls, mixer group zero is the vehicle attitude cont
 
 The remaining fields on the line configure the control scaler with parameters as discussed above. Whilst the calculations are performed as floating-point operations, the values stored in the definition file are scaled by a factor of 10000; i.e. an offset of -0.5 is encoded as -5000.
 
-An example of a typical mixer file is explained [here](../airframes/adding_a_new_frame.md#mixer-file).
+An example of a typical mixer file is explained [here](../dev_airframes/adding_a_new_frame.md#mixer-file).
 
 <a id="null_mixer"></a>
 

--- a/tr/concept/system_startup.md
+++ b/tr/concept/system_startup.md
@@ -2,7 +2,7 @@
 
 The PX4 startup is controlled by shell scripts. On NuttX they reside in the [ROMFS/px4fmu_common/init.d](https://github.com/PX4/PX4-Autopilot/tree/master/ROMFS/px4fmu_common/init.d) folder - some of these are also used on Posix (Linux/MacOS). The scripts that are only used on Posix are located in [ROMFS/px4fmu_common/init.d-posix](https://github.com/PX4/PX4-Autopilot/tree/master/ROMFS/px4fmu_common/init.d-posix).
 
-All files starting with a number and underscore (e.g. `10000_airplane`) are predefined airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](../airframes/adding_a_new_frame.md).
+All files starting with a number and underscore (e.g. `10000_airplane`) are predefined airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](../dev_airframes/adding_a_new_frame.md).
 
 The remaining files are part of the general startup logic. The first executed file is the [init.d/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d/rcS) script (or [init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS) on Posix), which calls all other scripts.
 
@@ -55,7 +55,7 @@ In most cases customizing the default boot is the better approach, which is docu
 
 ### Customizing the System Startup
 
-The best way to customize the system startup is to introduce a [new airframe configuration](../airframes/adding_a_new_frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
+The best way to customize the system startup is to introduce a [new airframe configuration](../dev_airframes/adding_a_new_frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
 
 > **Caution** The system boot files are UNIX FILES which require UNIX LINE ENDINGS. If editing on Windows use a suitable editor.
 

--- a/zh/advanced/parameters_and_configurations.md
+++ b/zh/advanced/parameters_and_configurations.md
@@ -4,13 +4,13 @@ PX4 使用 *param subsystem *（`float` 和 `int32_t` 值的平面表）和文�
 
 本节详细讨论 *param* 子系统。 This section discusses the *param* subsystem in detail. It covers how to list, save and load parameters, and how to define them.
 
-> **Note** 在其他页面上详细介绍了 [System 启动 ](../concept/system_startup.md) 和 [airframe 配置 ](../airframes/adding_a_new_frame.md) 工作方式。
+> **Note** 在其他页面上详细介绍了 [System 启动 ](../concept/system_startup.md) 和 [airframe 配置 ](../dev_airframes/adding_a_new_frame.md) 工作方式。
 
 
 ## 命令行使用方法
 
 PX4
-system 控制台/0 > 提供了 [param](../middleware/modules_command.md#param) 工具，可用于设置参数、读取其值、保存参数以及从文件中导出和还原参数。</p> 
+system 控制台/0 > 提供了 [param](../middleware/modules_command.md#param) 工具，可用于设置参数、读取其值、保存参数以及从文件中导出和还原参数。</p>
 
 
 
@@ -72,18 +72,18 @@ param save /fs/microsd/vtol_param_backup
 ```
 
 
-有两个不同的命令可用于 *load* 参数: 
+有两个不同的命令可用于 *load* 参数:
 
 - `param load ` 首先将所有参数完全重置为默认值，然后用存储在文件中的任何值覆盖参数值。
 - `param import ` 只是用文件中的值覆盖参数值，然后保存结果（即有效调用 `param save</0 >）。</li>
 </ul>
 
-<p spaces-before="0"><code>load` 有效地将参数重置为保存参数时的状态（我们说 "有效"，因为保存在文件中的任何参数都将被更新，但其他参数可能具有与参数文件）。 </p> 
+<p spaces-before="0"><code>load` 有效地将参数重置为保存参数时的状态（我们说 "有效"，因为保存在文件中的任何参数都将被更新，但其他参数可能具有与参数文件）。 </p>
   相比之下，`import` 将文件中的参数与车辆的当前状态合并。 By contrast, `import` merges the parameters in the file with the current state of the vehicle. This can be used, for example, to just import a parameter file containing calibration data, without overwriting the rest of the system configuration.
-  
+
   这两种情况的示例如下所示:
-  
-  
+
+
 
 ```sh
 # 将参数重置为保存文件时,
@@ -96,7 +96,7 @@ param save
 
 ```sh
 # 将保存的参数与当前参数合并
-param import /fs/microsd/vtol_param_backup  
+param import /fs/microsd/vtol_param_backup
 ```
 
 
@@ -216,10 +216,10 @@ void Module::parameters_update(int parameter_update_sub, bool force)
 
     if (force || updated) {
         // If any parameter updated, call updateParams() to check if
-        // this class attributes need updating (and do so). 
+        // this class attributes need updating (and do so).
         updateParams();
     }
-} 
+}
         updateParams();
     }
 }
@@ -266,7 +266,7 @@ param_get(param_find("PARAM_NAME"), &my_param);
 
 
 
-> **Note** 如果在参数元数据中声明了 `PARAM_NAME`，则将设置其默认值，上述查找参数的调用应始终成功。 
+> **Note** 如果在参数元数据中声明了 `PARAM_NAME`，则将设置其默认值，上述查找参数的调用应始终成功。
 
 `param_find()` 是一个 "昂贵" 的操作，它返回可供 `param_get()` 使用的句柄。 `param_find()` is an "expensive" operation, which returns a handle that can be used by `param_get()`. If you're going to read the parameter multiple times, you may cache the handle and use it in `param_get()` when needed
 
@@ -291,7 +291,7 @@ PX4 使用广泛的参数元数据系统来驱动面向用户的参数表示，�
 
 > **Tip** 正确的元数据对于在地面站获得良好的用户体验至关重要。
 
-Parameter metadata can be stored anywhere in the source tree as either **.c** or **.yaml** parameter definitions (the YAML definition is newer, and more flexible). 通常，它与关联的模块一起存储。 
+Parameter metadata can be stored anywhere in the source tree as either **.c** or **.yaml** parameter definitions (the YAML definition is newer, and more flexible). 通常，它与关联的模块一起存储。
 
 The build system extracts the metadata (using `make parameters_metadata`) to build the [parameter reference](../advanced/parameter_reference.md) and the parameter information used by ground stations.
 
@@ -415,7 +415,7 @@ MY_PARAM_${i}_RATE:
 ```
 
 
-The following YAML definitions provide the start and end indexes. 
+The following YAML definitions provide the start and end indexes.
 
 - `num_instances` (default 1): Number of instances to generate (>=1)
 - `instance_start` (default 0): First instance number. If 0, `${i}` expands to [0, N-1]`.

--- a/zh/concept/mixing.md
+++ b/zh/concept/mixing.md
@@ -206,7 +206,7 @@ You can specify more than one mixer in each file. The output order (allocation o
 <tag>: <mixer arguments>
 ```
 
-[这里](../airframes/adding_a_new_frame.md#mixer-file) 是一个典型混控器的示例文件。
+[这里](../dev_airframes/adding_a_new_frame.md#mixer-file) 是一个典型混控器的示例文件。
 - `R`: [Multirotor mixer](#multirotor_mixer)
 - `H`: [Helicopter mixer](#helicopter_mixer)
 - `M`: [Summing mixer](#summing_mixer)
@@ -243,14 +243,14 @@ S: <group> <index> <-ve scale> <+ve scale> <offset> <lower limit> <upper limit>
 
 > **Note** `S:` l行必须处于 `O:` 的下面。
 
-`&lt;group&gt;` 参数指定了缩放器从哪个控制组中读取数据，而 `&lt;index&gt;` 参数则是定义了该控制组的偏移值。   
+`&lt;group&gt;` 参数指定了缩放器从哪个控制组中读取数据，而 `&lt;index&gt;` 参数则是定义了该控制组的偏移值。
 这些参数的设定值会随着读取混控器定义文件的设备的不同而发生改变。
 
 当将混控器用于混合飞机的控制量时，编号为 0 的混控器组为飞机的姿态控制组，该控制组内编号 0 - 3 的选项通常分别便是滚转、俯仰、偏航和推力。
 
 剩下的字段则是使用上文提及的缩放参数对控制量的缩放器进行了设定。 同时，结果的计算是以浮点计算的形式进行的，在混控器定义文件中的值都将缩小 10000 倍，比如：实际中 -0.5 的偏移量（offset）在定义文件中保存为 -5000 。
 
-[这里](../airframes/adding_a_new_frame.md#mixer-file) 是一个典型混控器的示例文件。
+[这里](../dev_airframes/adding_a_new_frame.md#mixer-file) 是一个典型混控器的示例文件。
 
 <a id="null_mixer"></a>
 

--- a/zh/concept/system_startup.md
+++ b/zh/concept/system_startup.md
@@ -2,7 +2,7 @@
 
 PX4 系统的启动由 shell 脚本文件控制。 在 NuttX 平台上这些脚本文件位于 [ROMFS/px4fmu_common/init.d](https://github.com/PX4/Firmware/tree/master/ROMFS/px4fmu_common/init.d) 文件夹下 - 该文件夹下的部分脚本文件也适用于 Posix (Linux/MacOS) 平台。 仅适用于 Posix 平台的启动脚本文件可以在 [ROMFS/px4fmu_common/init.d-posix](https://github.com/PX4/Firmware/tree/master/ROMFS/px4fmu_common/init.d-posix) 文件夹下找到。
 
-上述文件夹中以数字和下划线为文件名开头的脚本文件（例如，`10000_airplane`）都是封装好的机架构型配置文件。 这些文件在编译时会被导出至 `airframes.xml` 文件中，[QGroundControl](http://qgroundcontrol.com) 通过解析该 xml 文件得到可以在 UI 界面上进行选择的机架构型。 如何添加一个新的配置请参阅 [这里](../airframes/adding_a_new_frame.md)。
+上述文件夹中以数字和下划线为文件名开头的脚本文件（例如，`10000_airplane`）都是封装好的机架构型配置文件。 这些文件在编译时会被导出至 `airframes.xml` 文件中，[QGroundControl](http://qgroundcontrol.com) 通过解析该 xml 文件得到可以在 UI 界面上进行选择的机架构型。 如何添加一个新的配置请参阅 [这里](../dev_airframes/adding_a_new_frame.md)。
 
 其它的文件则是系统常规启动逻辑的一部分。 在启动过程中第一个被系统执行的脚本文件是 [init.d/rcS](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d/rcS) （Posix 平台则为 [init.d-posix/rcS](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS) on Posix)），该脚本会调用所有的其它脚本。
 
@@ -55,7 +55,7 @@ dyn ./test.px4mod
 
 ### 自定义系统的启动文件
 
-自定义系统启动的最佳方法是引入 [新的机架配置](../airframes/adding_a_new_frame.md) 。 如果只需要一些小的调整（比如多启动一个应用程序，或只是启用一个不同的混控器)，那么你可以在启动过程中使用特殊的钩子（hook）来达成目的。
+自定义系统启动的最佳方法是引入 [新的机架配置](../dev_airframes/adding_a_new_frame.md) 。 如果只需要一些小的调整（比如多启动一个应用程序，或只是启用一个不同的混控器)，那么你可以在启动过程中使用特殊的钩子（hook）来达成目的。
 
 > **Caution** 系统的启动文件是 UNIX 系统文件，该文件要求以 UNIX 规范的 LF 作为行结束符。 在 Windows 平台上编辑系统的启动文件应该使用一个合适的文本编辑器。
 


### PR DESCRIPTION
I got a report the second link "airfram_configurations" on this page is broken (404):
http://docs.px4.io/master/en/advanced/parameters_and_configurations.html

I found that the file is now under the `dev_airframes/` folder and replaced all links to that particular file with search and replace. 

@hamishwillee could you please double check since I could not test each and every link since I don't have the rendered docs and I'm not sure if it's the right way to change the link directly also in other languages.