### PR TITLE
update multiple vehicle simultion option

### DIFF
--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -9,7 +9,7 @@ A different approach is used for simulation with and without ROS.
 
 To simulate multiple iris or plane vehicles in Gazebo use the following commands in the terminal (from the root of the *Firmware* tree):
 ```
-Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>] [-w <world>] [-s <script>] [-t <target>]
+Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>] [-w <world>] [-s <script>] [-t <target>] [-l <label>]
 ```
 
 - `<model>`: The [vehicle type/model](../simulation/gazebo_vehicles.md) to spawn, e.g.: `iris` (default), `plane`, `standard_vtol`.
@@ -26,6 +26,7 @@ Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>] [-w <wo
    - Maximum number of vehicles is 255.
 
  - `<target>`: build target, e.g: `px4_sitl_default` (default), `px4_sitl_rtps`
+ - `<label>` : specific label for model, e.g: `rtps`
 
 Each vehicle instance is allocated a unique MAVLink system id (1, 2, 3, etc.).
 Vehicle instances are accessed from sequentially allocated PX4 remote UDP ports: `14540` - `14548` (additional instances are all accessed using the same remote UDP port: `14549`).
@@ -80,7 +81,7 @@ To build an example setup, follow the steps below:
    For example, to spawn 4 vehicles, run:
 
    ```bash
-   ./Tools/gabo_sitl_multiple_run.sh  -m iris_rtps -t px4_sitl_rtps -n 4
+   ./Tools/gabo_sitl_multiple_run.sh -t px4_sitl_rtps -m iris -l rtps -n 4
    ```
 
    :::note

--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -81,7 +81,7 @@ To build an example setup, follow the steps below:
    For example, to spawn 4 vehicles, run:
 
    ```bash
-   ./Tools/gabo_sitl_multiple_run.sh -t px4_sitl_rtps -m iris -l rtps -n 4
+   ./Tools/gazebo_sitl_multiple_run.sh -t px4_sitl_rtps -m iris -l rtps -n 4
    ```
 
    :::note


### PR DESCRIPTION
The muliple vehicle simulation option is updated. 

For example, 

FROM
```
./Tools/gabo_sitl_multiple_run.sh  -m iris_rtps -t px4_sitl_rtps -n 4
```
TO.
```
Tools/gazebo_sitl_multiple_run.sh -t px4_sitl_rtps -m iris -l rtps -n 4
```