### PR TITLE
Adding a note to raise awareness for throttle input

### DIFF
--- a/en/concept/mixing.md
+++ b/en/concept/mixing.md
@@ -284,7 +284,7 @@ The `S:` lines must be below the `O:` line.
 :::
 
 :::note
-Be aware that every Mixer containing an `S:`-line with `<group>=0` and `<index>=3` (throttle) won't work in disarmed state. E.g. a helicopter servo that has four inputs (roll, pitch, yaw and throttle) won't move in disarmed state even with roll/pitch/yaw signals.
+Any mixer output that has a throttle input (an `S:`-line with `<group>=0` and `<index>=3`) won't work in disarmed or prearmed state. For example, a servo that has four inputs (roll, pitch, yaw and throttle) won't move in disarmed state even with roll/pitch/yaw signals.
 :::
 
 The `<group>` value identifies the control group from which the scaler will read, and the `<index>` value an offset within that group.

--- a/en/concept/mixing.md
+++ b/en/concept/mixing.md
@@ -283,6 +283,10 @@ S: <group> <index> <-ve scale> <+ve scale> <offset> <lower limit> <upper limit>
 The `S:` lines must be below the `O:` line.
 :::
 
+:::note
+Be aware that every Mixer containing an `S:`-line with `<group>=0` and `<index>=3` (throttle) won't work in disarmed state. E.g. a helicopter servo that has four inputs (roll, pitch, yaw and throttle) won't move in disarmed state even with roll/pitch/yaw signals.
+:::
+
 The `<group>` value identifies the control group from which the scaler will read, and the `<index>` value an offset within that group.
 These values are specific to the device reading the mixer definition.
 


### PR DESCRIPTION
It took me a very long time to figure out, why I couldn't use my summing mixers in disarmed state. I knew that throttle signals wouldn't work in disarmed state, but I had assumed that a summing mixer that gets multiple control inputs would still work in disarmed state for all signals that are NOT throttle. Since that is not the case and I assume others might have the same issue, I would like to raise awareness for it. I'm not sure, if this would be the right place to do so, but I decided to just give it a try.

Affects: http://docs.px4.io/master/en/concept/mixing.html