### PR TITLE
Change ROS1 command to ROS2 command

### DIFF
--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -177,7 +177,7 @@ We can do this by running the bridge against PX4 running in the simulator.
    accelerometer_integral_dt: 4739
    ```
 
-You can also verify the rate of the message using `ros2 topic hz`. <!-- how? -->
+You can also verify the rate of the message using `ros2 topic hz`.
 E.g. in the case of `sensor_combined` use `ros2 topic hz /SensorCombined_PubSubTopic`:
    ```sh
    average rate: 248.187

--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -177,8 +177,8 @@ We can do this by running the bridge against PX4 running in the simulator.
    accelerometer_integral_dt: 4739
    ```
 
-You can also verify the rate of the message using `rostopic hz`. <!-- how? -->
-For the case of `sensor_combined`:
+You can also verify the rate of the message using `ros2 topic hz`. <!-- how? -->
+E.g. in the case of `sensor_combined` use `ros2 topic hz /SensorCombined_PubSubTopic`:
    ```sh
    average rate: 248.187
    	min: 0.000s max: 0.012s std dev: 0.00147s window: 2724


### PR DESCRIPTION
I changed the `rostopic` command which only works in ROS1 to `ros2 topic` command. Also I provided a complete example, because in the markdown code here someone had already commented with "how?". Maybe you could also remove this comment.