### PR TITLE
Update dev_env_mac.md: Fix invalid brew syntax

### DIFF
--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -68,7 +68,7 @@ sudo -H python3 -m pip install --user pyserial empy toml numpy pandas jinja2 pyy
 To install SITL simulation with Gazebo:
 
 ```sh
-brew cask install xquartz
+brew install --cask xquartz
 brew install px4-sim-gazebo
 ```
 


### PR DESCRIPTION
`brew cask install xquartz` 

Command gives an error:

`Error: Calling brew cask install is disabled! Use brew install [--cask] instead.`

Correct Sytax added: `brew install --cask xquartz`