### PR TITLE
Add battery simulation info to sim pages

### DIFF
--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -193,7 +193,7 @@ See [System Startup](../concept/system_startup.md) for more information.
 
 ### Simulating Failsafes and Sensor/Hardware Failure 
 
-The [SITL parameters](../advanced_config/parameter_reference.md#sitl) can also be used to simulate common sensor failure cases, including low battery, loss of GPS or barometer, gyro failure, increased GPS noise etc.  (e.g. [SIM_GPS_BLOCK](../advanced_config/parameter_reference.md#SIM_GPS_BLOCK) can be set to simulate GPS failure).
+The [SITL parameters](../advanced_config/parameter_reference.md#sitl) can also be used to simulate low battery and common sensor failure cases, including: loss of GPS or barometer, gyro failure, increased GPS noise etc. (e.g. [SIM_GPS_BLOCK](../advanced_config/parameter_reference.md#SIM_GPS_BLOCK) can be set to simulate GPS failure).
 
 Additionally (and with some overlap), [Simulate Failsafes](../simulation/failsafes.md) explains how to trigger safety failsafes.
 

--- a/en/simulation/gazebo.md
+++ b/en/simulation/gazebo.md
@@ -165,6 +165,12 @@ make px4_sitl_default gazebo
 
 For more information see: [Simulation > Run Simulation Faster than Realtime](../simulation/README.md#simulation_speed).
 
+### Simulating Sensor Failure/Battery
+
+Some hardware and failsafe behaviour can be simulated using parameters; for example, battery drain rate and minimum percentage can be set using the parameters [SIM_BAT_DRAIN](../advanced_config/parameter_reference.md#SIM_BAT_DRAIN) and [SIM_BAT_MIN_PCT](../advanced_config/parameter_reference.md#SIM_BAT_MIN_PCT).
+
+For more information see: [Simulation > Simulating Failsafes and Sensor/Hardware Failure](../simulation/README.md#simulating-failsafes-and-sensor-hardware-failure).
+
 
 ### Change Wind Speed
 

--- a/en/simulation/jmavsim.md
+++ b/en/simulation/jmavsim.md
@@ -98,6 +98,12 @@ make px4_sitl_default jmavsim
 
 For more information see: [Simulation > Run Simulation Faster than Realtime](../simulation/README.md#simulation_speed).
 
+### Simulating Sensor Failure/Battery
+
+Some hardware and failsafe behaviour can be simulated using parameters; for example, battery drain rate and minimum percentage can be set using the parameters [SIM_BAT_DRAIN](../advanced_config/parameter_reference.md#SIM_BAT_DRAIN) and [SIM_BAT_MIN_PCT](../advanced_config/parameter_reference.md#SIM_BAT_MIN_PCT).
+
+For more information see: [Simulation > Simulating Failsafes and Sensor/Hardware Failure](../simulation/README.md#simulating-failsafes-and-sensor-hardware-failure).
+
 <a id="joystick"></a>
 ### Using a Joystick
 


### PR DESCRIPTION
This adds battery simulation info to gazebo and jmavsim pages with back links to parent simulation page.

Still need to fix up http://docs.px4.io/master/en/simulation/#simulating-failsafes-and-sensor-hardware-failure and http://docs.px4.io/master/en/simulation/failsafes.html#gps-loss as these refer to SIM_GPS_BLOCK  which no longer appears to exist (i.e. need to answer "how to I simulate sensor failures). Discussion on slack here https://px4.slack.com/archives/CL3LV4FUH/p1609112046065400