### PR TITLE
Add Devguide old versions to version switcher

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -165,6 +165,14 @@ module.exports = {
               { text: 'v1.10', link: 'https://docs.px4.io/v1.10/en/' },
               { text: 'v1.9', link: 'https://docs.px4.io/v1.9.0/en/' },
               { text: 'v1.8', link: 'https://docs.px4.io/v1.8.2/en/' },
+              {
+                text: 'DevGuide (Old/Merged)',
+                ariaLabel: 'Old Devguide',
+                items: [
+                  { text: 'DevGuide v1.11', link: 'https://dev.px4.io/v1.11_noredirect/en/' },
+                  { text: 'DevGuide v1.10', link: 'https://dev.px4.io/v1.10_noredirect/en/' },
+                ]
+              },
               
             ]
           },
@@ -231,7 +239,15 @@ module.exports = {
               { text: 'v1.10', link: 'https://docs.px4.io/v1.10/en/' },
               { text: 'v1.9', link: 'https://docs.px4.io/v1.9.0/en/' },
               { text: 'v1.8', link: 'https://docs.px4.io/v1.8.2/en/' },
-              
+              {
+                text: 'DevGuide (Old/Merged)',
+                ariaLabel: 'Old Devguide',
+                items: [
+                  { text: 'DevGuide v1.11', link: 'https://dev.px4.io/v1.11_noredirect/en/' },
+                  { text: 'DevGuide v1.10', link: 'https://dev.px4.io/v1.10_noredirect/en/' },
+                ]
+              },
+
             ]
           },
           
@@ -288,6 +304,14 @@ module.exports = {
               { text: 'v1.10', link: 'https://docs.px4.io/v1.10/zh/' },
               { text: 'v1.9', link: 'https://docs.px4.io/v1.9.0/en/' },
               { text: 'v1.8', link: 'https://docs.px4.io/v1.8.2/en/' },
+              {
+                text: 'DevGuide (Old/Merged)',
+                ariaLabel: 'Old Devguide',
+                items: [
+                  { text: 'DevGuide v1.11', link: 'https://dev.px4.io/v1.11_noredirect/en/' },
+                  { text: 'DevGuide v1.10', link: 'https://dev.px4.io/v1.10_noredirect/en/' },
+                ]
+              },
               
             ]
           },


### PR DESCRIPTION
Looks like this now. This is needed because the devguide now redirects from even the home page. 

![image](https://user-images.githubusercontent.com/5368500/111424425-dae70b00-8745-11eb-98af-3414c571ddd0.png)
