### PR TITLE
GPS docs update

### DIFF
--- a/en/advanced/rtk_gps.md
+++ b/en/advanced/rtk_gps.md
@@ -21,24 +21,21 @@ The datalink should typically be able to handle an uplink rate of 300 bytes per 
 
 ## Supported RTK GPS modules
 
-PX4 currently only supports the single-frequency (L1) u-blox M8P based GNSS receivers for RTK.
-
-A number of manufacturers have created products using this receiver.
 The list of devices that we have tested can be found [in the user guide](../gps_compass/rtk_gps.md#supported-rtk-devices).
 
 :::note
-u-blox has two variants of the M8P chip, the M8P-0 and the M8P-2. 
-The M8P-0 can only be used as Rover, not as Base, whereas the M8P-2 can be used both as Rover or as Base.
+Most devices come with two variants, a base and a rover.
+Make sure to select the correct variant.
 :::
 
 ## Automatic Configuration
 
-The PX4 GPS stack automatically sets up the u-blox M8P modules to send and receive the correct messages over the UART or USB, depending on where the module is connected (to *QGroundControl* or the autopilot). 
+The PX4 GPS stack automatically sets up the GPS modules to send and receive the correct messages over the UART or USB, depending on where the module is connected (to *QGroundControl* or the autopilot). 
 
 As soon as the autopilot receives `GPS_RTCM_DATA` MAVLink messages, it automatically forwards the RTCM data to the attached GPS module.
 
 :::note
-The U-Center RTK module configuration tool is not needed/used!
+The u-blox U-Center RTK module configuration tool is not needed/used!
 :::
 
 :::note
@@ -48,12 +45,14 @@ In practice, this means that support for new protocols and/or messages only need
 
 ### RTCM messages
 
-QGroundControl configures the RTK base station to output the following RTCM3.2 frames, each with 1 Hz:
+QGroundControl configures the RTK base station to output the following RTCM3.2 frames, each with 1 Hz, unless otherwise stated:
 
-- **1005** - Station coordinates XYZ for antenna reference point (Base position).
+- **1005** - Station coordinates XYZ for antenna reference point (Base position), 0.2 Hz.
 - **1077** - Full GPS pseudo-ranges, carrier phases, Doppler and signal strength (high resolution).
 - **1087** - Full GLONASS pseudo-ranges, carrier phases, Doppler and signal strength (high resolution).
-
+- **1230** - GLONASS code-phase biases.
+- **1097** - Full Galileo pseudo-ranges, carrier phases, Doppler and signal strength (high resolution)
+- **1127** - Full BeiDou pseudo-ranges, carrier phases, Doppler and signal strength (high resolution)
 
 ## Uplink datarate
 

--- a/en/advanced_features/rtk-gps.md
+++ b/en/advanced_features/rtk-gps.md
@@ -3,6 +3,6 @@
 [Real Time Kinematic (RTK)](https://en.wikipedia.org/wiki/Real_Time_Kinematic) GNSS/GPS systems provide centimeter-level accuracy, allowing PX4 to be used in applications like precision surveying (where pinpoint accuracy is essential).
 This feature requires *QGroundControl* running on a laptop/PC and a vehicle with a WiFi or Telemetry radio link to the ground station laptop.
 
-In addition, some RTK setups can provide heading from GPS, which can be used as an alternative to the compass.
+In addition, [some RTK setups](../gps_compass/u-blox_f9p_heading.md) can provide heading from GPS, which can be used as an alternative to the compass.
 
 Information about supported devices and setup can be found in the section: [Peripheral Hardware > RTK GPS](../gps_compass/rtk_gps.md).

--- a/en/gps_compass/README.md
+++ b/en/gps_compass/README.md
@@ -4,11 +4,6 @@ PX4 supports global navigation satellite systems (GNSS) (including GPS, GLONASS,
 It also supports [Real Time Kinematic (RTK) GPS Receivers](../gps_compass/rtk_gps.md), which extend GPS systems to centimetre-level precision.
 
 PX4 can be used with the following compass parts (magnetometers): Bosch BMM 150 MEMS (via I2C bus), HMC5883 / HMC5983 (I2C or SPI), IST8310 (I2C) and LIS3MDL (I2C or SPI).
-
-:::note
-The set of supported compasses can be inferred from the [magnetometer drivers](https://github.com/PX4/PX4-Autopilot/tree/master/src/drivers/magnetometer) in the source code.
-:::
-
 Up to 4 internal or external magnetometers can be connected, though only one will actually be used as a heading source.
 The system automatically chooses the best available compass based on their internal priority (external magnetometers have a higher priority).
 If the primary compass fails in-flight, it will failover to the next one.
@@ -22,55 +17,66 @@ The internal compass *may* be useful on larger vehicles (e.g. VTOL) where it is 
 On small vehicles an external compass is almost always required.
 :::
 
-## Combined GPS/Compass Options
+## Supported GPS and/or Compass
 
-Some popular GPS/compass options include:
-* [u-blox Neo-M8N GPS with Compass](https://hobbyking.com/en_us/ublox-neo-m8n-gps-with-compass.html?gclid=Cj0KCQjwqM3VBRCwARIsAKcekb3ojv1ZhLz1-GuvCsUuGT8ZZuw8meMIV_I6pgUCj6DJRzHBY9OApekaAgI5EALw_wcB&gclsrc=aw.ds&___store=en_us) (Hobbyking)
-* [mRo GPS u-blox Neo-M8N Dual Compass LIS3MDL+ IST8310](https://store.mrobotics.io/ProductDetails.asp?ProductCode=mro-gps003-mr) (mRo store)
-* [Drotek u-blox GPS/Compasses](https://store-drotek.com/index.php?controller=search&s=ublox+compass) - e.g [DP0804 (NEO-M9N GPS + LIS3MDL Magnetometer for Pixhawk 3 Pro)](https://store-drotek.com/920-DP0804.html) (drotek)
-* [Holybro Pix32 M8N GPS Module](https://shop.holybro.com/pix32-gps-module_p1099.html) ([Holybro Shop](https://shop.holybro.com/pix32-gps-module_p1099.html), [getfpv](https://www.getfpv.com/holybro-pix32-neo-m8n-gps.html))
-* [Holybro Micro M8N GPS Module](https://shop.holybro.com/micro-m8n-gps_p1009.html) ([Holybro Shop](https://shop.holybro.com/micro-m8n-gps_p1009.html), [getfpv](https://www.getfpv.com/holybro-micro-m8n-gps-module.html))
-* [Holybro Pixhawk 4 GPS Module (10 pin)](https://shop.holybro.com/pixhawk-4-gps-module_p1094.html) ([Holybro Shop](https://shop.holybro.com/pixhawk-4-gps-module_p1094.html), [getfpv](https://www.getfpv.com/holybro-pixhawk-4-neo-m8n-gps.html))
-* [Holybro Pixhawk 4 2nd GPS Module (6 pin)](https://shop.holybro.com/pixhawk4-2nd-gps-module_p1145.html) (Holybro Shop)
-* [Here GNSS GPS (M8N)](https://www.getfpv.com/here-gnss-gps-m8n.html) (getfpv)
-* [Hex Here2  GNSS GPS (M8N)](../gps_compass/gps_hex_here2.md)
-* [Zubax GNSS 2](https://zubax.com/products/gnss_2) (zubax.com)
-* [Avionics Anonymous UAVCAN GNSS/Mag](https://www.tindie.com/products/avionicsanonymous/uavcan-gps-magnetometer/) (Tindie)
-* [3DR u-blox GPS with Compass kit](https://www.getfpv.com/3dr-ublox-gps-with-compass-kit.html) (getfpv) - *Discontinued*
+Device | GPS | Compass | [RTK](../gps_compass/rtk_gps.md) | [GPS Yaw Output](#configuring-gps-as-yaw-heading-source) | [Dual FP9 GPS Heading](../gps_compass/u-blox_f9p_heading.md)
+:--- | :---: | :---:  | :---:  | :---:  | :---: | :---:
+[Hobbyking u-blox Neo-M8N GPS with Compass](https://hobbyking.com/en_us/ublox-neo-m8n-gps-with-compass.html?gclid=Cj0KCQjwqM3VBRCwARIsAKcekb3ojv1ZhLz1-GuvCsUuGT8ZZuw8meMIV_I6pgUCj6DJRzHBY9OApekaAgI5EALw_wcB&gclsrc=aw.ds&___store=en_us) | M8N | &check; | | |
+[mRo GPS u-blox Neo-M8N Dual Compass](https://store.mrobotics.io/ProductDetails.asp?ProductCode=mro-gps003-mr) | M8N | LIS3MDL, IST8310 | | |
+[Drotek DP0804](https://store-drotek.com/920-DP0804.html) (and other [Drotek u-blox GPS/Compasses](https://store-drotek.com/index.php?controller=search&s=ublox+compass)) | M9N | LIS3MDL | | |
+[Emlid Reach M+](https://emlid.com/reach/)  - PX4 only supports "ordinary" GPS with this module. RTK support is expected in the near future. | &check; | &cross; | | |
+[Holybro Pix32 M8N GPS Module](https://shop.holybro.com/pix32-gps-module_p1099.html) | M8N | IST8310 | | |
+[Holybro Micro M8N GPS Module](https://shop.holybro.com/micro-m8n-gps_p1009.html) | M8N | &check; | | |
+[Holybro Pixhawk 4 GPS Module (10 pin)](https://shop.holybro.com/pixhawk-4-gps-module_p1094.html) | M8N | IST8310 | | |
+[Holybro Pixhawk 4 2nd GPS Module (6 pin)](https://shop.holybro.com/pixhawk4-2nd-gps-module_p1145.html) | M8N | IST8310 | | |
+Hex Here GNSS GPS (M8N) (discontinued) | M8N | HMC5983, LIS3MDL | | |
+[Hex Here2 GNSS GPS (M8N)](../gps_compass/gps_hex_here2.md) | M8N | ICM20948 | | |
+[Zubax GNSS 2](https://zubax.com/products/gnss_2) | MAX-M8Q | LIS3MDL | | |
+[Avionics Anonymous UAVCAN GNSS/Mag](https://www.tindie.com/products/avionicsanonymous/uavcan-gps-magnetometer/) | SAM-M8Q | MMC5983MA | | |
+3DR u-blox GPS with Compass kit (discontinued) | LEA-6H | &check; | | | 
+[CUAV C-RTK GPS](../gps_compass/rtk_gps_cuav_c-rtk.md) | M8P/M8N | &check; | &check; | |
+[Drotek XL RTK GPS](../gps_compass/rtk_gps_drotek_xl.md) | M8U | LIS3MDL | &check; | | 
+[Femtones MINI2 Receiver](../gps_compass/rtk_gps_fem_mini2.md) | FB672, FB6A0 | &check; | &check; | | 
+[Freefly RTK GPS](../gps_compass/rtk_gps_freefly.md) | F9P | IST8310 | &check; | 
+[Here+ RTK GPS](../gps_compass/rtk_gps_hex_hereplus.md) | M8P | HMC5983 | &check; | | 
+[Holybro H-RTK F9P GNSS](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | F9P | IST8310 | &check; | | 
+[Holybro H-RTK M8P GNSS](../gps_compass/rtk_gps_holybro_h-rtk-m8p.md) | M8P | IST8310 | &check; | | 
+[SparkFun GPS-RTK2 Board - ZED-F9P](https://www.sparkfun.com/products/15136) | F9P |  &cross; | &check; | | &check;
+[Drotek SIRIUS RTK GNSS ROVER (F9P)](https://store-drotek.com/911-1010-sirius-rtk-gnss-rover-f9p.html#/158-sensor-no_magnetometer) | F9P | RM3100 | &check; | | &check;
+[mRo u-blox ZED-F9 RTK L1/L2 GPS](https://store.mrobotics.io/product-p/mr-m10020-a.htm) | F9P | &cross; | &check; | | &check;
+[Trimble MB-Two](../gps_compass/rtk_gps_trimble_mb_two.md) | F9P | &cross; | &check; | &check; | |  
+[Avionics Anonymous UAVCAN Magnetometer](https://www.tindie.com/products/avionicsanonymous/uavcan-magnetometer/) | &cross; | &check; | | | | 
 
-Instructions for connecting the GPS and compass are usually provided by the manufacturer (at least for more common [Autopilot Hardware](../flight_controller/README.md)).
 
 :::note
-[Pixhawk Series](../flight_controller/pixhawk_series.md) controllers usually have a clearly labeled port for connecting the GPS, and the compass is connected to either the I2C or SPI port/bus (depending on the device). 
-The [Zubax GNSS 2](https://zubax.com/products/gnss_2) and [Avionics Anonymous GNSS/Mag](https://www.tindie.com/products/avionicsanonymous/uavcan-gps-magnetometer/) can also be connected via [UAVCAN](../uavcan/README.md).
+- &check; or a specific part number indicate that a features is supported, while &cross; or empty show that the feature is not supported.
+  "?" indicates "unknown".
+- Where possible and relevant the part name is used (i.e. &check; in the GPS column indicates that a GPS module is present but the part is not known).
+- [Avionics Anonymous UAVCAN Magnetometer](https://www.tindie.com/products/avionicsanonymous/uavcan-magnetometer/) is a compass (not a GPS).
+- Some RTK modules can only be used in a particular role (base or rover), while others can be used interchangeably.
 :::
+
+## Hardware Setup
+
+Instructions for connecting the GPS (and compass, if present) are usually provided by the manufacturer (at least for more common [Autopilot Hardware](../flight_controller/README.md)).
+
+[Pixhawk Series](../flight_controller/pixhawk_series.md) controllers typicaly have a clearly labeled port for connecting the GPS, and the compass is connected to either the I2C or SPI port/bus (depending on the device). 
+
+The [Zubax GNSS 2](https://zubax.com/products/gnss_2) and [Avionics Anonymous GNSS/Mag](https://www.tindie.com/products/avionicsanonymous/uavcan-gps-magnetometer/) can also be connected via [UAVCAN](../uavcan/README.md).
+
 
 :::warning
 Pay attention to pinout when connecting the GPS module.
 While these are all software-compatible, there are several different pin orderings.
 :::
 
-## GPS (Only) Options
-
-* [Emlid Reach M+](https://emlid.com/reach/) (emlid.com)
-  
-  :::note
-  At time of writing PX4 does not support RTK GPS with this module (only "ordinary" GPS).
-  Support is expected in the near future.
-  :::
-
-## Compass (Only) Options
-
-* [Avionics Anonymous UAVCAN Magnetometer](https://www.tindie.com/products/avionicsanonymous/uavcan-magnetometer/) (Tindie)
-
-## RTK-GPS Devices
-
-Information about supported devices and setup/configuration can be found in the sidebar under: [RTK GPS](../gps_compass/rtk_gps.md).
-
 
 ## Configuration
 
-### Primary GPS
+The "standard" GPS/compass configuration is provided below.
+Additional device-specific configuration may be provided in PX4 or manufacturer device documentation (e.g. [Trimble MB-Two > Configuration](../gps_compass/rtk_gps_trimble_mb_two.md#configuration)).
+
+### Configuring the Primary GPS
 
 GPS configuration on Pixhawk is handled transparently for the user - simply connect the GPS module to the port labeled **GPS** and everything should work.
 
@@ -80,7 +86,7 @@ If you are using the *Trimble MB-Two* you will need to modify the configuration 
 :::
 
 <span id="dual_gps"></span>
-### Secondary GPS (Dual GPS System)
+### Configuring a Secondary GPS (Dual GPS System)
 
 To use a secondary GPS, attach it to any free port, and then perform a [Serial Port Configuration](../peripherals/serial_configuration.md) to assign [GPS_2_CONFIG](../advanced_config/parameter_reference.md#GPS_2_CONFIG) to the selected port.
 
@@ -97,15 +103,31 @@ The following steps show how to configure a secondary GPS on the `TELEM 2` port 
 After setting up the second GPS port:
 1. Configure the ECL/EKF2 estimator to blend data from both GPS systems.
    For detailed instructions see: [Using the ECL EKF > Dual Receivers](../advanced_config/tuning_the_ecl_ekf.md#dual-receivers).
+   
+### Configuring GPS as Yaw/Heading Source
 
-### Compass
+GPS can be used as a source for yaw fusion when using modules where *yaw output is supported by the device* (e.g. [Trimble MB-Two](../gps_compass/rtk_gps_trimble_mb_two.md)) or when using some [RTK GPS Setups with Dual u-blox F9P](../gps_compass/u-blox_f9p_heading.md).
+
+When using GPS for yaw fusion you will need to configure the following parameters:
+
+Parameter | Setting
+--- | ---
+[GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) |  The angle made by the *baseline* (the line between the two GPS antennas) relative to the vehicle x-axis (front/back axis, as shown [here](../config/flight_controller_orientation.md#calculating-orientation)).
+[EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) | Set bit position 7 "GPS yaw fusion" to `1` (i.e. add 128 to the parameter value).
+
+
+:::tip
+- If using this feature, all other configuration should be setup up as normal (e.g. [RTK Positioning](#positioning-setup-configuration)).
+:::
+
+
+### Compass Configuration
 
 Compass calibration is covered in: [Compass Configuration](../config/compass.md).
 The process is straightforward and will calibrate all connected magnetometers.
 
 Additional configuration can be [performed](../advanced_config/parameters.md) using the [CAL\_MAGx\_](../advanced_config/parameter_reference.md#CAL_MAG0_EN) parameters (where `x=0-3`).
-Generally you will not need to *modify* these as compasses are autodetected, prioritised and are all calibrated at the same time
-(a possible exception is [CAL\_MAGx\_EN](../advanced_config/parameter_reference.md#CAL_MAG0_EN) which might be used to disable an internal compass).
+Generally you will not need to *modify* these as compasses are autodetected, prioritised and are all calibrated at the same time (a possible exception is [CAL\_MAGx\_EN](../advanced_config/parameter_reference.md#CAL_MAG0_EN) which might be used to disable an internal compass).
 You may however wish to read them, as they will let you know which magnetometers are internal or external ([CAL\_MAGx\_EN](../advanced_config/parameter_reference.md#CAL_MAG0_EN)) and which is being uses as the main heading source ([CAL_MAG_PRIME](../advanced_config/parameter_reference.md#CAL_MAG_PRIME)).
 
 
@@ -115,4 +137,5 @@ You may however wish to read them, as they will let you know which magnetometers
   - [RTK-GPS](../advanced/rtk_gps.md)
   - [GPS driver](../modules/modules_driver.md#gps)
   - [UAVCAN Example](../uavcan/README.md)
-- [Driver source code](https://github.com/PX4/PX4-Autopilot/tree/master/src/drivers/magnetometer) (Compasses)
+- Compass
+  - [Driver source code](https://github.com/PX4/PX4-Autopilot/tree/master/src/drivers/magnetometer) (Compasses)

--- a/en/gps_compass/rtk_gps.md
+++ b/en/gps_compass/rtk_gps.md
@@ -2,13 +2,10 @@
 
 *RTK GPS* devices can be accurate to centimeter-level, allowing PX4 to be used in applications like precision surveying (where pinpoint accuracy is essential).
 
-Some RTK devices have dual antennas, and can output yaw as well as position infomation.
-This can be used as an alternative to a compass for providing heading information.
-
-This topic covers the setup for both positioning and yaw (if supported).
-
 :::note
-[RTK GPS Heading with Dual u-blox F9P](../gps_compass/u-blox_f9p_heading.md) explains an alternative approach for getting yaw from RTK GPS, which requires two vehicle-mounted RTK FP9 GPS devices.
+GPS can also be used as a source of yaw/heading information:
+- [RTK GPS Heading with Dual u-blox F9P](../gps_compass/u-blox_f9p_heading.md).
+- [GPS that Output Yaw](../gps_compass/README.md#gps-that-output-yaw).
 :::
 
 
@@ -159,31 +156,6 @@ See the [EKF2 GPS Configuration](../advanced_config/tuning_the_ecl_ekf.md#gps) s
 The airframe build topic [DJI Flamewheel 450 with distance sensor and RTK GPS](../frames_multicopter/dji_flamewheel_450.md) describes an airframe setup with the Here+ RTK GPS and a Pixhawk 3 Pro.
 
 
-
-## RTK GPS that Output Yaw
-
-Some RTK GPS units have multiple antennas, and can output a yaw angle.
-This yaw can be used instead of the heading from the magnetic compass (and as an alternative to [RTK Heading with Two FP9 modules](#rtk-gps-heading-setup-configuration-u-blox-f9p)).
-
-###  Supported Devices
-
-* [Trimble MB-Two](../gps_compass/rtk_gps_trimble_mb_two.md)
-
-### Configuration
-
-[RTK Positioning](#positioning-setup-configuration) should be set up as normal.
-
-In order to use the GPS for yaw fusion you will also need to configure:
-
-Parameter | Setting
---- | ---
-[GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) |  The angle made by the *baseline* (the line between the two GPS antennas) relative to the vehicle x-axis (front/back axis, as shown [here](../config/flight_controller_orientation.md#calculating-orientation)).
-[EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) | Set bit position 7 "GPS yaw fusion" to `1` (i.e. add 128 to the parameter value).
-
-
-:::tip
-Additional device-specific configuration is covered in the device documentation (e.g. [Trimble MB-Two > Configuration](../gps_compass/rtk_gps_trimble_mb_two.md#configuration)).
-:::
 
 ## Further Information
 

--- a/en/gps_compass/rtk_gps_trimble_mb_two.md
+++ b/en/gps_compass/rtk_gps_trimble_mb_two.md
@@ -59,3 +59,7 @@ The `GPS_YAW_OFFSET` is the angle made by the *baseline* (the line between the t
 [Configure the serial port](../peripherals/serial_configuration.md) on which the Trimple will run using [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG), and set the baud rate to 115200 using [SER_GPS1_BAUD](../advanced_config/parameter_reference.md#SER_GPS1_BAUD).
 
 To activate heading fusion for the attitude estimation, set the [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter to enable *GPS yaw fusion*.
+
+:::note
+See also: [GPS > Configuration > GPS as Yaw/Heading Source](../gps_compass/README.md#configuring-gps-as-yaw-heading-source)
+:::

--- a/en/gps_compass/u-blox_f9p_heading.md
+++ b/en/gps_compass/u-blox_f9p_heading.md
@@ -1,14 +1,11 @@
 # RTK GPS Heading with Dual u-blox F9P
 
-Two u-blox F9P devices mounted on a vehicle can be used to accurately compute a heading angle (i.e. an alternative to compass-based heading estimation).
+Two u-blox F9P [RTK GPS](../gps_compass/rtk_gps.md) modules mounted on a vehicle can be used to accurately compute a heading angle (i.e. an alternative to compass-based heading estimation).
 The two GPS devices in this scenario are referred to as the *Moving Base* and *Rover*.
 
-:::note
-This feature works on F9P devices that expose the GPS UART2 port (access to the port is required for setup).
-:::
-
-
 ## Supported Devices
+
+This feature works on F9P devices that expose the GPS UART2 port (access to the port is required for setup).
 
 The following devices are supported for this use case:
 * [SparkFun GPS-RTK2 Board - ZED-F9P](https://www.sparkfun.com/products/15136) (www.sparkfun.com)
@@ -16,16 +13,16 @@ The following devices are supported for this use case:
 * [mRo u-blox ZED-F9 RTK L1/L2 GPS](https://store.mrobotics.io/product-p/mr-m10020-a.htm) (store.mrobotics.io)
 
 :::note
-[Freefly RTK GPS](../gps_compass/rtk_gps_freefly.md) and [Holybro H-RTK F9P GNSS](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) cannot be used because they do not expose the UART2 port.
+- [Freefly RTK GPS](../gps_compass/rtk_gps_freefly.md) and [Holybro H-RTK F9P GNSS](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) cannot be used because they do not expose the UART2 port.
+- Supported devices are also listed in [GPS/Compass > Supported GPS and/or Compass](../gps_compass/README.md#supported-gps-and-or-compass).
 :::
 
 ## Setup
 
-:::tip
-The general setup is described in: [ZED-F9P Moving base applications (Application note)](https://www.u-blox.com/sites/default/files/ZED-F9P-MovingBase_AppNote_%28UBX-19009093%29.pdf).
-:::
-
-## Configuration/Setup
+Ideally the two antennas should be identical, on the same level/horizontal plane and oriented the same way, and on an identical ground plane size and shape ([Application note](https://www.u-blox.com/sites/default/files/ZED-F9P-MovingBase_AppNote_%28UBX-19009093%29.pdf), section *System Level Considerations*).
+- The application note does not state the minimal required separation between modules (50cm has been used in test vehicles running PX4).
+- The antennas can be positioned as needed, but the [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) must be configured: 
+  [GPS > Configuration > GPS as Yaw/Heading Source](../gps_compass/README.md#configuring-gps-as-yaw-heading-source). 
 
 In overview:
 - The UART2 of the GPS devices need to be connected together (TXD2 of the "Moving Base" to RXD2 of the "Rover")
@@ -34,21 +31,19 @@ In overview:
   - Main GPS = Rover
   - Secondary GPS = Moving Base
 - Set [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `Heading` (1)
+- [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter bit 7 must be set (see [GPS > Configuration > GPS as Yaw/Heading Source](../gps_compass/README.md#configuring-gps-as-yaw-heading-source)).
+- [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) may need to be set (see [GPS > Configuration > GPS as Yaw/Heading Source](../gps_compass/README.md#configuring-gps-as-yaw-heading-source)).
 - Reboot and wait until both devices have GPS reception.
   `gps status` should then show the Main GPS going into RTK mode, which means the heading angle is available.
+
 
 :::note
 If using RTK with a fixed base station the secondary GPS will show the RTK state w.r.t. the base station.
 :::
 
-Ideally the two antennas should be identical, on the same level/horizontal plane and oriented the same way, and on an identical ground plane size and shape ([Application note](https://www.u-blox.com/sites/default/files/ZED-F9P-MovingBase_AppNote_%28UBX-19009093%29.pdf), section *System Level Considerations*)). 
 
-Otherwise the antennas can be positioned as needed, but the [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) must be configured.
-This offset is the angle made by the *baseline* (the line between the two GPS modules) relative to the vehicle x-axis (front/back axis, as shown [here](../config/flight_controller_orientation.md#calculating-orientation)).
 
-:::note
-The application note does not state the minimal required separation between modules.
-50cm has been used in test vehicles running PX4.
-:::
+## Further Informaiton
 
-To activate heading fusion for the attitude estimation, set the [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter bit 7 (*GPS yaw fusion*).
+- [ZED-F9P Moving base applications (Application note)](https://www.u-blox.com/sites/default/files/ZED-F9P-MovingBase_AppNote_%28UBX-19009093%29.pdf) - General setup/instructions.
+- [GPS > Configuration > GPS as Yaw/Heading Source](../gps_compass/README.md#configuring-gps-as-yaw-heading-source)


### PR DESCRIPTION
- All GPS/compass docs now listed in one big table. This has columns for the main features of interest - gps module, compass module, RTK support, yaw support etc.
- Other docs link to this table. I think will be easier to maintain.
- MOved "devices that support yaw" out of RTK into the main doc.

I _think_ this is a better overall structure.