### PR TITLE
1.12: Add bugfix for stick velocity ramp before takeoff

### DIFF
--- a/en/releases/1.12.md
+++ b/en/releases/1.12.md
@@ -77,12 +77,12 @@ The release includes new hardware support for the following boards, peripherals,
   * Removes unexpected tilt changes upon reaching travel speed velocity
   * Intuitive shunting e.g. when landing
   * Opt out possible using [MPC_POS_MODE](../advanced_config/parameter_reference.md#MPC_POS_MODE)
-  * Development: [First attempt](https://github.com/PX4/PX4-Autopilot/pull/12072), [Introduction](https://github.com/PX4/PX4-Autopilot/pull/16052), [Improvements](https://github.com/PX4/PX4-Autopilot/pull/16320), [Bugfix zero oscillation](https://github.com/PX4/PX4-Autopilot/pull/16786), [Bugfix position unlock](https://github.com/PX4/PX4-Autopilot/pull/16791), [Bugfix invalid setpoint](https://github.com/PX4/PX4-Autopilot/pull/17078)
+  * Development: [First attempt](https://github.com/PX4/PX4-Autopilot/pull/12072), [Introduction](https://github.com/PX4/PX4-Autopilot/pull/16052), [Improvements](https://github.com/PX4/PX4-Autopilot/pull/16320), [Bugfix zero oscillation](https://github.com/PX4/PX4-Autopilot/pull/16786), [Bugfix position unlock](https://github.com/PX4/PX4-Autopilot/pull/16791), [Bugfix invalid setpoint](https://github.com/PX4/PX4-Autopilot/pull/17078), [Bugfix high velocity pre takeoff](https://github.com/PX4/PX4-Autopilot/pull/17437)
 
 * **Hover thrust independent velocity control gains**
-  * Parameters `MPC_{XY/Z}_VEL_{P/I/D}` were replaced with `MPC_{XY/Z}_VEL_{P/I/D}_ACC`, see: 
+  * Parameters `MPC_{XY/Z}_VEL_{P/I/D}` were replaced with `MPC_{XY/Z}_VEL_{P/I/D}_ACC`, see:
    [MPC_XY_VEL_P_ACC](../advanced_config/parameter_reference.md#MPC_XY_VEL_P_ACC), [MPC_XY_VEL_I_ACC](../advanced_config/parameter_reference.md#MPC_XY_VEL_I_ACC), [MPC_XY_VEL_D_ACC](../advanced_config/parameter_reference.md#MPC_XY_VEL_D_ACC), [MPC_Z_VEL_P_ACC](../advanced_config/parameter_reference.md#MPC_Z_VEL_P_ACC), [MPC_Z_VEL_I_ACC](../advanced_config/parameter_reference.md#MPC_Z_VEL_I_ACC), [MPC_Z_VEL_D_ACC](../advanced_config/parameter_reference.md#MPC_Z_VEL_D_ACC)
-   
+
     :::warning The gains have a new meaning
     * Scale from velocity error in $m/s$ to acceleration output in $m/s^2$
     * Existing gains need to roughly be rescaled by a factor of: $gravitational \_ constant / hover\_thrust$
@@ -121,7 +121,7 @@ Nuttx was upgraded from [8.2+ to NuttX 10.10.0+](https://github.com/apache/incub
   * [**BACKPORT**] stm32f7:lse Use Kconfig values directly
   * [**BACKPORT**] stm32h7:Add DBGMCU
   * [**BACKPORT**] stm32f7:Add option to auto select LSE CAPABILITY
-  * [**BACKPORT**] stm32h7:Add option to auto select LSE CAPABILITY  
+  * [**BACKPORT**] stm32h7:Add option to auto select LSE CAPABILITY
 
     :::note
       This Knob will cycle through the correct*
@@ -149,7 +149,7 @@ Nuttx was upgraded from [8.2+ to NuttX 10.10.0+](https://github.com/apache/incub
   * [**BACKPORT**] tcp: Remove incomplete support for TCP reassembly
 * [**BACKPORT**] net/tcp/tcp_input.c:  Correct bad check of urgent data length
 * **IMXRT fixes**
-* Add Single wire and proper parity settings to IMXRT  to support sbus etal. 
+* Add Single wire and proper parity settings to IMXRT  to support sbus etal.
 * [**BACKPORT**] imxrt:serial support single-wire mode
 * [**BACKPORT**] imxrt:imxrt_lowputc Fixed parity settings.
 * **STM32H7 improvements**


### PR DESCRIPTION
Thanks to us adding the release notes label to https://github.com/PX4/PX4-Autopilot/pull/17437 I remembered to add it here.