### PR TITLE
jMAVSim wrong jdk version

### DIFF
--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -89,6 +89,17 @@ brew install px4-sim-jmavsim
 jMAVSim for PX4 v1.11 and earlier required Java 8.
 :::
 
+### troubleshoot (for macOS Catalina users)
+When compiling jmavsim, if the following error appears
+```
+Exception in thread "main" java.lang.UnsupportedClassVersionError: me/drton/jmavsim/Simulator has been compiled by a more recent version of the Java Runtime (class file version 59.0), this version of the Java Runtime only recognizes class file versions up to 58.0
+```
+it means a more recent version of Java is needed. Class file versions 58 corresponds to jdk14, version 59 to jdk15, etc.
+To fix it, tap
+```sh
+brew install --cask adoptopenjdk15
+```
+
 ## Next Steps
 
 Once you have finished setting up the command-line toolchain:

--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -73,12 +73,12 @@ brew install px4-sim-gazebo
 
 ## jMAVSim Simulation
 
-To use SITL simulation with jMAVSim you need to install a recent version of Java (e.g. Java 14).
-You can either download [Java 14 from Oracle](https://www.oracle.com/java/technologies/javase-jdk14-downloads.html) or use the AdoptOpenJDK tap:
+To use SITL simulation with jMAVSim you need to install a recent version of Java (e.g. Java 15).
+You can download [Java 15 (or later) from Oracle](https://www.oracle.com/java/technologies/javase-downloads.html#JDK15) or use the AdoptOpenJDK tap:
 
 ```sh
 brew tap AdoptOpenJDK/openjdk
-brew install --cask adoptopenjdk14
+brew install --cask adoptopenjdk15
 ```
 
 ```sh

--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -85,20 +85,11 @@ brew install --cask adoptopenjdk14
 brew install px4-sim-jmavsim
 ```
 
-:::note
-jMAVSim for PX4 v1.11 and earlier required Java 8.
-:::
+:::warning
+jMAVSim for PX4 v1.11 and beyond we require at least JDK 15. (for troubleshooting information see [the jMAVSim guide](../simulation/jmavsim.html))
 
-### troubleshoot (for macOS Catalina users)
-When compiling jmavsim, if the following error appears
-```
-Exception in thread "main" java.lang.UnsupportedClassVersionError: me/drton/jmavsim/Simulator has been compiled by a more recent version of the Java Runtime (class file version 59.0), this version of the Java Runtime only recognizes class file versions up to 58.0
-```
-it means a more recent version of Java is needed. Class file versions 58 corresponds to jdk14, version 59 to jdk15, etc.
-To fix it, tap
-```sh
-brew install --cask adoptopenjdk15
-```
+Specifically macOS users might run into this problem check for the error code: `Exception in thread "main" java.lang.UnsupportedClassVersionError:`. You can find the fix on [the jMAVSim guide](../simulation/jmavsim.html)) under the troubleshooting section.
+:::
 
 ## Next Steps
 
@@ -106,8 +97,7 @@ Once you have finished setting up the command-line toolchain:
 - Install [VSCode](../dev_setup/vscode.md) (if you prefer using an IDE to the command line).
 - Install the [QGroundControl Daily Build](https://docs.qgroundcontrol.com/en/releases/daily_builds.html)
   :::tip
-  The *daily build* includes development tools that hidden in release builds. 
+  The *daily build* includes development tools that are hidden in release builds. 
   It may also provide access to new PX4 features that are not yet supported in release builds.
   :::
 - Continue to the [build instructions](../dev_setup/building_px4.md).
-

--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -86,9 +86,10 @@ brew install px4-sim-jmavsim
 ```
 
 :::warning
-jMAVSim for PX4 v1.11 and beyond we require at least JDK 15. (for troubleshooting information see [the jMAVSim guide](../simulation/jmavsim.html))
+jMAVSim for PX4 v1.11 and beyond we require at least JDK 15.
 
-Specifically macOS users might run into this problem check for the error code: `Exception in thread "main" java.lang.UnsupportedClassVersionError:`. You can find the fix on [the jMAVSim guide](../simulation/jmavsim.html)) under the troubleshooting section.
+For earlier versions macOS users might see the error `Exception in thread "main" java.lang.UnsupportedClassVersionError:`.
+You can find the fix in the [jMAVSim with SITL > Troubleshooting](../simulation/jmavsim.html#troubleshooting)).
 :::
 
 ## Next Steps

--- a/en/simulation/jmavsim.md
+++ b/en/simulation/jmavsim.md
@@ -230,5 +230,19 @@ and comment out the line indicated below:
 #assistive_technologies=org.GNOME.Acessibility.AtkWrapper
 ```
 
-For more info check [this GitHub issue](https://github.com/PX4/PX4-Autopilot/issues/9557).
-The fix was found in [askubuntu.com](https://askubuntu.com/questions/695560).
+For more info, check [this GitHub issue](https://github.com/PX4/PX4-Autopilot/issues/9557).
+A contributor found the fix in [askubuntu.com](https://askubuntu.com/questions/695560).
+
+### Exception in thread "main" java.lang.UnsupportedClassVersionError:
+When compiling jMAVsim, you might encounter the following error:
+
+```
+Exception in thread "main" java.lang.UnsupportedClassVersionError: me/drton/jmavsim/Simulator has been compiled by a more recent version of the Java Runtime (class file version 59.0), this version of the Java Runtime only recognizes class file versions up to 58.0
+```
+
+This error is telling you, you need a more recent version of Java in your environment. Class file version 58 corresponds to jdk14, version 59 to jdk15, etc.
+
+To fix it under macOS, we recommend installing OpenJDK through homebrew
+```sh
+brew install --cask adoptopenjdk15
+```


### PR DESCRIPTION
should we put that here, or in "building jMAVSim" section?

I'm referring to this forum post
https://discuss.px4.io/t/jmavsim-fails-wrong-java-version/21368