### PR TITLE
fix: fix broken link to standards

### DIFF
--- a/de/flight_controller/cubepilot_cube_orange.md
+++ b/de/flight_controller/cubepilot_cube_orange.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Cube Orange](http://www.proficnc.com/61-system-kits2) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems.

--- a/de/flight_controller/pixhawk-2.md
+++ b/de/flight_controller/pixhawk-2.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Hex Cube Black](http://www.proficnc.com/61-system-kits2) flight controller (previously known as Pixhawk 2.1) is a flexible autopilot intended primarily for manufacturers of commercial systems. It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.

--- a/en/flight_controller/cubepilot_cube_orange.md
+++ b/en/flight_controller/cubepilot_cube_orange.md
@@ -6,7 +6,7 @@ Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or
 :::
 
 :::tip
-The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Cube Orange](http://www.proficnc.com/61-system-kits2) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems. 

--- a/en/flight_controller/pixhawk-2.md
+++ b/en/flight_controller/pixhawk-2.md
@@ -6,7 +6,7 @@ Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or
 :::
 
 :::tip
-The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Hex Cube Black](http://www.proficnc.com/61-system-kits2) flight controller (previously known as Pixhawk 2.1) is a flexible autopilot intended primarily for manufacturers of commercial systems. 

--- a/ja/flight_controller/cubepilot_cube_orange.md
+++ b/ja/flight_controller/cubepilot_cube_orange.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Cube Orange](http://www.proficnc.com/61-system-kits2) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems.

--- a/ja/flight_controller/pixhawk-2.md
+++ b/ja/flight_controller/pixhawk-2.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Hex Cube Black](http://www.proficnc.com/61-system-kits2) flight controller (previously known as Pixhawk 2.1) is a flexible autopilot intended primarily for manufacturers of commercial systems. It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.

--- a/ko/flight_controller/cubepilot_cube_orange.md
+++ b/ko/flight_controller/cubepilot_cube_orange.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Cube Orange](http://www.proficnc.com/61-system-kits2) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems.

--- a/ko/flight_controller/pixhawk-2.md
+++ b/ko/flight_controller/pixhawk-2.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Hex Cube Black](http://www.proficnc.com/61-system-kits2) flight controller (previously known as Pixhawk 2.1) is a flexible autopilot intended primarily for manufacturers of commercial systems. It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.

--- a/ru/flight_controller/cubepilot_cube_orange.md
+++ b/ru/flight_controller/cubepilot_cube_orange.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Cube Orange](http://www.proficnc.com/61-system-kits2) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems.

--- a/ru/flight_controller/pixhawk-2.md
+++ b/ru/flight_controller/pixhawk-2.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Hex Cube Black](http://www.proficnc.com/61-system-kits2) flight controller (previously known as Pixhawk 2.1) is a flexible autopilot intended primarily for manufacturers of commercial systems. It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.

--- a/tr/flight_controller/cubepilot_cube_orange.md
+++ b/tr/flight_controller/cubepilot_cube_orange.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Cube Orange](http://www.proficnc.com/61-system-kits2) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems.

--- a/tr/flight_controller/pixhawk-2.md
+++ b/tr/flight_controller/pixhawk-2.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Hex Cube Black](http://www.proficnc.com/61-system-kits2) flight controller (previously known as Pixhawk 2.1) is a flexible autopilot intended primarily for manufacturers of commercial systems. It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.

--- a/zh/flight_controller/cubepilot_cube_orange.md
+++ b/zh/flight_controller/cubepilot_cube_orange.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The PX4 dev team supports this flight controller as a footprint compatible replacement for Cube Black. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Cube Orange](http://www.proficnc.com/61-system-kits2) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems.

--- a/zh/flight_controller/pixhawk-2.md
+++ b/zh/flight_controller/pixhawk-2.md
@@ -4,7 +4,7 @@
 :::
 
 :::tip
-The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](../autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
+The [Cube Orange](../cubepilot_cube_orange.md) is the successor to this product. We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md). This flight controller is not following the standard and uses a patented connector.
 :::
 
 The [Hex Cube Black](http://www.proficnc.com/61-system-kits2) flight controller (previously known as Pixhawk 2.1) is a flexible autopilot intended primarily for manufacturers of commercial systems. It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.


### PR DESCRIPTION
Some pages have a broken link to the standards page. This PR fixes that 