### PR TITLE
Start PX4 with no simulator

### DIFF
--- a/en/dev_setup/building_px4.md
+++ b/en/dev_setup/building_px4.md
@@ -413,7 +413,12 @@ make list_config_targets
 
 **VIEWER_MODEL_DEBUGGER_WORLD:**
   
-- **VIEWER:** This is the simulator ("viewer") to launch and connect: `gazebo`, `jmavsim` <!-- , ?airsim -->
+- **VIEWER:** This is the simulator ("viewer") to launch and connect: `gazebo`, `jmavsim`, `none` <!-- , ?airsim -->
+
+  :::tip
+  `none` can be used if you want to launch PX4 and wait for a simulator (jmavsim, gazebo, or some other simulator).
+  For example, `make px4_sitl none_iris` launches PX4 without a simulator (but with the iris airframe).
+  :::
 - **MODEL:** The *vehicle* model to use (e.g. `iris` (*default*), `rover`, `tailsitter`, etc), which will be loaded by the simulator.
   The environment variable `PX4_SIM_MODEL` will be set to the selected model, which is then used in the [startup script](../simulation/README.md#startup-scripts) to select appropriate parameters. 
 - **DEBUGGER:** Debugger to use: `none` (*default*), `ide`, `gdb`, `lldb`, `ddd`, `valgrind`, `callgrind`. 

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -116,6 +116,9 @@ make px4_sitl gazebo_iris_opt_flow
 
 # Start JMavSim with iris (default vehicle model)
 make px4_sitl jmavsim
+
+# Start PX4 with no simulator (i.e. to use your own "custom" simulator)
+make px4_sitl none_iris
 ```
 
 The simulation can be further configured via environment variables:


### PR DESCRIPTION
Provides example of how to start simulator with no viewer (simulator) provided.