### PR TITLE
code: Update recommended astyle version

### DIFF
--- a/en/contribute/code.md
+++ b/en/contribute/code.md
@@ -19,9 +19,9 @@ All code contributions have to be under the permissive [BSD 3-clause license](ht
 ## Code Style Formatting
 
 PX4 uses [astyle](http://astyle.sourceforge.net/) for code formatting. Valid versions are
-* [astyle 2.06](https://sourceforge.net/projects/astyle/files/astyle/astyle%202.06/) (recommended)
+* [astyle 2.06](https://sourceforge.net/projects/astyle/files/astyle/astyle%202.06/) (deprecated)
 * [astyle 3.0](https://sourceforge.net/projects/astyle/files/astyle/astyle%203.0/)
-* [astyle 3.01](https://sourceforge.net/projects/astyle/files/)
+* [astyle 3.01](https://sourceforge.net/projects/astyle/files/) (recommended)
 
 Once installed, formatting can be checked with `./Tools/astyle/check_code_style_all.sh`. The output should be `Format checks passed` on a clean master. If that worked, `make format` can be used in the future to check and format all files automatically.
 


### PR DESCRIPTION
We switched to exclusively astyle 3.1 in CI 8 months ago and solved a lot of inconsistency issues with that:
https://github.com/PX4/PX4-containers/blame/9b21c97e313fceda0f7591c626dee33705a1b3ca/docker/Dockerfile_base-focal#L73-L77
It's time to recommend this version in the docs. Should we remove 2.06 completely?

Came to my attention through https://github.com/PX4/PX4-Autopilot/pull/16509#discussion_r555006610