### PR TITLE
release1.12 hide component info notes

### DIFF
--- a/en/releases/1.12.md
+++ b/en/releases/1.12.md
@@ -23,8 +23,11 @@
 
 * **MAVLink Ethernet configuration ([PR#14460](https://github.com/PX4/PX4-Autopilot/pull/14460))**
   * MAVLink Ethernet channel settings such as UDP port, remote port and broadcast mode now can be changed dynamically via parameters.
+
+<!--
 * **Support for querying `COMPONENT_INFORMATION` ([PR#16039](https://github.com/PX4/PX4-Autopilot/pull/16039))**
   * This new message allows any MAVLink system to request rich hierarchical information from an autopilot, i.e., to understand which commands are supported in missions or to get parameter metadata. This message was introduced primarily to help GCS better understand autopilots (RFC: [mavlink#1339](https://github.com/mavlink/mavlink/issues/1339))
+-->
 
 ### Commander
 


### PR DESCRIPTION
As stated by Beat here https://github.com/PX4/PX4-user_guide/pull/1122#discussion_r599327485 the COMPONENT_INFO is not yet stable enough for real use. I have hidden it in a comment. If we get it finished before a release this can be exposed again.