### PR TITLE
Document acceleration setpoints for offboard mode

### DIFF
--- a/en/flight_modes/offboard.md
+++ b/en/flight_modes/offboard.md
@@ -39,9 +39,9 @@ The action is defined in the parameters [COM_OBL_ACT](#COM_OBL_ACT) and [COM_OBL
   * The following input combinations are supported: <!-- https://github.com/PX4/PX4-Autopilot/blob/master/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp#L166-L170 -->
     * Position setpoint (only `x`, `y`, `z`)
     * Velocity setpoint (only `vx`, `yy`, `vz`)
-    * *Thrust* setpoint  (only `afx`, `afy`, `afz`)
-      > **Note** Acceleration setpoint values are mapped to create a normalized thrust setpoint (i.e. acceleration setpoints are not "properly" supported).
+    * Acceleration setpoint  (only `afx`, `afy`, `afz`)
     * Position setpoint **and** velocity setpoint (the velocity setpoint is used as feedforward; it is added to the output of the position controller and the result is used as the input to the velocity controller).
+    * Position setpoint **and** velocity setpoint **and** acceleration (the acceleration setpoint is used as feedforward; it is added to the output of the position controller and the result is used as the input to the velocity controller).
   - - PX4 supports the following  `coordinate_frame` values (only): [MAV_FRAME_LOCAL_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_NED) and [MAV_FRAME_BODY_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_BODY_NED).
 
 * [SET_POSITION_TARGET_GLOBAL_INT](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT)


### PR DESCRIPTION
**Problem Description**
This documents the added support of acceleration supports in offboard mode.

Now we can provide acceleration setpoints in combination of position/velocity setpoints. 

This is a documentation of https://github.com/PX4/PX4-Autopilot/pull/15707