### PR TITLE
Release 1.12: Links to info about improved rounded turns

### DIFF
--- a/en/releases/1.12.md
+++ b/en/releases/1.12.md
@@ -55,6 +55,7 @@
   * Development: [Logic introduction](https://github.com/PX4/PX4-Autopilot/pull/14749), [Parameter replacement](https://github.com/PX4/PX4-Autopilot/pull/14823)
 * **Improve Rounded Turns ([PR#16376](https://github.com/PX4/PX4-Autopilot/pull/16376))**
   * Creates a more rounded turn at waypoints in multirotor missions (using L1-style guidance logic in corners)
+  * See [Mission Mode > Inter-waypoint Trajectory](../flight_modes/mission.md#inter-waypoint-trajectory) and [Mission > Setting Acceptance/Turning Radius](../flying/missions.md#setting-acceptance-turning-radius)
 
 ### VTOL
 


### PR DESCRIPTION
FYI @mrpollo This adds links to info for rounded turns in MC to the release notes (thanks @bresch for this). I will merge, but when we get to the end of the process of updating docs we might want to revisit the format.

