### PR TITLE
Improve airsim docs with videos

### DIFF
--- a/en/simulation/airsim.md
+++ b/en/simulation/airsim.md
@@ -1,11 +1,38 @@
 # AirSim Simulation
 
-AirSim is a open-source, cross platform simulator for drones, built on Unreal Engine. It provides physically and visually realistic simulations of Pixhawk/PX4 using either Hardware-In-The-Loop \(HITL\) or Software-In-The-Loop \(SITL\).
+[AirSim](https://microsoft.github.io/AirSim/) is a open-source, cross platform simulator for drones, built on _Unreal Engine_.
+It provides physically and visually realistic simulations of Pixhawk/PX4 using either Hardware-In-The-Loop (HITL) or Software-In-The-Loop (SITL).
 
-The main entry point for the documentation is the [AirSim Documentation](https://microsoft.github.io/AirSim/).
+@[youtube](https://youtu.be/-WfTr1-OBGQ) <!-- datestamp:video:youtube:20170216:AirSim Demo -->
 
-The main entry point for documentation on working with PX4 is [PX4 Setup for AirSim](https://microsoft.github.io/AirSim/px4_setup/) (covering both HITL and SITL).
+
+## PX4 Setup
+
+[PX4 Setup for AirSim](https://microsoft.github.io/AirSim/px4_setup/) describes how to use PX4 with AirSim using both [SITL](https://microsoft.github.io/AirSim/px4_sitl/) and [HITL](https://microsoft.github.io/AirSim/px4_setup/#setting-up-px4-hardware-in-loop).
+
+
+## Videos
+
+#### AirSim with PX4 on WSL 2
+
+@[youtube](https://youtu.be/DiqgsWIOoW4) <!-- datestamp:video:youtube:20210401:AirSim with PX4 on WSL 2 -->
+
+:::note
+WSL 2 is not a supported [PX4 Windows development environment](../dev_setup/dev_env_windows_cygwin.md), mainly because it is non-trivial to display simulator UIs running within WSL 2 in the normal Windows environment.
+This limitation does not apply for AirSim because its UI is run natively in Windows.
+:::
+
+
+#### Microsoft AirSim: Applications to Research and Industry (PX4 Developer Summit Virtual 2020)
+
+@[youtube](https://youtu.be/-YMiKaJYl44) <!-- datestamp:video:youtube:20200716:Microsoft AirSim: Applications to Research and Industry — PX4 Developer Summit Virtual 2020 -->
+
+#### Autonomous Drone Inspections using AirSim and PX4 (PX4 Developer Summit Virtual 2020)
+
+@[youtube](https://youtu.be/JDx0MPTlhrg) <!-- datestamp:video:youtube:20200716:Autonomous Drone Inspections using AirSim and PX4 — PX4 Developer Summit Virtual 2020 -->
+
 
 ## Further Information
 
+* [AirSim Documentation](https://microsoft.github.io/AirSim/)
 * [Using AirSim to Simulate Aircraft Inspection by Autonomous Drones](https://github.com/generalized-intelligence/GAAS/tree/master/demo/case_study_1?fbclid=IwAR2JO0LPesA5z313sA2QGm1t01bb4wn0Xpz_JkD7Z1s3nombJWHyTZdLuMA) (Case Study from Generalized Autonomy Aviation System (GAAS) project).


### PR DESCRIPTION
This makes airsim docs a bit more interesting by adding some videos, including the new one showing how to use Airsim with WSL2.

In addition I'm trying to enable better tracking of video assets and how they age by including a html comment in source that makes it more easy to determine when these things were added. E.g. `<!-- datestamp:video:youtube:20210401:AirSim with PX4 on WSL 2 -->`