### PR TITLE
Fixed command to return the IP address

### DIFF
--- a/en/test_and_ci/docker.md
+++ b/en/test_and_ci/docker.md
@@ -174,7 +174,7 @@ When running a simulation instance e.g. SITL inside the docker container and con
 In *QGroundControl*, navigate to [Settings](https://docs.qgroundcontrol.com/en/SettingsView/SettingsView.html) and select Comm Links. Create a new link that uses the UDP protocol. The port depends on the used [configuration](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS) e.g. port 14570 for the SITL config. The IP address is the one of your docker container, usually 172.17.0.1/16 when using the default network. The IP address of the docker container can be found with the following command (assuming the container name is `mycontainer`):
 
 ```sh
-$ docker inspect -f '{ {range .NetworkSettings.Networks}}{ {.IPAddress}}{ {end}}' mycontainer
+$ docker inspect -f '{{ .NetworkSettings.IPAddress }}' mycontainer
 ```
 
 :::note


### PR DESCRIPTION
Fixed docker command to return only the IP address of the container.