### PR TITLE
Position mode stick

### DIFF
--- a/en/flight_modes/README.md
+++ b/en/flight_modes/README.md
@@ -244,7 +244,7 @@ th {
  <td>S<sub>rate</sub></td>
  <td>S<sup>+</sup></td>
  <td><a href="#key_position_fixed"><img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="20px" /></a></td>
- <td><p>RC mode where RPT sticks control movement in corresponding axes/directions. Centered sticks level vehicle and hold it to fixed position and altitude against wind.
+ <td><p>RC mode where roll, pitch, throttle sticks control movement in corresponding axes/directions. Centered sticks level vehicle and hold it to fixed altitude and position against wind.
   <ul>
     <li>Centered RPT sticks hold x, y, z position steady against any wind and levels attitude.</li>
     <li>Outside center:
@@ -429,4 +429,3 @@ Auto | This mode is automatic (RC control is disabled by default except to chang
 Abbreviations:
   * RPY: Roll, Pitch, Yaw
   * RPT: Roll, Pitch Throttle
-

--- a/en/flight_modes/README.md
+++ b/en/flight_modes/README.md
@@ -249,7 +249,7 @@ th {
     <li>Centered RPT sticks hold x, y, z position steady against any wind and levels attitude.</li>
     <li>Outside center:
       <ul>
-       <li>Roll/Pitch sticks control horizontal acceleration over ground in left-right and forward-back directions (respectively) relative to the "front" of the vehicle.</li>
+       <li>Roll/Pitch sticks control horizontal acceleration over ground in the vehicle's left-right and forward-back directions (respectively).</li>
        <li>Throttle stick controls speed of ascent-descent.</li>
        <li>Yaw stick controls rate of angular rotation above the horizontal plane.</li>
       </ul>

--- a/en/flight_modes/README.md
+++ b/en/flight_modes/README.md
@@ -249,7 +249,7 @@ th {
     <li>Centered RPT sticks hold x, y, z position steady against any wind and levels attitude.</li>
     <li>Outside center:
       <ul>
-       <li>Roll/Pitch sticks control acceleration over ground in left-right and forward-back directions (respectively) relative to the "front" of the vehicle.</li>
+       <li>Roll/Pitch sticks control horizontal acceleration over ground in left-right and forward-back directions (respectively) relative to the "front" of the vehicle.</li>
        <li>Throttle stick controls speed of ascent-descent.</li>
        <li>Yaw stick controls rate of angular rotation above the horizontal plane.</li>
       </ul>

--- a/en/flight_modes/README.md
+++ b/en/flight_modes/README.md
@@ -244,12 +244,12 @@ th {
  <td>S<sub>rate</sub></td>
  <td>S<sup>+</sup></td>
  <td><a href="#key_position_fixed"><img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="20px" /></a></td>
- <td><p>RC mode where RPT sticks control <em>speed</em> in corresponding directions. Centered sticks level vehicle and hold it to fixed position and altitude against wind.
+ <td><p>RC mode where RPT sticks control movement in corresponding axes/directions. Centered sticks level vehicle and hold it to fixed position and altitude against wind.
   <ul>
     <li>Centered RPT sticks hold x, y, z position steady against any wind and levels attitude.</li>
     <li>Outside center:
       <ul>
-       <li>Roll/Pitch sticks control speed over ground in left-right and forward-back directions (respectively) relative to the "front" of the vehicle.</li>
+       <li>Roll/Pitch sticks control acceleration over ground in left-right and forward-back directions (respectively) relative to the "front" of the vehicle.</li>
        <li>Throttle stick controls speed of ascent-descent.</li>
        <li>Yaw stick controls rate of angular rotation above the horizontal plane.</li>
       </ul>

--- a/en/flight_modes/position_mc.md
+++ b/en/flight_modes/position_mc.md
@@ -25,18 +25,24 @@ Landing in this mode is easy:
 1. The vehicle will lower propeller thrust, detect the ground and automatically disarm by default (see [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND))
 
 :::warning
-In case the vehicle fails to stop horizontally: Keep it under control in [Altitude](../flight_modes/altitude_mc.md) mode and land like instructed above but manually making sure the vehicle stays above the landing spot using roll and pitch stick. After landing check GPS and magnetometer orientation, calibration.
-
-In case the vehicle fails to detect the ground and landing: After the vehicle is on the ground switch to [Manual/Stabilized](../flight_modes/manual_stabilized_mc.md) mode keeping the throttle stick low and manually disarm using a gesture or other command. Alternatively you can also use the kill switch when the vehicle is already on the ground.
+While very rare on a well calibrated vehicle, sometimes there may be problems with landing.
+- If the vehicle does not stop moving horizontally:
+  - You can still land under control in [Altitude mode](../flight_modes/altitude_mc.md).
+    The approach is the same as above, except that you manually ensure that the vehicle stays above the landing spot using the roll and pitch stick.
+  - After landing check GPS and magnetometer orientation, calibration.
+- If the vehicle does not detect the ground/landing and disarm:
+  - After the vehicle is on the ground switch to [Manual/Stabilized mode](../flight_modes/manual_stabilized_mc.md) keeping the throttle stick low, and manually disarm using a gesture or other command.
+    Alternatively you can also use the kill switch when the vehicle is already on the ground.
 :::
 
 ## Technical Summary
 
-RC/manual mode where RPT sticks control *speed* in corresponding directions. Centered sticks level vehicle and hold it to fixed position and altitude against wind.
+RC mode where roll, pitch, throttle (RPT) sticks control movement in corresponding axes/directions.
+Centered sticks level vehicle and hold it to fixed altitude and position against wind.
 
 * Centered roll, pitch, throttle sticks (within RC deadzone [MPC_HOLD_DZ](../advanced_config/parameter_reference.md#MPC_HOLD_DZ)) hold x, y, z position steady against any disturbance like wind.
 * Outside center:
-  * Roll/Pitch sticks control horizontal acceleration over ground in forward-back and left-right directions relative to the front direction of the vehicle.
+  * Roll/Pitch sticks control horizontal acceleration over ground in the vehicle's left-right and forward-back directions (respectively).
   * Throttle stick controls speed of ascent-descent.
   * Yaw stick controls rate of angular rotation above the horizontal plane.
 * Takeoff:
@@ -55,15 +61,17 @@ All the parameters in the [Multicopter Position Control](../advanced_config/para
 
 Parameter | Description
 --- | ---
-<span id="MPC_HOLD_DZ"></span>[MPC_HOLD_DZ](../advanced_config/parameter_reference.md#MPC_HOLD_DZ) | Deadzone of sticks where position hold is enabled. Default: 0.1 (10% of full stick range).
-<span id="MPC_Z_VEL_MAX_UP"></span>[MPC_Z_VEL_MAX_UP](../advanced_config/parameter_reference.md#MPC_Z_VEL_MAX_UP) | Maximum vertical ascent velocity. Default: 3 m/s.
-<span id="MPC_Z_VEL_MAX_DN"></span>[MPC_Z_VEL_MAX_DN](../advanced_config/parameter_reference.md#MPC_Z_VEL_MAX_DN) | Maximum vertical descent velocity. Default: 1 m/s.
-<span id="MPC_LAND_VEL_XY"></span>[MPC_LAND_VEL_XY](../advanced_config/parameter_reference.md#MPC_LAND_VEL_XY) | Horizontal velocity limit when close to ground ([MPC_LAND_ALT2](#MPC_LAND_ALT2) meters above ground, or above home if distance-to-ground is unknown). Default: 10 m/s.
-<span id="MPC_LAND_ALT1"></span>[MPC_LAND_ALT1](../advanced_config/parameter_reference.md#MPC_LAND_ALT1) | Altitude for triggering first phase of slow landing. Affects maximum allowed horizontal velocity setpoint. Default 5m.
-<span id="MPC_LAND_ALT2"></span>[MPC_LAND_ALT2](../advanced_config/parameter_reference.md#MPC_LAND_ALT2) | Altitude for second phase of slow landing. In this phase maximum horizontal velocity is limited to [MPC_LAND_VEL_XY](#MPC_LAND_VEL_XY). Default 5m.
-<span id="RCX_DZ"></span>`RCX_DZ` | RC dead zone for channel X. The value of X for throttle will depend on the value of [RC_MAP_THROTTLE](../advanced_config/parameter_reference.md#RC_MAP_THROTTLE). For example, if the throttle is channel 4 then  [RC4_DZ](../advanced_config/parameter_reference.md#RC4_DZ) specifies the deadzone.
-<span id="MPC_xxx"></span>`MPC_XXXX` | Most of the MPC_xxx parameters affect flight behaviour in this mode (at least to some extent). For example, [MPC_THR_HOVER](../advanced_config/parameter_reference.md#MPC_THR_HOVER) defines the thrust at which a vehicle will hover.
-<span id="MPC_POS_MODE"></span>[MPC_POS_MODE](../advanced_config/parameter_reference.md#MPC_POS_MODE) | Stick input to movement translation strategy. From PX4 v1.12 the default (4) is that stick position controls acceleration (in a similar way to a car accelerator pedal). Other options allow stick deflection to directly control speed over ground, with and without smoothing and acceleration limits.
+<a id="MPC_HOLD_DZ"></a>[MPC_HOLD_DZ](../advanced_config/parameter_reference.md#MPC_HOLD_DZ) | Deadzone of sticks where position hold is enabled. Default: 0.1 (10% of full stick range).
+<a id="MPC_Z_VEL_MAX_UP"></a>[MPC_Z_VEL_MAX_UP](../advanced_config/parameter_reference.md#MPC_Z_VEL_MAX_UP) | Maximum vertical ascent velocity. Default: 3 m/s.
+<a id="MPC_Z_VEL_MAX_DN"></a>[MPC_Z_VEL_MAX_DN](../advanced_config/parameter_reference.md#MPC_Z_VEL_MAX_DN) | Maximum vertical descent velocity. Default: 1 m/s.
+<a id="MPC_LAND_VEL_XY"></a>[MPC_LAND_VEL_XY](../advanced_config/parameter_reference.md#MPC_LAND_VEL_XY) | Horizontal velocity limit when close to ground ([MPC_LAND_ALT2](#MPC_LAND_ALT2) meters above ground, or above home if distance-to-ground is unknown). Default: 10 m/s.
+<a id="MPC_LAND_ALT1"></a>[MPC_LAND_ALT1](../advanced_config/parameter_reference.md#MPC_LAND_ALT1) | Altitude for triggering first phase of slow landing. Affects maximum allowed horizontal velocity setpoint. Default 5m.
+<a id="MPC_LAND_ALT2"></a>[MPC_LAND_ALT2](../advanced_config/parameter_reference.md#MPC_LAND_ALT2) | Altitude for second phase of slow landing. In this phase maximum horizontal velocity is limited to [MPC_LAND_VEL_XY](#MPC_LAND_VEL_XY). Default 5m.
+<a id="RCX_DZ"></a>`RCX_DZ` | RC dead zone for channel X. The value of X for throttle will depend on the value of [RC_MAP_THROTTLE](../advanced_config/parameter_reference.md#RC_MAP_THROTTLE). For example, if the throttle is channel 4 then  [RC4_DZ](../advanced_config/parameter_reference.md#RC4_DZ) specifies the deadzone.
+<a id="MPC_xxx"></a>`MPC_XXXX` | Most of the MPC_xxx parameters affect flight behaviour in this mode (at least to some extent). For example, [MPC_THR_HOVER](../advanced_config/parameter_reference.md#MPC_THR_HOVER) defines the thrust at which a vehicle will hover.
+<a id="MPC_POS_MODE"></a>[MPC_POS_MODE](../advanced_config/parameter_reference.md#MPC_POS_MODE) | Stick input to movement translation strategy. From PX4 v1.12 the default (4) is that stick position controls acceleration (in a similar way to a car accelerator pedal). Other options allow stick deflection to directly control speed over ground, with and without smoothing and acceleration limits.
+<a id="MPC_ACC_HOR_MAX"></a>[MPC_ACC_HOR_MAX](../advanced_config/parameter_reference.md#MPC_ACC_HOR_MAX) | Maximum horizontal acceleration.
+<a id="MPC_VEL_MANUAL"></a>[MPC_VEL_MANUAL](../advanced_config/parameter_reference.md#MPC_VEL_MANUAL) | Maximum horizontal velocity.
 
 
 ## Additional Information

--- a/en/flight_modes/position_mc.md
+++ b/en/flight_modes/position_mc.md
@@ -2,7 +2,7 @@
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](../getting_started/flight_modes.md#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](../getting_started/flight_modes.md#key_manual)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
 
-*Position* is an easy-to-fly RC mode in which roll and pitch sticks control acceleration over ground in the left-right and forward-back directions (relative to the "front" of the vehicle), and throttle controls speed of ascent-descent.
+*Position* is an easy-to-fly RC mode in which roll and pitch sticks control acceleration over ground in the left-right and forward-back directions (similar to a car's accelerator pedal), and throttle controls speed of ascent-descent.
 When the sticks are released/centered the vehicle will actively brake, level, and be locked to a position in 3D space — compensating for wind and other forces.
 
 :::tip
@@ -15,9 +15,10 @@ The diagram below shows the mode behaviour visually (for a mode 2 transmitter).
 ![MC Position Mode](../../assets/flight_modes/position_MC.png)
 
 :::warning
-Care must be taken when landing in this mode. When first landing in this mode, be ready to switch to [Manual/Stabilized](../flight_modes/manual_stabilized_mc.md) in order to be able to disarm.
-If landing is correctly detected, motors will spin down after touch down and then disarm shortly after. 
-If the motors keep spinning at higher RPM or start spinning up, first switch to [Manual/Stabilized (MC)](../flight_modes/manual_stabilized_mc.md), and then disarm. 
+Care must be taken when landing in this mode.
+When first landing in this mode, be ready to switch to [Manual/Stabilized](../flight_modes/manual_stabilized_mc.md) in order to be able to disarm.
+If landing is correctly detected, motors will spin down after touch down and then disarm shortly after.
+If the motors keep spinning at higher RPM or start spinning up, first switch to [Manual/Stabilized (MC)](../flight_modes/manual_stabilized_mc.md), and then disarm.
 Be aware that the vehicle may tip over on the ground due to GPS drift.
 :::
 

--- a/en/flight_modes/position_mc.md
+++ b/en/flight_modes/position_mc.md
@@ -2,12 +2,12 @@
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](../getting_started/flight_modes.md#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](../getting_started/flight_modes.md#key_manual)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
 
-*Position* is an easy-to-fly RC mode in which roll and pitch sticks control speed over ground in the left-right and forward-back directions (relative to the "front" of the vehicle), and throttle controls speed of ascent-descent. 
+*Position* is an easy-to-fly RC mode in which roll and pitch sticks control acceleration over ground in the left-right and forward-back directions (relative to the "front" of the vehicle), and throttle controls speed of ascent-descent.
 When the sticks are released/centered the vehicle will actively brake, level, and be locked to a position in 3D space — compensating for wind and other forces.
 
 :::tip
 Position mode is the safest manual mode for new fliers. 
-Unlike [Altitude](../flight_modes/altitude_mc.md) and [Manual/Stabilized](../flight_modes/manual_stabilized_mc.md) modes the vehicle will stop when the sticks are centered rather than continuing until slowed by wind resistance. 
+Unlike [Altitude](../flight_modes/altitude_mc.md) and [Manual/Stabilized](../flight_modes/manual_stabilized_mc.md) modes the vehicle will stop when the sticks are centered rather than continuing until slowed by wind resistance.
 :::
 
 The diagram below shows the mode behaviour visually (for a mode 2 transmitter).
@@ -18,16 +18,16 @@ The diagram below shows the mode behaviour visually (for a mode 2 transmitter).
 Care must be taken when landing in this mode. When first landing in this mode, be ready to switch to [Manual/Stabilized](../flight_modes/manual_stabilized_mc.md) in order to be able to disarm.
 If landing is correctly detected, motors will spin down after touch down and then disarm shortly after. 
 If the motors keep spinning at higher RPM or start spinning up, first switch to [Manual/Stabilized (MC)](../flight_modes/manual_stabilized_mc.md), and then disarm. 
-Be aware that the vehicle may tip over on the ground due to GPS drift. 
+Be aware that the vehicle may tip over on the ground due to GPS drift.
 :::
 
 ## Technical Summary
 
 RC/manual mode where RPT sticks control *speed* in corresponding directions. Centered sticks level vehicle and hold it to fixed position and altitude against wind.
 
-* Centered RPT sticks (in RC deadzone) hold x, y, z position steady against any wind and levels attitude.
+* Centered RPT sticks (in RC deadzone) hold x, y, z position steady against any wind, and levels attitude.
 * Outside center:
-  * Roll/Pitch sticks control speed over ground in left-right and forward-back directions (respectively) relative to the "front" of the vehicle.
+  * Roll/Pitch sticks control acceleration horizontally (over ground) in left-right and forward-back directions (respectively) relative to the "front" of the vehicle.
   * Throttle stick controls speed of ascent-descent.
   * Yaw stick controls rate of angular rotation above the horizontal plane.
 * Takeoff:
@@ -54,6 +54,8 @@ Parameter | Description
 <span id="MPC_LAND_ALT2"></span>[MPC_LAND_ALT2](../advanced_config/parameter_reference.md#MPC_LAND_ALT2) | Altitude for second phase of slow landing. In this phase maximum horizontal velocity is limited to [MPC_LAND_VEL_XY](#MPC_LAND_VEL_XY). Default 5m.
 <span id="RCX_DZ"></span>`RCX_DZ` | RC dead zone for channel X. The value of X for throttle will depend on the value of [RC_MAP_THROTTLE](../advanced_config/parameter_reference.md#RC_MAP_THROTTLE). For example, if the throttle is channel 4 then  [RC4_DZ](../advanced_config/parameter_reference.md#RC4_DZ) specifies the deadzone.
 <span id="MPC_xxx"></span>`MPC_XXXX` | Most of the MPC_xxx parameters affect flight behaviour in this mode (at least to some extent). For example, [MPC_THR_HOVER](../advanced_config/parameter_reference.md#MPC_THR_HOVER) defines the thrust at which a vehicle will hover.
+<span id="MPC_POS_MODE"></span>[MPC_POS_MODE](../advanced_config/parameter_reference.md#MPC_POS_MODE) | Stick control mode for movement over ground. From PX4 v1.12 the default (4) is that stick position controls acceleration (in a similar way to a car accelerator pedal). Other options allow stick angle to directly control speed over ground, with and without smoothing/acceleration limits.
+
 
 ## Additional Information
 

--- a/en/flight_modes/position_mc.md
+++ b/en/flight_modes/position_mc.md
@@ -4,6 +4,7 @@
 
 *Position* is an easy-to-fly RC mode in which roll and pitch sticks control acceleration over ground in the vehicle's left-right and forward-back directions (similar to a car's accelerator pedal), and throttle controls speed of ascent-descent.
 When the sticks are released/centered the vehicle will actively brake, level, and be locked to a position in 3D space — compensating for wind and other forces.
+With full stick deflection the vehicle accelerates initially with [MPC_ACC_HOR_MAX](../advanced_config/parameter_reference.md#MPC_ACC_HOR_MAX) ramping down until it reaches the final velocity [MPC_VEL_MANUAL](../advanced_config/parameter_reference.md#MPC_VEL_MANUAL).
 
 :::tip
 Position mode is the safest manual mode for new fliers. 
@@ -14,21 +15,28 @@ The diagram below shows the mode behaviour visually (for a mode 2 transmitter).
 
 ![MC Position Mode](../../assets/flight_modes/position_MC.png)
 
+### Landing
+
+Landing in this mode is easy:
+1. Position the drone horizontally above the landing spot using the roll and pitch stick.
+1. Let go of the roll and pitch stick and give it enough time to come to a complete stop.
+1. Pull the throttle stick down gently until the vehicle touches the ground.
+1. Pull the throttle stick all the way down to facilitate and accelerate land detection.
+1. The vehicle will lower propeller thrust, detect the ground and automatically disarm by default (see [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND))
+
 :::warning
-Care must be taken when landing in this mode.
-When first landing in this mode, be ready to switch to [Manual/Stabilized](../flight_modes/manual_stabilized_mc.md) in order to be able to disarm.
-If landing is correctly detected, motors will spin down after touch down and then disarm shortly after.
-If the motors keep spinning at higher RPM or start spinning up, first switch to [Manual/Stabilized (MC)](../flight_modes/manual_stabilized_mc.md), and then disarm.
-Be aware that the vehicle may tip over on the ground due to GPS drift.
+In case the vehicle fails to stop horizontally: Keep it under control in [Altitude](../flight_modes/altitude_mc.md) mode and land like instructed above but manually making sure the vehicle stays above the landing spot using roll and pitch stick. After landing check GPS and magnetometer orientation, calibration.
+
+In case the vehicle fails to detect the ground and landing: After the vehicle is on the ground switch to [Manual/Stabilized](../flight_modes/manual_stabilized_mc.md) mode keeping the throttle stick low and manually disarm using a gesture or other command. Alternatively you can also use the kill switch when the vehicle is already on the ground.
 :::
 
 ## Technical Summary
 
 RC/manual mode where RPT sticks control *speed* in corresponding directions. Centered sticks level vehicle and hold it to fixed position and altitude against wind.
 
-* Centered RPT sticks (in RC deadzone) hold x, y, z position steady against any wind, and levels attitude.
+* Centered roll, pitch, throttle sticks (within RC deadzone [MPC_HOLD_DZ](../advanced_config/parameter_reference.md#MPC_HOLD_DZ)) hold x, y, z position steady against any disturbance like wind.
 * Outside center:
-  * Roll/Pitch sticks control horizontal acceleration (over ground) in left-right and forward-back directions (respectively) relative to the "front" of the vehicle.
+  * Roll/Pitch sticks control horizontal acceleration over ground in forward-back and left-right directions relative to the front direction of the vehicle.
   * Throttle stick controls speed of ascent-descent.
   * Yaw stick controls rate of angular rotation above the horizontal plane.
 * Takeoff:
@@ -55,7 +63,7 @@ Parameter | Description
 <span id="MPC_LAND_ALT2"></span>[MPC_LAND_ALT2](../advanced_config/parameter_reference.md#MPC_LAND_ALT2) | Altitude for second phase of slow landing. In this phase maximum horizontal velocity is limited to [MPC_LAND_VEL_XY](#MPC_LAND_VEL_XY). Default 5m.
 <span id="RCX_DZ"></span>`RCX_DZ` | RC dead zone for channel X. The value of X for throttle will depend on the value of [RC_MAP_THROTTLE](../advanced_config/parameter_reference.md#RC_MAP_THROTTLE). For example, if the throttle is channel 4 then  [RC4_DZ](../advanced_config/parameter_reference.md#RC4_DZ) specifies the deadzone.
 <span id="MPC_xxx"></span>`MPC_XXXX` | Most of the MPC_xxx parameters affect flight behaviour in this mode (at least to some extent). For example, [MPC_THR_HOVER](../advanced_config/parameter_reference.md#MPC_THR_HOVER) defines the thrust at which a vehicle will hover.
-<span id="MPC_POS_MODE"></span>[MPC_POS_MODE](../advanced_config/parameter_reference.md#MPC_POS_MODE) | Stick control mode for movement over ground. From PX4 v1.12 the default (4) is that stick position controls acceleration (in a similar way to a car accelerator pedal). Other options allow stick angle to directly control speed over ground, with and without smoothing/acceleration limits.
+<span id="MPC_POS_MODE"></span>[MPC_POS_MODE](../advanced_config/parameter_reference.md#MPC_POS_MODE) | Stick input to movement translation strategy. From PX4 v1.12 the default (4) is that stick position controls acceleration (in a similar way to a car accelerator pedal). Other options allow stick deflection to directly control speed over ground, with and without smoothing and acceleration limits.
 
 
 ## Additional Information

--- a/en/flight_modes/position_mc.md
+++ b/en/flight_modes/position_mc.md
@@ -2,7 +2,7 @@
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](../getting_started/flight_modes.md#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](../getting_started/flight_modes.md#key_manual)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
 
-*Position* is an easy-to-fly RC mode in which roll and pitch sticks control acceleration over ground in the left-right and forward-back directions (similar to a car's accelerator pedal), and throttle controls speed of ascent-descent.
+*Position* is an easy-to-fly RC mode in which roll and pitch sticks control acceleration over ground in the vehicle's left-right and forward-back directions (similar to a car's accelerator pedal), and throttle controls speed of ascent-descent.
 When the sticks are released/centered the vehicle will actively brake, level, and be locked to a position in 3D space — compensating for wind and other forces.
 
 :::tip

--- a/en/flight_modes/position_mc.md
+++ b/en/flight_modes/position_mc.md
@@ -27,7 +27,7 @@ RC/manual mode where RPT sticks control *speed* in corresponding directions. Cen
 
 * Centered RPT sticks (in RC deadzone) hold x, y, z position steady against any wind, and levels attitude.
 * Outside center:
-  * Roll/Pitch sticks control acceleration horizontally (over ground) in left-right and forward-back directions (respectively) relative to the "front" of the vehicle.
+  * Roll/Pitch sticks control horizontal acceleration (over ground) in left-right and forward-back directions (respectively) relative to the "front" of the vehicle.
   * Throttle stick controls speed of ascent-descent.
   * Yaw stick controls rate of angular rotation above the horizontal plane.
 * Takeoff:

--- a/en/getting_started/flight_modes.md
+++ b/en/getting_started/flight_modes.md
@@ -83,7 +83,7 @@ Icon | Description
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
-[Position mode](../flight_modes/position_mc.md) is an easy-to-fly RC mode in which roll and pitch sticks control acceleration over ground in the left-right and forward-back directions (relative to the "front" of the vehicle), and throttle controls speed of ascent-descent.
+[Position mode](../flight_modes/position_mc.md) is an easy-to-fly RC mode in which roll and pitch sticks control _acceleration_ over ground in the left-right and forward-back directions (similar to a car's accelerator pedal), and throttle controls speed of ascent-descent.
 When the sticks are released/centered the vehicle will actively brake, level, and be locked to a position in 3D space — compensating for wind and other forces.
 
 :::tip

--- a/en/getting_started/flight_modes.md
+++ b/en/getting_started/flight_modes.md
@@ -83,12 +83,12 @@ Icon | Description
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
-[Position mode](../flight_modes/position_mc.md) is an easy-to-fly RC mode in which roll and pitch sticks control _acceleration_ over ground in the vehicle's left-right and forward-back directions (similar to a car's accelerator pedal), and throttle controls speed of ascent-descent.
+[Position mode](../flight_modes/position_mc.md) is an easy-to-fly RC mode in which roll and pitch sticks control _acceleration_ over ground in the vehicle's forward-back and left-right directions (similar to a car's accelerator pedal), and throttle controls speed of ascent-descent.
 When the sticks are released/centered the vehicle will actively brake, level, and be locked to a position in 3D space — compensating for wind and other forces.
 
 :::tip
 Position mode is the safest manual mode for new fliers.
-Unlike [Altitude](#altitude-mode-mc) and [Manual/Stabilized](#manual_stabilized_mc) modes the vehicle will stop when the sticks are centered rather than continuing until slowed by wind resistance. 
+Unlike [Altitude](#altitude-mode-mc) and [Manual/Stabilized](#manual_stabilized_mc) modes the vehicle will stop when the sticks are centered rather than continuously drifting without constant manual guidance. 
 :::
 
 ![MC Position Mode](../../assets/flight_modes/position_MC.png)

--- a/en/getting_started/flight_modes.md
+++ b/en/getting_started/flight_modes.md
@@ -83,7 +83,7 @@ Icon | Description
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
-[Position mode](../flight_modes/position_mc.md) is an easy-to-fly RC mode in which roll and pitch sticks control _acceleration_ over ground in the left-right and forward-back directions (similar to a car's accelerator pedal), and throttle controls speed of ascent-descent.
+[Position mode](../flight_modes/position_mc.md) is an easy-to-fly RC mode in which roll and pitch sticks control _acceleration_ over ground in the vehicle's left-right and forward-back directions (similar to a car's accelerator pedal), and throttle controls speed of ascent-descent.
 When the sticks are released/centered the vehicle will actively brake, level, and be locked to a position in 3D space — compensating for wind and other forces.
 
 :::tip

--- a/en/getting_started/flight_modes.md
+++ b/en/getting_started/flight_modes.md
@@ -78,22 +78,22 @@ Icon | Description
 <a id="mc_flight_modes"></a>
 ## Multicopter
 
-<a id="position_mc"></a>
+
 ### Position Mode (MC)
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
-[Position mode](../flight_modes/position_mc.md) is an easy-to-fly RC mode in which roll and pitch sticks control speed over ground in the left-right and forward-back directions (relative to the "front" of the vehicle), and throttle controls speed of ascent-descent.
+[Position mode](../flight_modes/position_mc.md) is an easy-to-fly RC mode in which roll and pitch sticks control acceleration over ground in the left-right and forward-back directions (relative to the "front" of the vehicle), and throttle controls speed of ascent-descent.
 When the sticks are released/centered the vehicle will actively brake, level, and be locked to a position in 3D space — compensating for wind and other forces.
 
 :::tip
-Position mode is the safest manual mode for new fliers. Unlike [Altitude](#altitude_mc) and [Manual/Stabilized](#manual_stabilized_mc) modes the vehicle will stop when the sticks are centered rather than continuing until slowed by wind resistance. 
+Position mode is the safest manual mode for new fliers.
+Unlike [Altitude](#altitude-mode-mc) and [Manual/Stabilized](#manual_stabilized_mc) modes the vehicle will stop when the sticks are centered rather than continuing until slowed by wind resistance. 
 :::
 
 ![MC Position Mode](../../assets/flight_modes/position_MC.png)
 
 
-<a id="altitude_mc"></a>
 ### Altitude Mode (MC)
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;[<img src="../../assets/site/altitude_icon.svg" title="Altitude required (e.g. Baro, Rangefinder)" width="30px" />](#altitude_only)


### PR DESCRIPTION
Fixes #1133

@MaEtUgR Because the docs are versioned, we document the current behaviour rather than the "change". Essentially this means changing the text where we say that we control movement over ground from speed to acceleration. This happens in three places:
- [Getting Started > Flight Modes](https://docs.px4.io/master/en/getting_started/flight_modes.html#position-mode-mc)
- [Flight Modes Overview page](https://docs.px4.io/master/en/flight_modes/)
  - [Position Mode (MC)](https://docs.px4.io/master/en/flight_modes/position_mc.html)

Mostly pretty straightforward, but some clarifications required both related to this change, and generally.