### PR TITLE
Update Java Version

### DIFF
--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -65,12 +65,12 @@ brew install px4-sim-gazebo
 
 ## jMAVSim Simulation
 
-To use SITL simulation with jMAVSim you need to install a recent version of Java (e.g. Java 14).
-You can either download [Java 14 from Oracle](https://www.oracle.com/java/technologies/javase-jdk14-downloads.html) or use the AdoptOpenJDK tap:
+To use SITL simulation with jMAVSim you need to install the most recent version of Java (e.g. Java 15).
+You can either download [Java 15 from Oracle](https://www.oracle.com/java/technologies/javase-downloads.html) or use the AdoptOpenJDK tap:
 
 ```sh
 brew tap AdoptOpenJDK/openjdk
-brew install --cask adoptopenjdk14
+brew install --cask adoptopenjdk15
 ```
 
 ```sh


### PR DESCRIPTION
Got this error using Java 14 so updating docs to Java 15 which worked for me.

> `Exception in thread "main" java.lang.UnsupportedClassVersionError: me/drton/jmavsim/Simulator has been compiled by a more recent version of the Java Runtime (class file version 59.0), this version of the Java Runtime only recognizes class file versions up to 58.0`

Looks like this needs updating in the following areas - I'm happy to update the PR but I cannot test all those envs.