### PR TITLE
cube: add note about powering servo rail

### DIFF
--- a/en/assembly/quick_start_cube.md
+++ b/en/assembly/quick_start_cube.md
@@ -64,7 +64,7 @@ Customized screws are supposed to be M2.5 with thread length inside Cube in rang
 ![Cube Mount - Mounting Plate](../../assets/flight_controller/cube/cube_mount_plate_screws.jpg)
 
 
-<span id="gps"></span>
+<a id="gps"></a>
 ## GPS + Compass + Safety Switch + LED
 
 The recommended GPS modules are the *Here* and [Here+](../gps_compass/rtk_gps_hex_hereplus.md), both of which incorporate a GPS module, Compass, Safety Switch and [LEDs](../getting_started/led_meanings.md).
@@ -88,7 +88,7 @@ To disable the safety press and hold the safety switch for 1 second. You can pre
 If you want to use an old-style 6-pin GPS module, the kit comes with a cable that you can use to connect both the GPS and [Safety Switch](#safety_switch).
 :::
 
-<span id="safety_switch"></span>
+<a id="safety_switch"></a>
 ## Safety Switch
 
 The *dedicated* safety switch that comes with the Cube is only required if you are not using the recommended [GPS](#gps) (which has an inbuilt safety switch).
@@ -104,7 +104,7 @@ This should be connected to the USB port as shown (no further configuration is r
 ![Cube Buzzer](../../assets/flight_controller/cube/cube_buzzer.jpg)
 
 
-<span id="rc_control"></span>
+<a id="rc_control"></a>
 ## Radio Control
 
 A [remote control (RC) radio system](../getting_started/rc_transmitter_receiver.md) is required if you want to *manually* control your vehicle (PX4 does not require a radio system for autonomous flight modes). 
@@ -137,16 +137,21 @@ which may be purchased from hex.aero or proficnc.com.
 ## Power
 
 Cube is typically powered from a Lithium Ion Polymer (LiPo) Battery via a Power Module (supplied with the kit) that is connected to the **POWER1** port.
-The power module provides reliable supply and voltage/current indication to the board and may separately supply power to ESCs that are used to drive motors on a multicopter vehicle. 
+The power module provides reliable supply and voltage/current indication to the board, and may *separately* supply power to ESCs that are used to drive motors on a multicopter vehicle.
 
 A typical power setup for a Multicopter vehicle is shown below.
 
 ![Power Setup - MC](../../assets/flight_controller/cube/cube_wiring_power_mc.jpg)
 
+:::Note
+The power (+) rail of **MAIN/AUX** is *not powered* by the power module supply to the flight controller.
+In order to drive servos for rudders, elevons, etc., it will need to be separately powered.
 
-<!-- HOw is the power rail powered for servos - power rail? Plane/Vtol would be cool to show here too -->
+This can be done by connecting the power rail to a BEC equipped ESC, a standalone 5V BEC, or a 2S LiPo battery.
+Ensure the voltage of servo you are going to use is appropriate!
+:::
 
-<span id="telemetry"></span>
+<a id="telemetry"></a>
 ## Telemetry System (Optional)
 
 A telemetry system allows you to communicate with, monitor, and control a vehicle in flight from a ground station (for example, you can direct the UAV to a particular position, or upload a new mission).


### PR DESCRIPTION
This note was omitted. Came up as a question on slack.