### PR TITLE
Binary size profiling in own doc

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -354,6 +354,7 @@
     * [Sending Debug Values](debug/debug_values.md)
     * [System-wide Replay](debug/system_wide_replay.md)
     * [Profiling](debug/profiling.md)
+    * [Binary Size Profiling](debug/binary_size_profiling.md)
     * [Logging](dev_log/logging.md)
     * [Flight Log Analysis](dev_log/flight_log_analysis.md)
     * [ULog File Format](dev_log/ulog_file_format.md)

--- a/en/debug/binary_size_profiling.md
+++ b/en/debug/binary_size_profiling.md
@@ -1,0 +1,59 @@
+# Binary Size Profiling
+
+The `bloaty_compare_master` build target allows you to get a better understanding of the impact of changes on code size.
+When it is used, the toolchain downloads the latest successful master build of a particular firmware and compares it to the local build (using the [bloaty](https://github.com/google/bloaty) size profiler for binaries).
+
+:::tip
+This can help analyse changes that (may) cause `px4_fmu-v2_default` to hit the 1MB flash limit.
+:::
+
+*Bloaty* must be in your path and found at *cmake* configure time.
+The PX4 [docker files](https://github.com/PX4/containers/blob/master/docker/Dockerfile_nuttx-bionic) install *bloaty* as shown:
+```
+git clone --recursive https://github.com/google/bloaty.git /tmp/bloaty \
+	&& cd /tmp/bloaty && cmake -GNinja . && ninja bloaty && cp bloaty /usr/local/bin/ \
+	&& rm -rf /tmp/*
+```
+
+The example below shows how you might see the impact of removing the *mpu9250* driver from `px4_fmu-v2_default`.
+First it locally sets up a build without the driver:
+```sh
+ % git diff
+diff --git a/boards/px4/fmu-v2/default.cmake b/boards/px4/fmu-v2/default.cmake
+index 40d7778..2ce7972 100644
+--- a/boards/px4/fmu-v2/default.cmake
++++ b/boards/px4/fmu-v2/default.cmake
+@@ -36,7 +36,7 @@ px4_add_board(
+                imu/l3gd20
+                imu/lsm303d
+                imu/mpu6000
+-               imu/mpu9250
++               #imu/mpu9250
+                #iridiumsbd
+                #irlock
+                #magnetometer # all available magnetometer drivers
+```
+Then use the make target, specifying the target build to compare (`px4_fmu-v2_default` in this case):
+```sh
+% make px4_fmu-v2_default bloaty_compare_master
+...
+...
+...
+     VM SIZE                                                                                        FILE SIZE
+ --------------                                                                                  --------------
+  [DEL]     -52 MPU9250::check_null_data(unsigned int*, unsigned char)                               -52  [DEL]
+  [DEL]     -52 MPU9250::test_error()                                                                -52  [DEL]
+  [DEL]     -52 MPU9250_gyro::MPU9250_gyro(MPU9250*, char const*)                                    -52  [DEL]
+  [DEL]     -56 mpu9250::info(MPU9250_BUS)                                                           -56  [DEL]
+  [DEL]     -56 mpu9250::regdump(MPU9250_BUS)                                                        -56  [DEL]
+...                                        -336  [DEL]
+  [DEL]    -344 MPU9250_mag::_measure(ak8963_regs)                                                  -344  [DEL]
+  [DEL]    -684 MPU9250::MPU9250(device::Device*, device::Device*, char const*, char const*, cha    -684  [DEL]
+  [DEL]    -684 MPU9250::init()                                                                     -684  [DEL]
+  [DEL]   -1000 MPU9250::measure()                                                                 -1000  [DEL]
+ -41.3%   -1011 [43 Others]                                                                        -1011 -41.3%
+  -1.0% -1.05Ki [Unmapped]                                                                       +24.2Ki  +0.2%
+  -1.0% -10.3Ki TOTAL                                                                            +14.9Ki  +0.1%
+```
+This shows that removing *mpu9250* from `px4_fmu-v2_default` would save 10.3 kB of flash.
+It also shows the sizes of different pieces of the *mpu9250* driver.

--- a/en/dev_setup/building_px4.md
+++ b/en/dev_setup/building_px4.md
@@ -137,143 +137,6 @@ Build commands for other boards are given the [board-specific flight controller 
 [VSCode](../dev_setup/vscode.md) is the officially supported (and recommended) IDE for PX4 development.
 It is easy to set up and can be used to compile PX4 for both simulation and hardware environments.
 
-## PX4 Make Build Targets
-
-The previous sections showed how you can call *make* to build a number of different targets, start simulators, use IDEs etc.
-This section shows how *make* options are constructed and how to find the available choices.
-
-The full syntax to call *make* with a particular configuration and initialization file is:
-```sh
-make [VENDOR_][MODEL][_VARIANT] [VIEWER_MODEL_DEBUGGER_WORLD]
-```
-
-**VENDOR_MODEL_VARIANT**: (also known as `CONFIGURATION_TARGET`)
-
-- **VENDOR:** The manufacturer of the board: `px4`, `aerotenna`, `airmind`, `atlflight`, `auav`, `beaglebone`, `intel`, `nxp`, etc.
-    The vendor name for Pixhawk series boards is `px4`.
-- **MODEL:** The *board model* "model": `sitl`, `fmu-v2`, `fmu-v3`, `fmu-v4`, `fmu-v5`, `navio2`, etc.
-- **VARIANT:** Indicates particular configurations: e.g. `rtps`, `lpe`, which contain components that are not present in the `default` configuration. Most commonly this is `default`, and may be omitted.
-
-:::tip
-You can get a list of *all* available `CONFIGURATION_TARGET` options using the command below:
-```sh
-make list_config_targets
-```
-:::
-
-**VIEWER_MODEL_DEBUGGER_WORLD:**
-  
-- **VIEWER:** This is the simulator ("viewer") to launch and connect: `gazebo`, `jmavsim`, `none` <!-- , ?airsim -->
-
-  :::tip
-  `none` can be used if you want to launch PX4 and wait for a simulator (jmavsim, gazebo, or some other simulator).
-  For example, `make px4_sitl none_iris` launches PX4 without a simulator (but with the iris airframe).
-  :::
-- **MODEL:** The *vehicle* model to use (e.g. `iris` (*default*), `rover`, `tailsitter`, etc), which will be loaded by the simulator.
-  The environment variable `PX4_SIM_MODEL` will be set to the selected model, which is then used in the [startup script](../simulation/README.md#startup-scripts) to select appropriate parameters. 
-- **DEBUGGER:** Debugger to use: `none` (*default*), `ide`, `gdb`, `lldb`, `ddd`, `valgrind`, `callgrind`. 
-  For more information see [Simulation Debugging](../debug/simulation_debugging.md).
-- **WORLD:** (Gazebo only). Set a the world ([PX4/sitl_gazebo/worlds](https://github.com/PX4/sitl_gazebo/tree/master/worlds)) that is loaded.
-  Default is [empty.world](https://github.com/PX4/sitl_gazebo/blob/master/worlds/empty.world).
-  For more information see [Gazebo > Loading a Specific World](../simulation/gazebo.md#set_world).
-
-:::tip
-You can get a list of *all* available `VIEWER_MODEL_DEBUGGER_WORLD` options using the command below:
-```sh
-make px4_sitl list_vmd_make_targets
-```
-:::
-
-Notes:
-- Most of the values in the `CONFIGURATION_TARGET` and `VIEWER_MODEL_DEBUGGER` have defaults, and are hence optional.
-  For example, `gazebo` is equivalent to `gazebo_iris` or `gazebo_iris_none`.
-- You can use three underscores if you want to specify a default value between two other settings.
-  For example, `gazebo___gdb` is equivalent to `gazebo_iris_gdb`.
-- You can use a `none` value for `VIEWER_MODEL_DEBUGGER` to start PX4 and wait for a simulator.
-  For example start PX4 using `make px4_sitl_default none` and jMAVSim using `./Tools/jmavsim_run.sh -l`.
-
-
-The `VENDOR_MODEL_VARIANT` options map to particular *cmake* configuration files in the PX4 source tree under the [/boards](https://github.com/PX4/PX4-Autopilot/tree/master/boards) directory.
-Specifically `VENDOR_MODEL_VARIANT` maps to a configuration file **boards/VENDOR/MODEL/VARIANT.cmake**
-(e.g. `px4_fmu-v5_default` corresponds to [boards/px4/fmu-v5/default.cmake](https://github.com/PX4/PX4-Autopilot/blob/master/boards/px4/fmu-v5/default.cmake)).
-
-Additional make targets are discussed in the following sections (list is not exhaustive):
-
-
-### Binary Size Profiling
-
-The `bloaty_compare_master` build target allows you to get a better understanding of the impact of changes on code size.
-When it is used, the toolchain downloads the latest successful master build of a particular firmware and compares it to the local build (using the [bloaty](https://github.com/google/bloaty) size profiler for binaries).
-
-:::tip
-This can help analyse changes that (may) cause `px4_fmu-v2_default` to hit the 1MB flash limit.
-:::
-
-*Bloaty* must be in your path and found at *cmake* configure time.
-The PX4 [docker files](https://github.com/PX4/containers/blob/master/docker/Dockerfile_nuttx-bionic) install *bloaty* as shown:
-```
-git clone --recursive https://github.com/google/bloaty.git /tmp/bloaty \
-	&& cd /tmp/bloaty && cmake -GNinja . && ninja bloaty && cp bloaty /usr/local/bin/ \
-	&& rm -rf /tmp/*
-```
-
-The example below shows how you might see the impact of removing the *mpu9250* driver from `px4_fmu-v2_default`.
-First it locally sets up a build without the driver:
-```sh
- % git diff
-diff --git a/boards/px4/fmu-v2/default.cmake b/boards/px4/fmu-v2/default.cmake
-index 40d7778..2ce7972 100644
---- a/boards/px4/fmu-v2/default.cmake
-+++ b/boards/px4/fmu-v2/default.cmake
-@@ -36,7 +36,7 @@ px4_add_board(
-                imu/l3gd20
-                imu/lsm303d
-                imu/mpu6000
--               imu/mpu9250
-+               #imu/mpu9250
-                #iridiumsbd
-                #irlock
-                #magnetometer # all available magnetometer drivers
-```
-Then use the make target, specifying the target build to compare (`px4_fmu-v2_default` in this case):
-```sh
-% make px4_fmu-v2_default bloaty_compare_master
-...
-...
-...
-     VM SIZE                                                                                        FILE SIZE
- --------------                                                                                  --------------
-  [DEL]     -52 MPU9250::check_null_data(unsigned int*, unsigned char)                               -52  [DEL]
-  [DEL]     -52 MPU9250::test_error()                                                                -52  [DEL]
-  [DEL]     -52 MPU9250_gyro::MPU9250_gyro(MPU9250*, char const*)                                    -52  [DEL]
-  [DEL]     -56 mpu9250::info(MPU9250_BUS)                                                           -56  [DEL]
-  [DEL]     -56 mpu9250::regdump(MPU9250_BUS)                                                        -56  [DEL]
-...                                        -336  [DEL]
-  [DEL]    -344 MPU9250_mag::_measure(ak8963_regs)                                                  -344  [DEL]
-  [DEL]    -684 MPU9250::MPU9250(device::Device*, device::Device*, char const*, char const*, cha    -684  [DEL]
-  [DEL]    -684 MPU9250::init()                                                                     -684  [DEL]
-  [DEL]   -1000 MPU9250::measure()                                                                 -1000  [DEL]
- -41.3%   -1011 [43 Others]                                                                        -1011 -41.3%
-  -1.0% -1.05Ki [Unmapped]                                                                       +24.2Ki  +0.2%
-  -1.0% -10.3Ki TOTAL                                                                            +14.9Ki  +0.1%
-```
-This shows that removing *mpu9250* from `px4_fmu-v2_default` would save 10.3 kB of flash.
-It also shows the sizes of different pieces of the *mpu9250* driver.
-
-
-## Firmware Version & Git Tags
-
-The *PX4 Firmware Version* and *Custom Firmware Version* are published using the MAVLink [AUTOPILOT_VERSION](https://mavlink.io/en/messages/common.html#AUTOPILOT_VERSION) message, and displayed in the *QGroundControl* **Setup > Summary** airframe panel:
-
-![Firmware info](../../assets/gcs/qgc_setup_summary_airframe_firmware.jpg)
-
-These are extracted at build time from the active *git tag* for your repo tree.
-The git tag should be formatted as `<PX4-version>-<vendor-version>` (e.g. the tag in the image above was set to `v1.8.1-2.22.1`).
-
-:::warning
-If you use a different git tag format, versions information may not be displayed properly.
-:::
-
 
 ## Troubleshooting
 
@@ -339,3 +202,85 @@ You should be able to fix this by explicitly installing the dependencies as show
 ```
 pip3 install --user pyserial empy toml numpy pandas jinja2 pyyaml pyros-genmsg packaging
 ```
+
+
+## PX4 Make Build Targets
+
+The previous sections showed how you can call *make* to build a number of different targets, start simulators, use IDEs etc.
+This section shows how *make* options are constructed and how to find the available choices.
+
+The full syntax to call *make* with a particular configuration and initialization file is:
+```sh
+make [VENDOR_][MODEL][_VARIANT] [VIEWER_MODEL_DEBUGGER_WORLD]
+```
+
+**VENDOR_MODEL_VARIANT**: (also known as `CONFIGURATION_TARGET`)
+
+- **VENDOR:** The manufacturer of the board: `px4`, `aerotenna`, `airmind`, `atlflight`, `auav`, `beaglebone`, `intel`, `nxp`, etc.
+    The vendor name for Pixhawk series boards is `px4`.
+- **MODEL:** The *board model* "model": `sitl`, `fmu-v2`, `fmu-v3`, `fmu-v4`, `fmu-v5`, `navio2`, etc.
+- **VARIANT:** Indicates particular configurations: e.g. `rtps`, `lpe`, which contain components that are not present in the `default` configuration. Most commonly this is `default`, and may be omitted.
+
+:::tip
+You can get a list of *all* available `CONFIGURATION_TARGET` options using the command below:
+```sh
+make list_config_targets
+```
+:::
+
+**VIEWER_MODEL_DEBUGGER_WORLD:**
+  
+- **VIEWER:** This is the simulator ("viewer") to launch and connect: `gazebo`, `jmavsim`, `none` <!-- , ?airsim -->
+
+  :::tip
+  `none` can be used if you want to launch PX4 and wait for a simulator (jmavsim, gazebo, or some other simulator).
+  For example, `make px4_sitl none_iris` launches PX4 without a simulator (but with the iris airframe).
+  :::
+- **MODEL:** The *vehicle* model to use (e.g. `iris` (*default*), `rover`, `tailsitter`, etc), which will be loaded by the simulator.
+  The environment variable `PX4_SIM_MODEL` will be set to the selected model, which is then used in the [startup script](../simulation/README.md#startup-scripts) to select appropriate parameters. 
+- **DEBUGGER:** Debugger to use: `none` (*default*), `ide`, `gdb`, `lldb`, `ddd`, `valgrind`, `callgrind`. 
+  For more information see [Simulation Debugging](../debug/simulation_debugging.md).
+- **WORLD:** (Gazebo only). Set a the world ([PX4/sitl_gazebo/worlds](https://github.com/PX4/sitl_gazebo/tree/master/worlds)) that is loaded.
+  Default is [empty.world](https://github.com/PX4/sitl_gazebo/blob/master/worlds/empty.world).
+  For more information see [Gazebo > Loading a Specific World](../simulation/gazebo.md#set_world).
+
+:::tip
+You can get a list of *all* available `VIEWER_MODEL_DEBUGGER_WORLD` options using the command below:
+```sh
+make px4_sitl list_vmd_make_targets
+```
+:::
+
+Notes:
+- Most of the values in the `CONFIGURATION_TARGET` and `VIEWER_MODEL_DEBUGGER` have defaults, and are hence optional.
+  For example, `gazebo` is equivalent to `gazebo_iris` or `gazebo_iris_none`.
+- You can use three underscores if you want to specify a default value between two other settings.
+  For example, `gazebo___gdb` is equivalent to `gazebo_iris_gdb`.
+- You can use a `none` value for `VIEWER_MODEL_DEBUGGER` to start PX4 and wait for a simulator.
+  For example start PX4 using `make px4_sitl_default none` and jMAVSim using `./Tools/jmavsim_run.sh -l`.
+
+
+The `VENDOR_MODEL_VARIANT` options map to particular *cmake* configuration files in the PX4 source tree under the [/boards](https://github.com/PX4/PX4-Autopilot/tree/master/boards) directory.
+Specifically `VENDOR_MODEL_VARIANT` maps to a configuration file **boards/VENDOR/MODEL/VARIANT.cmake**
+(e.g. `px4_fmu-v5_default` corresponds to [boards/px4/fmu-v5/default.cmake](https://github.com/PX4/PX4-Autopilot/blob/master/boards/px4/fmu-v5/default.cmake)).
+
+Additional make targets are discussed in relevant sections:
+- `bloaty_compare_master`: [Binary Size Profiling]()
+- ...
+
+
+
+## Firmware Version & Git Tags
+
+The *PX4 Firmware Version* and *Custom Firmware Version* are published using the MAVLink [AUTOPILOT_VERSION](https://mavlink.io/en/messages/common.html#AUTOPILOT_VERSION) message, and displayed in the *QGroundControl* **Setup > Summary** airframe panel:
+
+![Firmware info](../../assets/gcs/qgc_setup_summary_airframe_firmware.jpg)
+
+These are extracted at build time from the active *git tag* for your repo tree.
+The git tag should be formatted as `<PX4-version>-<vendor-version>` (e.g. the tag in the image above was set to `v1.8.1-2.22.1`).
+
+:::warning
+If you use a different git tag format, versions information may not be displayed properly.
+:::
+
+

--- a/en/dev_setup/building_px4.md
+++ b/en/dev_setup/building_px4.md
@@ -131,6 +131,11 @@ Rebooting.
 
 Build commands for other boards are given the [board-specific flight controller pages](../flight_controller/README.md) (usually under a heading *Building Firmware*).
 
+You can also list all configuration targets using the command:
+```sh
+make list_config_targets
+```
+
 
 ## Compiling in a Graphical IDE
 
@@ -267,7 +272,6 @@ Specifically `VENDOR_MODEL_VARIANT` maps to a configuration file **boards/VENDOR
 Additional make targets are discussed in relevant sections:
 - `bloaty_compare_master`: [Binary Size Profiling]()
 - ...
-
 
 
 ## Firmware Version & Git Tags


### PR DESCRIPTION
This splits Binary Size profiling into its own doc. It is not particularly relevant to "Building" or to Getting Started, but it is relevant to debugging. So I have moved it into that section.

@bkueng This is a step towards further simplifying the build instructions, as we discussed here: https://github.com/PX4/PX4-user_guide/pull/1126#issuecomment-801561856

The thing about [Building PX4 Software](https://github.com/PX4/PX4-user_guide/pull/1126#issuecomment-801561856) is that it is under Getting Started, but it includes things that are relatively advanced. For example, as a getting started person you basically need to know some basic build commands and troubleshooting. 
Presenting the [PX4 make targets](http://docs.px4.io/master/en/dev_setup/building_px4.html), should be linked for more information, but is kind of irrelevant at this level.

So, what I have done for now is pushed that below troubleshooting to the end. You only see it when you got the basics.

I was wondering if perhaps this could be its own document under "Concepts"? or Concepts > Building, with other more advanced topics related to the toolchain - e.g. cmake files etc. Just an idea. Let me know if you think that is worth exploring.