### PR TITLE
Clarify mixers set payload/rc outputs, not params

### DIFF
--- a/en/payloads/README.md
+++ b/en/payloads/README.md
@@ -29,8 +29,8 @@ PX4 supports servo and GPIO triggering via both RC and MAVLink commands.
 
 You can map up to three RC channels to control servos/actuators attached to the flight controller using the parameters [RC_MAP_AUX1](../advanced_config/parameter_reference.md#RC_MAP_AUX1) to [RC_MAP_AUX3](../advanced_config/parameter_reference.md#RC_MAP_AUX3).
 
-The RC channels are *usually* mapped to the `AUX1`, `AUX2`, `AUX3` outputs of your flight controller - _but they don't have to be_.
-You can check which outputs are used for RC AUX passthrough on your vehicle in the [Airframe Reference](../airframes/airframe_reference.html).
+The RC channels are *usually* mapped to the `AUX1`, `AUX2`, `AUX3` outputs of your flight controller (using a [mixer file](../concept/mixing.md) defined in your airfame).
+You can confirm which outputs are used for RC AUX passthrough on your vehicle in the [Airframe Reference](../airframes/airframe_reference.html).
 For example, [Quadrotor-X](../airframes/airframe_reference.md#quadrotor-x) has the normal mapping: "**AUX1:** feed-through of RC AUX1 channel", "**AUX2:** feed-through of RC AUX2 channel", "**AUX3:** feed-through of RC AUX3 channel".
 
 If your vehicle doesn't specify RC AUX feed-through outputs, then you can add them using using a custom [Mixer File](../concept/mixing.md) that maps [Control group 3](../concept/mixing.md#control-group-3-manual-passthrough) outputs 5-7 to your desired port(s).
@@ -46,12 +46,14 @@ PX4 will use the last value set through either mechanism.
 
 You can use the [MAV_CMD_DO_SET_ACTUATOR](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_ACTUATOR) MAVLink command to set (up to) three actuators values at a time, either in a mission or as a command.
 
-Command parameters `param1`, `param2`, and `param3`, are mapped to the _same outputs_ as are used for [RC triggering](#rc-triggering).
-Usually these are the `AUX1`, `AUX2`, `AUX3` outputs of your flight controller (the RC section above explains how to check).
-The other command parameters (`param4` to `param7`) are unused/ignored by PX4.
-
+Command parameters `param1`, `param2`, and `param3` are _usually_ mapped to the `AUX1`, `AUX2`, `AUX3` outputs of your flight controller, while command parameters `param4` to `param7` are unused/ignored by PX4.
 The parameters take normalised values in the range `[-1, 1]` (resulting in PWM outputs in the range `[PWM_AUX_MINx, PWM_AUX_MAXx]`, where X is the output number).
 All params/actuators that are not being controlled should be set to `NaN`.
+
+:::note
+MAVLink uses the same outputs as are configured for [RC AUX passthrough](#rc-triggering) (see prevous section).
+You can check which outputs are used in the [Airframe Reference](../airframes/airframe_reference.html) for your vehicle, and change them if needed using a [custom mixer file](../concept/mixing.md).
+:::
 
 
 ### MAVSDK (Example script)


### PR DESCRIPTION
Unambiguously states that payload outputs are usually AUX1-3, but can be changed in the mixer file.

This was already pretty clear, but because the intent of mavlink is that the mapping might be set via a parameter, I was able to confuse myself about what it was saying. That is less likely with new wording. 