### PR TITLE
Fix a command in the installation guide

### DIFF
--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -57,7 +57,7 @@ To install the toolchain:
    ```
 1. Run the **ubuntu.sh** with no arguments (in a bash shell) to install everything:
    ```bash
-   bash ./Tools/setup/ubuntu.sh
+   bash ./PX4-Autopilot/Tools/setup/ubuntu.sh
    ```
    - Acknowledge any prompts as the script progress.
    - You can use the `--no-nuttx` and `--no-sim-tools` options to omit the NuttX and/or simulation tools.


### PR DESCRIPTION
Signed-off-by: mohamedsayed18 <mohamed95.a.s@gmail.com>

it is not mentioned that the user should be in the PX4-Autopilot directory, so it can me problem for users not familiar with ubutnu and commandline 