### PR TITLE
Discontinue OcPoc-Zynq

### DIFF
--- a/en/flight_controller/ocpoc_zynq.md
+++ b/en/flight_controller/ocpoc_zynq.md
@@ -6,7 +6,9 @@ Contact the [manufacturer](https://ainstein.ai/) for hardware support or complia
 :::
 
 :::warning
-PX4 support for this flight controller is [experimental](../flight_controller/autopilot_experimental.md).
+This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
+
+PX4 v1.11 is the last release that has experimental support for this platform.
 :::
 
 The [OcPoC-Zynq Mini](https://aerotenna.readme.io/docs/ocpoc-mini-zynq-specifications) is a FPGA+ARM SoC based flight control platform.


### PR DESCRIPTION
It's been recently deprecated in PX4 Autopilot, and will no longer be part of the supported boards starting with version v1.12

https://github.com/PX4/PX4-Autopilot/pull/16966