### PR TITLE
microRTPS: make sure to state clearly that only Fast-RTPS-Gen 1.0.4 is required and supported

### DIFF
--- a/en/dev_setup/fast-dds-installation.md
+++ b/en/dev_setup/fast-dds-installation.md
@@ -22,8 +22,8 @@ Fast DDS was previously named FastRTPS (the name was changed in version 2.0.0 as
 
 :::note
 At time of writing you will need to install *from source* for:
-- **Ubuntu 18.04:** Fast RTPS 1.8.2 and Fast-RTPS-Gen 1.0.4 (or higher).
-- **Ubuntu 20.04:** Fast DDS 2.0.0 and Fast-RTPS-Gen 1.0.4 (or higher).
+- **Ubuntu 18.04:** Fast RTPS 1.8.2 (or later) and Fast-RTPS-Gen 1.0.4 (not later!).
+- **Ubuntu 20.04:** Fast DDS 2.0.0 (or later) and Fast-RTPS-Gen 1.0.4 (not later!).
 :::
 
 ### Java
@@ -178,4 +178,3 @@ $ sudo make install
   - Installation from Binaries
     - [Linux](https://fast-dds.docs.eprosima.com/en/latest/installation/binaries/binaries_linux.html)
     - [Windows](https://fast-dds.docs.eprosima.com/en/latest/installation/binaries/binaries_windows.html)
-

--- a/en/middleware/micrortps.md
+++ b/en/middleware/micrortps.md
@@ -49,7 +49,7 @@ The *Agent* and any *Fast DDS* applications are connected via UDP and may be on 
 ## Code generation
 
 ### Dependencies
-Fast DDS 2.0.0 and Fast-RTPS-Gen 1.0.4 or later must be installed in order to generate the required code, and continue to the next steps. [Follow the installation guide.](../dev_setup/fast-dds-installation.md)
+Fast DDS 2.0.0 or later and Fast-RTPS-Gen 1.0.4 (not later!) must be installed in order to generate the required code, and continue to the next steps. [Follow the installation guide.](../dev_setup/fast-dds-installation.md)
 
 :::note
 RTPS has been adopted as the middleware for the ROS 2 (Robot Operating System).

--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -58,7 +58,7 @@ To setup ROS 2 for use with PX4 you will need to:
 
 ### Install Fast DDS
 
-Follow the [Fast DDS Installation Guide](../dev_setup/fast-dds-installation.md) to install **Fast RTPS(DDS) 2.0.0** (or later) and **Fast-RTPS-Gen 1.0.4** (or later) and their dependencies.
+Follow the [Fast DDS Installation Guide](../dev_setup/fast-dds-installation.md) to install **Fast RTPS(DDS) 2.0.0** (or later) and **Fast-RTPS-Gen 1.0.4** (not later!) and their dependencies.
 
 :::note
 Check the guide to confirm the latest dependencies!
@@ -420,13 +420,13 @@ To build both ROS 2 and ROS (1) workspaces (replacing the previous steps):
    ```sh
    cd ~/px4_ros_com_ros2 && colcon build --symlink-install --packages-select ros1_bridge --cmake-force-configure --event-handlers console_direct+
    ```
-   
+
    :::note
    The build process may consume a lot of memory resources.
    On a resource limited machine, reduce the number of jobs being processed in parallel (e.g. set environment variable `MAKEFLAGS=-j1`).
    For more details on the build process, see the build instructions on the [ros1_bridge](https://github.com/ros2/ros1_bridge) package page.
    :::
-   
+
 
 ### Cleaning the workspaces
 


### PR DESCRIPTION
This is to avoid that the users/devs install later versions.

@teyrana FYI.