### PR TITLE
additional NuttX Backports

### DIFF
--- a/en/releases/1.12.md
+++ b/en/releases/1.12.md
@@ -114,11 +114,15 @@ The release includes new hardware support for the following boards, peripherals,
 ### NuttX
 Nuttx was upgraded from [8.2+ to NuttX 10.10.0+](https://github.com/apache/incubator-nuttx/compare/nuttx-8.2..nuttx-10.0.1) (@ [904a602c74dc08a100b5c2bd490807de19e73e10](https://github.com/apache/incubator-nuttx/commit/904a602c74dc08a100b5c2bd490807de19e73e10))
 * **SDCARD performance:** Results in better performance on H7 Targets
-* [**BACKPORT**] mmcsd:Stuck in 1-bit mode, Removed CONFIG_ARCH_HAVE_SDIO_DELAYED_INVLDT
+  * [**BACKPORT**] stm32:SDIO:Use 250 Ms Data path timeout, regardless of Card Clock frequency
+  * [**BACKPORT**] stm32h7:SDMMC:Use 250 Ms Data path timeout, regardless of Card Clock frequency
+  * [**BACKPORT**] stm32f7:SDMMC:Use 250 Ms Data path timeout, regardless of Card Clock frequency
+  * [**BACKPORT**] Fixes race condition in event wait logic of SDMMC driver.
+  * [**BACKPORT**] mmcsd:Stuck in 1-bit mode, Removed CONFIG_ARCH_HAVE_SDIO_DELAYED_INVLDT
 * **Ethernet stability:**
   * [**BACKPORT**] stm32x7:Ethernet Fixed hardfaults, from too big frames
   * [**BACKPORT**] stm32:Ethernet Fix too big frames
-* Boot up stability for V5-V6X ensuring the LSE (RTC) oscillator is started
+* **Boot up stability** V5-V6X ensuring the LSE (RTC) oscillator is started
   * [**BACKPORT**] stm32h7:lse fix Kconfig help text
   * [**BACKPORT**] stm32f7:lse Use Kconfig values directly
   * [**BACKPORT**] stm32h7:Add DBGMCU
@@ -136,7 +140,16 @@ Nuttx was upgraded from [8.2+ to NuttX 10.10.0+](https://github.com/apache/incub
       driving capability selection bits are swapped.
     :::
 
-* [**BACKPORT**] libc/stdio: Preallocate the stdin, stdout and stderr
+* **Driver changes**
+  * [**BACKPORT**] drivers/serial: fix Rx interrupt enable for cdcacm
+  * [**BACKPORT**] binnfmt:Fix return before close ELF fd
+
+  * [**BACKPORT**] stm32f7:Allow for reuse of the OTG_ID GPIO
+  * [**BACKPORT**] stm32h7: serial: use dma tx semaphore as resource holder
+  * [**BACKPORT**] stm32h7:Serial Add RX and TX DMA
+  * [**BACKPORT**] stm32h7:Allow for reuse of the OTG_ID GPIO
+
+  * [**BACKPORT**] libc/stdio: Preallocate the stdin, stdout and stderr
   For targets without consoles.
 * **FlexCan fixes**
   * [**BACKPORT**] [FlexCAN] Correct reset state for CTRL1 register


### PR DESCRIPTION
Updates the PX4 v1.12 release notes with additional NuttX backports not previously captured