### PR TITLE
Clarify that safety and arm buttons are different

### DIFF
--- a/en/advanced_config/prearm_arm_disarm.md
+++ b/en/advanced_config/prearm_arm_disarm.md
@@ -30,7 +30,7 @@ This reduces the amount of time where an armed (and therefore dangerous) vehicle
 PX4 allows you to configure how pre-arming, arming and disarming work using parameters (which can be edited in *QGroundControl* via the [parameter editor](../advanced_config/parameters.md)), as described in the following sections.
 
 :::tip
-Arming/disarming parameters can be found in [Parameter Reference > Commander](../advanced_config/parameter_reference.md#commander) (search for `COM_ARM_` and `COM_DISARM_*`).
+Arming/disarming parameters can be found in [Parameter Reference > Commander](../advanced_config/parameter_reference.md#commander) (search for `COM_ARM_*` and `COM_DISARM_*`).
 :::
 
 <span id="arm_disarm_gestures"></span>

--- a/en/advanced_config/prearm_arm_disarm.md
+++ b/en/advanced_config/prearm_arm_disarm.md
@@ -7,12 +7,19 @@ To reduce the chance of accidents, PX4 has explicit state(s) for powering the ve
 - **Pre-armed:** Motors/propellers are locked but actuators for non-dangerous electronics are powered (e.g. ailerons, flaps etc.).
 - **Armed:** Vehicle is fully powered. Motors/propellers may be turning (dangerous!)
 
-> **Note** Ground stations may display *disarmed* for both disarmed and pre-armed states.
-  While not technically correct for pre-armed vehicles, it is "safe".
+:::tip Note
+Ground stations may display *disarmed* for pre-armed vehicles.
+While not technically correct for pre-armed vehicles, it is "safe".
+:::
 
 Users can control progression though these states using a [safety switch](../getting_started/px4_basic_concepts.md#safety_switch) on the vehicle (optional) *and* an [arming switch/button](#arm_disarm_switch), [arming gesture](#arm_disarm_gestures),  or *MAVLink command* on the ground controller:
-- A *safety switch* is an optional button or switch *on the vehicle* that completely prevents arming (i.e. motors turning) and which may also prevent prearming (depending on the configuration).
-  It is often part of the GPS reciever, but may be  separate switch.
+- A *safety switch* is an control *on the vehicle* that must be engaged before the vehicle can be armed, and which may also prevent prearming (depending on the configuration).
+  Commonly the safety switch is integrated into a GPS unit, but it may also be a separate physical component.
+  
+  :::warning
+  A vehicle that is armed is potentially dangerous.
+  The safety switch is an additional mechanism that prevents arming from happening by accident.
+  :::  
 - An *arming switch* is a switch or button *on an RC controller* that can be used to arm the vehicle and start motors (provided arming is not prevented by a safety switch).
 - An *arming gesture* is a stick movement *on an RC controller* that can be used as an alternative to an arming switch.
 - MAVLink commands can also be sent by a ground control station to arm/disarm a vehicle.
@@ -22,7 +29,9 @@ This reduces the amount of time where an armed (and therefore dangerous) vehicle
 
 PX4 allows you to configure how pre-arming, arming and disarming work using parameters (which can be edited in *QGroundControl* via the [parameter editor](../advanced_config/parameters.md)), as described in the following sections.
 
-> **Note** Arming/disarming parameters can be found in [Parameter Reference > Commander](../advanced_config/parameter_reference.md#commander) (search for `COM_ARM_` and `COM_DISARM_*`).
+:::tip
+Arming/disarming parameters can be found in [Parameter Reference > Commander](../advanced_config/parameter_reference.md#commander) (search for `COM_ARM_` and `COM_DISARM_*`).
+:::
 
 <span id="arm_disarm_gestures"></span>
 ## Arming Gesture

--- a/en/advanced_config/prearm_arm_disarm.md
+++ b/en/advanced_config/prearm_arm_disarm.md
@@ -9,10 +9,16 @@ To reduce the chance of accidents, PX4 has explicit state(s) for powering the ve
 
 > **Note** Ground stations may display *disarmed* for both disarmed and pre-armed states.
   While not technically correct for pre-armed vehicles, it is "safe".
-  
-A [safety switch](../getting_started/px4_basic_concepts.md#safety_switch) (if available) is used as a precondition for arming the vehicle, and may also be used to enable the pre-armed state.
 
-When permitted, arming is enabled using an [arming gesture](#arm_disarm_gestures), [arming switch](#arm_disarm_switch) or MAVLink command. 
+Users can control progression though these states using a [safety switch](../getting_started/px4_basic_concepts.md#safety_switch) on the vehicle (optional) *and* an [arming switch/button](#arm_disarm_switch), [arming gesture](#arm_disarm_gestures),  or *MAVLink command* on the ground controller:
+- A *safety switch* is an optional button or switch *on the vehicle* that completely prevents arming (i.e. motors turning) and which may also prevent prearming (depending on the configuration).
+  It is often part of the GPS reciever, but may be  separate switch.
+- An *arming switch* is a switch or button *on an RC controller* that can be used to arm the vehicle and start motors (provided arming is not prevented by a safety switch).
+- An *arming gesture* is a stick movement *on an RC controller* that can be used as an alternative to an arming switch.
+- MAVLink commands can also be sent by a ground control station to arm/disarm a vehicle.
+
+PX4 will also automatically disarm the vehicle if it does not takeoff within a certain amount of time after arming, and if it is not manually disarmed after landing.
+This reduces the amount of time where an armed (and therefore dangerous) vehicle is on the ground.
 
 PX4 allows you to configure how pre-arming, arming and disarming work using parameters (which can be edited in *QGroundControl* via the [parameter editor](../advanced_config/parameters.md)), as described in the following sections.
 

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -215,7 +215,7 @@ To reduce the chance of accidents:
 - A vehicle will also usually revert to the disarmed state after landing or if a pilot does not take off quickly enough.
 
 Arming is triggered by default (Mode 2 transmitters) by holding the RC throttle/yaw stick on the *bottom right* for one second (to disarm, hold stick on bottom left).
-It is also possible to configure PX4 to arm using an RC button on the RC control (and arming commands can also be sent from a ground station).
+It is alternatively possible to configure PX4 to arm using an RC switch or button (and arming MAVLink commands can also be sent from a ground station).
 
 A detailed overview of arming and disarming configuration can be found here: [Prearm, Arm, Disarm Configuration](../advanced_config/prearm_arm_disarm.md).
 

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -209,13 +209,13 @@ Vehicles may have moving parts, some of which are potentially dangerous when pow
 
 To reduce the chance of accidents:
 - PX4 vehicles are *disarmed* (unpowered) when not in use, and must be explicitly *armed* before taking off.
-- Some vehicles additionally require a [safety switch](../getting_started/px4_basic_concepts.md#safety_switch) be disengaged before arming can succeed.
+- Some vehicles also have a [safety switch](#safety_switch) that must be disengaged before arming can succeed (often this switch is part of the GPS).
 - Arming is prevented if the vehicle is not in a "healthy" state.
 - Arming is prevented if a VTOL vehicle is in fixed-wing mode ([by default](../advanced_config/parameter_reference.md#CBRK_VTOLARMING)).
 - A vehicle will also usually revert to the disarmed state after landing or if a pilot does not take off quickly enough.
 
 Arming is triggered by default (Mode 2 transmitters) by holding the RC throttle/yaw stick on the *bottom right* for one second (to disarm, hold stick on bottom left).
-It is also possible to configure PX4 to arm using an RC button on the RC control (and arming commands can be sent from a ground station).
+It is also possible to configure PX4 to arm using an RC button on the RC control (and arming commands can also be sent from a ground station).
 
 A detailed overview of arming and disarming configuration can be found here: [Prearm, Arm, Disarm Configuration](../advanced_config/prearm_arm_disarm.md).
 


### PR DESCRIPTION
This attempts to rectify criticism that
- The docs do not clearly explain why that button exists and when to disable
- And how it’s different from the switch on the remote

@LorenzMeier This spells out the difference between safety switch and the arming options - in particular by stating that the safety is on the vehicle while the arming button/gesture is on the controller. 
I haven't specifically said when you should or should not use safety switches other than that they are a useful safety interlock.