### PR TITLE
Intel Aero - note indicating PX4 v1.11 removes support

### DIFF
--- a/en/complete_vehicles/intel_aero.md
+++ b/en/complete_vehicles/intel_aero.md
@@ -2,6 +2,8 @@
 
 :::warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
+
+PX4 v1.11 is the last release that supports this platform.
 :::
 
 The *Intel Aero Ready to Fly Drone*® is a UAV development platform.


### PR DESCRIPTION
Intel Aero no longer has support in master - see https://github.com/PX4/PX4-Autopilot/pull/16952

This adds a note to the Aero page indicating that it is not supported after PX4 v1.11