### PR TITLE
Parameter definitition docs updates

### DIFF
--- a/en/advanced/parameters_and_configurations.md
+++ b/en/advanced/parameters_and_configurations.md
@@ -250,8 +250,8 @@ It supports all the same metadata, along with new features like multi-instance d
 - An example of YAML definitions being used can be found in the MAVLink parameter definitions: [/src/modules/mavlink/module.yaml](https://github.com/PX4/PX4-Autopilot/blob/master/src/modules/mavlink/module.yaml).
 - A YAML file is registered in the cmake build system by adding
   ```
-	MODULE_CONFIG
-		module.yaml
+  MODULE_CONFIG
+  	module.yaml
   ```
   to the `px4_add_module` section of the `CMakeLists.txt` file of that module.
 
@@ -331,8 +331,8 @@ The purpose of each line is given below (for more detail see [module_schema.yaml
 ```
 
 
-
 ## Further Information
 
 - [Finding/Updating Parameters](../advanced_config/parameters.md)
 - [Parameter Reference](../advanced_config/parameter_reference.md)
+- [Param implementation](https://github.com/PX4/PX4-Autopilot/blob/master/platforms/common/include/px4_platform_common/param.h#L129) (information on `.get()`, `.commit()`, and other methods)


### PR DESCRIPTION
This attempts to fix #1256.  @bkueng it would be better if you made any needed updates directly. I can see that there will be some around subscription API but I don't want to inject crap.

Further, this is still missing 

1. Info on how to add yaml to the build system
2. Re "how to use the parameter and how the system reacts (e.g. .get(), .commit(), ... methods)" you said best to look at the code: https://github.com/PX4/PX4-Autopilot/blob/master/platforms/common/include/px4_platform_common/param.h#L129 - worth adding that to further reading?
3. How to get the metadata into QGC