### PR TITLE
Add payload to sidebar and improve context

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -12,6 +12,7 @@
     * [LED Meanings](getting_started/led_meanings.md)
     * [Tune/Sound Meanings](getting_started/tunes.md)
     * [Preflight Checks](flying/pre_flight_checks.md)
+  * [Payloads & Cameras](payloads/README.md)
   * [Flight Reporting](getting_started/flight_reporting.md)
 * [Basic Assembly](assembly/README.md)
   * [Mounting the Flight Controller](assembly/mount_and_orient_controller.md)

--- a/en/getting_started/README.md
+++ b/en/getting_started/README.md
@@ -14,4 +14,6 @@ This section provides an overview of the basic concepts you need to understand i
 
 [Flight Modes](../getting_started/flight_modes.md) — Control modes for manual, assisted and autonomous movement.
 
+[Payloads & Cameras](../payloads/README.md)
+
 [Flight Reporting](../getting_started/flight_reporting.md) — Download detailed flight logs for debugging and analysis.

--- a/en/payloads/README.md
+++ b/en/payloads/README.md
@@ -4,24 +4,37 @@ PX4 supports a wide range of payloads and cameras.
 
 ## Mapping Drones
 
-* [Camera triggering](../peripherals/camera.md) via GPIO out
-* [Camera triggering](../peripherals/camera.md) via PWM out
-* [Camera triggering](../peripherals/camera.md) via MAVLink out
-* [Camera timing](../peripherals/camera.md#camera_capture) feedback via hotshoe input
+Mapping drones use cameras to capture images at time or distance intervals during surveys.
 
-## Cargo drones and alike: Servos / Outputs
+The following topics show how to connect your camera and set up camera triggering:
+* [Camera triggering](../peripherals/camera.md) from flight controller PWM or GPIO outputs, or via MAVLink.
+* [Camera timing feedback](../peripherals/camera.md#camera_capture) via hotshoe input.
 
-* Servo or GPIO triggering (via RC or via commands)
+The MAVLink commands used in survey missions (and as standalone commands) are:
+* [MAV_CMD_DO_SET_CAM_TRIGG_INTERVAL](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_CAM_TRIGG_INTERVAL) - set time interval between captures.
+* [MAV_CMD_DO_SET_CAM_TRIGG_DIST](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_CAM_TRIGG_DIST) - set distance between captures
+* [MAV_CMD_DO_TRIGGER_CONTROL](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_TRIGGER_CONTROL) - start/stop capturing (using distance or time, as defined using above messages).
+
+## Cargo Drones ("Actuator" Payloads)
+
+Cargo drones commonly use servos/actuators to trigger cargo release, control winches, etc.
+PX4 supports servo and GPIO triggering via both RC and MAVLink commands.
 
 ### Example Mission (in QGC)
 
-Use MAV_CMD_DO_SET_ACTUATOR to trigger one of the payload actuators.
+Use the [MAV_CMD_DO_SET_ACTUATOR](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_ACTUATOR) MAVLink command to trigger one of the payload actuators.
 
 ### Example script (MAVSDK)
 
-This script sends a command to set the actuator and trigger the payload release on a servo:
+The following [MAVSDK](https://mavsdk.mavlink.io/develop/en/) sample code shows how to trigger payload release.
 
-```
+The code uses the MAVSDK [MavlinkPassthrough](https://mavsdk.mavlink.io/develop/en/api_reference/classmavsdk_1_1_mavlink_passthrough.html) plugin to send the [MAV_CMD_DO_SET_ACTUATOR](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_ACTUATOR) MAVLink command, specifying the value of up to 3 actuators.
+
+<!-- note, we still need to explain how to map those values to actual outputs on PX4 
+There are also questions on this script in the original PR.
+-->
+
+```cpp
 #include <mavsdk/mavsdk.h>
 #include <mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.h>
 #include <mavsdk/plugins/info/info.h>
@@ -56,54 +69,54 @@ int main(int argc, char **argv)
         return 1;
     }
 
-	bool discovered_system = false;
+    bool discovered_system = false;
     mavsdk.subscribe_on_new_system([&mavsdk, &discovered_system]() {
-		const auto system = mavsdk.systems().at(0);
+        const auto system = mavsdk.systems().at(0);
 
-		if (system->is_connected()) {
-			std::cout << "Discovered system" << std::endl;
-			discovered_system = true;
-		}
-	});
+        if (system->is_connected()) {
+            std::cout << "Discovered system" << std::endl;
+            discovered_system = true;
+        }
+    });
 
-	std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
-	if (!discovered_system) {
+    if (!discovered_system) {
         std::cout << "No device found, exiting." << std::endl;
         return 1;
     }
 
-	std::shared_ptr<System> system = mavsdk.systems().at(0);
-	for (auto& tsystem : mavsdk.systems()) {
-		auto info = Info{tsystem};
-		std::cout << info.get_identification().second.hardware_uid << std::endl;
-		if (info.get_identification().second.hardware_uid == "3762846593019032885") {
-			system = tsystem;
-		}
-	}
+    std::shared_ptr<System> system = mavsdk.systems().at(0);
+    for (auto& tsystem : mavsdk.systems()) {
+        auto info = Info{tsystem};
+        std::cout << info.get_identification().second.hardware_uid << std::endl;
+        if (info.get_identification().second.hardware_uid == "3762846593019032885") {
+            system = tsystem;
+        }
+    }
 
-	auto mavlink_passthrough = MavlinkPassthrough{system};
+    auto mavlink_passthrough = MavlinkPassthrough{system};
 
-	send_actuator(mavlink_passthrough, value1, value2, value3);
+    send_actuator(mavlink_passthrough, value1, value2, value3);
 
     return 0;
 }
 
 void send_actuator(MavlinkPassthrough& mavlink_passthrough,
-		float value1, float value2, float value3)
+        float value1, float value2, float value3)
 {
-	std::cout << "Sending message" << std::endl;
-	mavlink_message_t message;
-	mavlink_msg_command_long_pack(
-			mavlink_passthrough.get_our_sysid(),
-			mavlink_passthrough.get_our_compid(),
-			&message,
-			1, 1,
-			MAV_CMD_DO_SET_ACTUATOR,
-			0,
-			value1, value2, value3,
-			NAN, NAN, NAN, 0);
-	mavlink_passthrough.send_message(message);
-	std::cout << "Sent message" << std::endl;
+    std::cout << "Sending message" << std::endl;
+    mavlink_message_t message;
+    mavlink_msg_command_long_pack(
+            mavlink_passthrough.get_our_sysid(),
+            mavlink_passthrough.get_our_compid(),
+            &message,
+            1, 1,
+            MAV_CMD_DO_SET_ACTUATOR,
+            0,
+            value1, value2, value3,
+            NAN, NAN, NAN, 0);
+    mavlink_passthrough.send_message(message);
+    std::cout << "Sent message" << std::endl;
 }
 ```


### PR DESCRIPTION
This follows on from #1105.
- Adds payload doc to sidebar in "Getting Started". Not quite right place, but best place "for now". 
  ![image](https://user-images.githubusercontent.com/5368500/111399263-1fa87d00-8719-11eb-9fbd-567e3818af16.png)
- Provides a bit more info and cross linking to mavlink messages.

This is still draft because it needs more info on how servos are mapped in PX4 to the actuator message. Those questions are open in  #1105. 

Other things to cover include perhaps 
- adding links to actual cameras.
- Reworking camera triggering to better explain the different options. In particular how MAVLink part works. So rather than saying "this is how you set up camera triggering config" start by saying "these are supported cameras", "this is how you connect up cameras", this is how you configure them. (i.e. more traditional approach for docs).
- More types of payload?