### PR TITLE
Correct mRo Pixhawk to fmuv3

### DIFF
--- a/en/flight_controller/autopilot_pixhawk_standard.md
+++ b/en/flight_controller/autopilot_pixhawk_standard.md
@@ -15,5 +15,5 @@ The boards in this category are:
 - [Drotek Pixhawk 3 Pro](../flight_controller/pixhawk3_pro.md) (FMUv4pro)
 - [mRo Pixracer](../flight_controller/pixracer.md) (FMUv4)
 - [Hex Cube Black](../flight_controller/pixhawk-2.md) (FMUv3)
-- [mRo Pixhawk](../flight_controller/mro_pixhawk.md) (FMUv2)
+- [mRo Pixhawk](../flight_controller/mro_pixhawk.md) (FMUv3)
 - [Holybro Pixhawk Mini](../flight_controller/pixhawk_mini.md) (FMUv3)


### PR DESCRIPTION
>The controller can be used as a drop-in replacement for the 3DR® Pixhawk 1. The main difference is that it is based on the Pixhawk-project FMUv3 open hardware design, which corrects a bug that limited the original Pixhawk 1 to 1MB of flash.