### PR TITLE
Update information about simulated batteries

### DIFF
--- a/en/simulation/failsafes.md
+++ b/en/simulation/failsafes.md
@@ -43,12 +43,12 @@ All parameters in SITL including this one get reset when you do `make clean`.
 The simulated battery is implemented to never run out of energy, and by default only depletes to 50% of its capacity and hence reported voltage.
 This enables testing of battery indication in GCS UIs without triggering low battery reactions that might interrupt other testing.
 
-To change this minimal battery percentage value change [this line](https://github.com/PX4/PX4-Autopilot/blob/9d67bbc328553bbd0891ffb8e73b8112bca33fcc/src/modules/simulator/simulator_mavlink.cpp#L330).
+To change this minimal battery percentage value use the parameter [SIM_BAT_MIN_PCT](../advanced_config/parameter_reference.md#SIM_BAT_MIN_PCT).
 
 To control how fast the battery depletes to the minimal value use the parameter [SIM_BAT_DRAIN](../advanced_config/parameter_reference.md#SIM_BAT_DRAIN).
 
 :::tip
-By changing this configuration in flight, you can also test regaining capacity to simulate inaccurate battery state estimation or in-air charging technology.
+By changing [SIM_BAT_MIN_PCT](../advanced_config/parameter_reference.md#SIM_BAT_MIN_PCT) in flight, you can also test regaining capacity to simulate inaccurate battery state estimation or in-air charging technology.
 :::
 
 ## GPS Loss


### PR DESCRIPTION
Information about minimum battery percentage is outdated. The lines referenced in mavlink_receiver.cpp no longer exist :sweat_smile: and devs also no longer have to modify this one line to change the minimum simulated battery percentage :+1: 

Relevant upstream changes that removed the battery sim from simulator_mavlink into its own module: https://github.com/PX4/PX4-Autopilot/commit/55808ed2f9c47bb85edc1dab36212faf1c09b4db#

Not sure if other information relevant to the simulation needs to be updated too. I only had a quick look and did not find anything.