### PR TITLE
Add missing space character

### DIFF
--- a/en/flight_controller/snapdragon_flight_dev_environment_installation.md
+++ b/en/flight_controller/snapdragon_flight_dev_environment_installation.md
@@ -25,7 +25,7 @@ To set up the development environment:
    wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_common_deps.sh ~
    sudo chmod +x ubuntu_sim_common_deps.sh
    ./ubuntu_sim_common_deps.sh
-  ```
+   ```
 
 ## Cross-toolchain & Hexagon SDK
 


### PR DESCRIPTION
The missing space character was causing the remainder of the document to render incorrectly,
putting headings and instructions inside code blocks and script commands as plain text.

![before](https://user-images.githubusercontent.com/5408583/107735175-f5941300-6cb3-11eb-8dc2-a103ec1cba95.png)
![after](https://user-images.githubusercontent.com/5408583/107735179-f75dd680-6cb3-11eb-95b0-ce7155c1c17b.png)
