### PR TITLE
Update airsim.md documentation links

### DIFF
--- a/en/simulation/airsim.md
+++ b/en/simulation/airsim.md
@@ -2,9 +2,9 @@
 
 AirSim is a open-source, cross platform simulator for drones, built on Unreal Engine. It provides physically and visually realistic simulations of Pixhawk/PX4 using either Hardware-In-The-Loop \(HITL\) or Software-In-The-Loop \(SITL\).
 
-The main entry point for the documentation is the [Github AirSim README](https://github.com/Microsoft/AirSim/blob/master/README.md).
+The main entry point for the documentation is the [AirSim Documentation](https://microsoft.github.io/AirSim/).
 
-The main entry point for documentation on working with PX4 is [PX4 Setup for AirSim](https://github.com/Microsoft/AirSim/blob/master/docs/px4_setup.md) (covering both HITL and SITL).
+The main entry point for documentation on working with PX4 is [PX4 Setup for AirSim](https://microsoft.github.io/AirSim/px4_setup/) (covering both HITL and SITL).
 
 ## Further Information
 


### PR DESCRIPTION
There is a page dedicated to AirSim documentation. So it is better to refer to it. 