### PR TITLE
Hide search on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ heroText: PX4 User Guide
 tagline: PX4 is the *Professional Autopilot*, powering vehicles from cargo, mapping and surveillance drones through to ground vehicles and submersibles.
 actionText: Learn More →
 actionLink: /en/
+search: false
 features:
 - title: Modular Architecture
   details: PX4 is highly modular and extensible both in terms of hardware and software. It utilizes a port-based architecture – which means when developers add components, the extended system does not lose robustness or performance. 


### PR DESCRIPTION
Hide the non-working search box on the home page.

Note, 
- the language switcher still does not work, raised error against Vuepress here: https://github.com/vuejs/vuepress/issues/2776
- Search does work on this page with other search plugins. However those have their own problems - e.g. this one doesn't filter search on current language: https://github.com/leo-buneev/vuepress-plugin-fulltext-search/issues/27