### PR TITLE
Correct Holybro Pixhawk Mini to fmuv3

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -164,7 +164,7 @@
       * [mRo Pixracer (FMUv4)](flight_controller/pixracer.md)
       * [Hex Cube Black (FMUv3)](flight_controller/pixhawk-2.md)
       * [mRo Pixhawk (FMUv3)](flight_controller/mro_pixhawk.md)
-      * [Holybro Pixhawk Mini (FMUv2)](flight_controller/pixhawk_mini.md)
+      * [Holybro Pixhawk Mini (FMUv3)](flight_controller/pixhawk_mini.md)
     * [Manufacturer-Supported Autopilots](flight_controller/autopilot_manufacturer_supported.md)
       * [AirMind MindPX](flight_controller/mindpx.md)
       * [AirMind MindRacer](flight_controller/mindracer.md)

--- a/en/flight_controller/pixhawk_mini.md
+++ b/en/flight_controller/pixhawk_mini.md
@@ -325,7 +325,7 @@ It is pre-built and automatically installed by *QGroundControl* when appropriate
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 ```
-make px4_fmu-v2_default
+make px4_fmu-v3_default
 ```
 
 ## Debug Port


### PR DESCRIPTION
Pixhawk mini is using STM32F427 Rev 3 which has full 2MB storage could run fmuv3, also using different IMU compare with Pixhawk1(fmuv2), need drivers in fmuv3 configuration.
Current documentation makes many users can't boot their Pixhawk mini.