### PR TITLE
docker: remove inaccurate container hierarchy

### DIFF
--- a/en/test_and_ci/docker.md
+++ b/en/test_and_ci/docker.md
@@ -51,7 +51,9 @@ For example, below you can see that the docker container with nuttx build tools 
     - px4io/px4-dev-ros2-foxy
 
 
-The most recent version can be accessed using the `latest` tag: `px4io/px4-dev-nuttx:latest` (available tags are listed for each container on *hub.docker.com*. For example, the *px4-dev-ros* tags can be found [here](https://hub.docker.com/r/px4io/px4-dev-nuttx/tags)).
+The most recent version can be accessed using the `latest` tag: `px4io/px4-dev-nuttx-bionic:latest`
+(available tags are listed for each container on *hub.docker.com*.
+For example, the `px4io/px4-dev-nuttx-bionic` tags can be found [here](https://hub.docker.com/r/px4io/px4-dev-nuttx-bionic/tags?page=1&ordering=last_updated)).
 
 :::tip
 Typically you should use a recent container, but not necessarily the `latest` (as this changes too often).

--- a/en/test_and_ci/docker.md
+++ b/en/test_and_ci/docker.md
@@ -38,29 +38,29 @@ sudo usermod -aG docker $USER
 <a id="px4_containers"></a>
 ## Container Hierarchy
 
-The available containers are listed below (from [Github](https://github.com/PX4/containers/blob/master/README.md#container-hierarchy)):
+The available containers are on [Github here](https://github.com/PX4/containers/blob/master/README.md#container-hierarchy).
 
-Container | Description
----|---
-px4-dev-base | Base setup common to all containers
-&emsp;px4-dev-nuttx | NuttX toolchain
-&emsp;px4-dev-simulation | NuttX toolchain + simulation (jMAVSim, Gazebo)
-&emsp;&emsp;px4-dev-ros | NuttX toolchain, simulation + ROS (incl. MAVROS)
-&emsp;px4-dev-raspi | Raspberry Pi toolchain
-&emsp;px4-dev-snapdragon | Qualcomm Snapdragon Flight toolchain
-&emsp;px4-dev-clang | Clang tools
-&emsp;&emsp;px4-dev-nuttx-clang | Clang and NuttX tools
+These allow testing of various build targets and configurations (the included tools can be inferred from their names).
+The containers are hierarchial, such that containers have the functionality of their parents.
+For example, below you can see that the docker container with nuttx build tools (`px4-dev-nuttx-focal`) does not include ROS 2, while the simulation containers do:
+
+- px4io/px4-dev-base-focal
+  - px4io/px4-dev-nuttx-focal
+  - px4io/px4-dev-simulation-focal
+    - px4io/px4-dev-ros-noetic
+    - px4io/px4-dev-ros2-foxy
 
 
 The most recent version can be accessed using the `latest` tag: `px4io/px4-dev-nuttx:latest` (available tags are listed for each container on *hub.docker.com*. For example, the *px4-dev-ros* tags can be found [here](https://hub.docker.com/r/px4io/px4-dev-nuttx/tags)).
 
 :::tip
-Typically you should use a recent container, but not necessarily the latest (as this changes too often).
+Typically you should use a recent container, but not necessarily the `latest` (as this changes too often).
 :::
 
 ## Use the Docker Container
 
-The following instructions show how to build PX4 source code on the host computer using a toolchain running in a docker container. The information assumes that you have already downloaded the PX4 source code to **src/PX4-Autopilot**, as shown:
+The following instructions show how to build PX4 source code on the host computer using a toolchain running in a docker container.
+The information assumes that you have already downloaded the PX4 source code to **src/PX4-Autopilot**, as shown:
 
 ```sh
 mkdir src
@@ -71,7 +71,8 @@ cd PX4-Autopilot
 
 ### Helper Script (docker_run.sh)
 
-The easiest way to use the containers is via the [docker_run.sh](https://github.com/PX4/PX4-Autopilot/blob/master/Tools/docker_run.sh) helper script. This script takes a PX4 build command as an argument (e.g. `make tests`). It starts up docker with a recent version (hard coded) of the appropriate container and sensible environment settings.
+The easiest way to use the containers is via the [docker_run.sh](https://github.com/PX4/PX4-Autopilot/blob/master/Tools/docker_run.sh) helper script.
+This script takes a PX4 build command as an argument (e.g. `make tests`). It starts up docker with a recent version (hard coded) of the appropriate container and sensible environment settings.
 
 For example, to build SITL you would call (from within the **/PX4-Autopilot** directory):
 


### PR DESCRIPTION
Fixes https://github.com/PX4/PX4-containers/issues/289

Removes the full hierarchy and instead points to the repo where the info is kept. Keeps a small subset of the information to show that it is a hierarchy and that you can infer what is in each container from the name and its level of nesting.