### PR TITLE
Add 1.12 release notes

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -388,6 +388,8 @@
     * [ROS Integration Testing](test_and_ci/integration_testing.md)
     * [Docker Containers](test_and_ci/docker.md)
     * [Maintenance](test_and_ci/maintenance.md)
+* [Releases](releases/README.md)
+  * [1.12](releases/1.12.md)
 * [Robotics](robotics/README.md)
   * [Offboard Control from Linux](ros/offboard_control.md)
   * [ROS](ros/README.md)

--- a/en/releases/1.12.md
+++ b/en/releases/1.12.md
@@ -1,0 +1,30 @@
+# Release 1.12
+
+## Minor releases
+* [Beta 1](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.12.0-beta1)
+
+## Changes
+
+* [Multicoper](#multicopter)
+
+### Multicopter
+
+* #### Intuitive stick feel in Position mode
+  * Horizontal stick input mapped to acceleration instead of velocity setpoints
+  * Removes unexpected tilt changes upon reaching travel speed velocity
+  * Intuitive shunting e.g. when landing
+  * Comparable to Altitude mode but with the familiar benefits
+    * drift less hover
+    * straight fast forward flight
+    * automatic braking when letting go of the stick
+  * Opt out possible using [MPC_POS_MODE](../advanced_config/parameter_reference.md#MPC_POS_MODE)
+  * Development: [First attempt](https://github.com/PX4/PX4-Autopilot/pull/12072), [Introduction](https://github.com/PX4/PX4-Autopilot/pull/16052), [Improvements](https://github.com/PX4/PX4-Autopilot/pull/16320), [Bugfix zero oscillation](https://github.com/PX4/PX4-Autopilot/pull/16786), [Bugfix position unlock](https://github.com/PX4/PX4-Autopilot/pull/16791), [Bugfix invalid setpoint](https://github.com/PX4/PX4-Autopilot/pull/17078)
+
+* #### Hover thrust independent velocity control gains
+  * Parameters `MPC_{XY/Z}_VEL_{P/I/D}` were replaced with `MPC_{XY/Z}_VEL_{P/I/D}_ACC`, see:<br/>
+   [MPC_XY_VEL_P_ACC](../advanced_config/parameter_reference.md#MPC_XY_VEL_P_ACC), [MPC_XY_VEL_I_ACC](../advanced_config/parameter_reference.md#MPC_XY_VEL_I_ACC), [MPC_XY_VEL_D_ACC](../advanced_config/parameter_reference.md#MPC_XY_VEL_D_ACC), [MPC_Z_VEL_P_ACC](../advanced_config/parameter_reference.md#MPC_Z_VEL_P_ACC), [MPC_Z_VEL_I_ACC](../advanced_config/parameter_reference.md#MPC_Z_VEL_I_ACC), [MPC_Z_VEL_D_ACC](../advanced_config/parameter_reference.md#MPC_Z_VEL_D_ACC)
+  * **Attention:** The gains have a new meaning
+    * Scale from velocity error in m/s to acceleration output in m/s^2
+    * Existing gains need to roughly be rescaled by a factor of `* gravitational constant / hover thrust`
+    * Automatic parameter transition assumes 50% hover thrust: ~10m/s^2 / 50% = 20 m/s^2. See [question](https://github.com/PX4/PX4-Autopilot/pull/14823#issuecomment-791357646)
+  * Development: [Logic introduction](https://github.com/PX4/PX4-Autopilot/pull/14749), [Parameter replacement](https://github.com/PX4/PX4-Autopilot/pull/14823)

--- a/en/releases/README.md
+++ b/en/releases/README.md
@@ -1,0 +1,5 @@
+# Releases
+
+In depth release notes of what changed and how to adapt and make best use.
+
+* [1.12](../releases/1.12.md)


### PR DESCRIPTION
After the discussion started on slack I had the following idea:

> How about one high level point per topic e.g. UAVCAN, Board support, Multicopter, ... and then list the new things in one line but make them a link to the right place in the long description? That's at least what I would like as a user.

> link to where?
PX4 guide with 1.12 release page. which is on the detail level of what I wrote above with links to e.g. prs.

> To me it's more attractive to add description to documentation than to some release blog post. The 1.11 release notes are quite nice but the as short as possible description follows the link to the pr. I think quickly typing down a description on the more in-depth release page in the docs makes you think through what changes and if the description gets too involved it's also a lower barrier to directly add docs with the same pr.

This is the first stab at it and I already posted links to the points I added to https://github.com/PX4/PX4-Autopilot/releases/tag/v1.12.0-beta1