### PR TITLE
Clarify sub support

### DIFF
--- a/en/frames_sub/README.md
+++ b/en/frames_sub/README.md
@@ -1,6 +1,15 @@
 # Underwater Vehicles (UUV)
 
-PX4 supports a number of unmanned underwater vehicles (UUV):
+:::warning
+Support for UUVs is _experimental_. The platform does not support all features needed in a product-quality UUV, and the platform is not regularly tested by the core development team.
+
+At time of writing it has only been tested using ROS in offboard mode.
+The following features have not been implemented:
+- Modes like missions, depth hold, stabilised manual control, etc.
+- BlueRobotics gripper support.
+:::
+
+PX4 enables a number of unmanned underwater vehicle (UUV) frames:
 - [BlueROV2](../frames_sub/bluerov2.md): Vectored 6 DOF UUV
 - HippoCampus UUV: [Airframe Reference](../airframes/airframe_reference.md#underwater-robot-2), [Gazebo Simulation](../simulation/gazebo_vehicles.md#hippocampus-tuhh-uuv)
 
@@ -14,6 +23,7 @@ Other UUVs may be listed in [Airframe Reference > Underwater Robots](../airframe
 @[youtube](https://youtu.be/1sUaURmlmT8)
 
 @[youtube](https://youtu.be/xSXSoUK-iBM)
+
 
 
 

--- a/en/frames_sub/bluerov2.md
+++ b/en/frames_sub/bluerov2.md
@@ -1,7 +1,8 @@
-# BlueROV2 Platform Build
+# BlueROV2 (UUV)
 
 The [BlueROV2](https://bluerobotics.com/store/rov/bluerov2-upgrade-kits/brov2-heavy-retrofit-r1-rp/BlueROV2) is an affordable high-performance underwater vehicle that is perfect for inspections, research, and adventuring.
-PX4 supports an 8-thrust vectored configuration, known as the *BlueROV2 Heavy Configuration*.
+
+PX4 provides [experimental support](README.md) for an 8-thrust vectored configuration, known as the *BlueROV2 Heavy Configuration*.
 
 ![Hero](../../assets/airframes/sub/bluerov/bluerov_hero.jpg)
 
@@ -13,7 +14,9 @@ PX4 supports an 8-thrust vectored configuration, known as the *BlueROV2 Heavy Co
 
 ### Motor Mapping/Wiring
 
-The motors will need to be wired to the Flight controller as indicated:
+The motors must be wired to the flight controller following the standard instructions supplied by BlueRobotics for this vehicle .
+
+The vehicle will then match the configuration documented in the [Airframe Reference](../airframes/airframe_reference.md#vectored-6-dof-uuv):
 
 <img src="../../assets/airframes/types/Vectored6DofUUV.svg" width="29%" style="max-height: 180px;"/>
 
@@ -25,8 +28,6 @@ The motors will need to be wired to the Flight controller as indicated:
 - **MAIN6:** motor 6 CCW, bow port vertical, propeller CW
 - **MAIN7:** motor 7 CCW, stern starboard vertical, propeller CW
 - **MAIN8:** motor 8 CCW, stern port vertical, propeller CCW
-
-This is from [Airframe Reference > Vectored 6 DOF UUV](../airframes/airframe_reference.md#vectored-6-dof-uuv).
 
 
 ## Airframe Configuration


### PR DESCRIPTION
@DanielDuecker This is first pass at clarifying the support provided by PX4 for UUVs and more specifically by BlueRov2 and Hippocampus. Can you give it a quick look?

I have characterised it as "experimental" and said that this applies to the platform, and hence both the Bluerov and Hippocampus. Can you confirm that this is the case? I.e. that the two vehicles share the same limitations/core behaviour? If not, I can copy this into BlueRov, but would be good to understand what behaviour is enabled for Hippocampus.

Further, I can build the gazebo version using `make px4_sitl gazebo_uuv_bluerov2_heavy` but it won't let me zoom in on the vehicle so I can't get a good screenshot (trying to do this using mousewheel scroll). Can you generate a good gazebo zoomed image for me? (and if so, any idea what I might be doing wrong?