### PR TITLE
Update external_position_estimation.md

### DIFF
--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -187,16 +187,16 @@ To use MoCap data with EKF2 you will have to [remap](http://wiki.ros.org/roslaun
 
 The local/world and world frames used by ROS and PX4 are different.
 
-Frame | ROS | PX4
+Frame | PX4 | ROS
 --- | --- | ---
-Body | FLU (X **F**orward, Y **L**eft, Z **U**p), usually named `base_link` | FRD (X **F**orward, Y **R**ight and Z **D**own)
-World | FLU or ENU (X **E**ast, Y **N**orth and Z Up), with the naming being `odom` or `map` | FRD or NED (X **N**orth, Y **E**ast, Z **D**own)
+Body | FRD (X **F**orward, Y **R**ight, Z **D**own) | FLU (X **F**orward, Y **L**eft, Z **U**p), usually named `base_link`
+World | FRD or NED (X **N**orth, Y **E**ast, Z **D**own) | FLU or ENU (X **E**ast, Y **N**orth, Z **U**p), with the naming being `odom` or `map` 
 
 :::tip
 See [REP105: Coordinate Frames for Mobile Platforms](http://www.ros.org/reps/rep-0105.html) for more information about ROS frames.
 :::
 
-Both frames are shown in the image below (FLU on left/FRD on right).
+Both frames are shown in the image below (FRD on the left/FLU on the right).
 
 ![Reference frames](../../assets/lpe/ref_frames.png)
 


### PR DESCRIPTION
* Section Reference Frames and ROS
FRD and FLU explanation is not correct for the figure. So I correct the explanation.
Also, switch the columns of ROS and PX4 in the table to keep the consistency of the side.