### PR TITLE
PWM_ to PWM_MAIN_xxxn changes

### DIFF
--- a/en/advanced_config/esc_calibration.md
+++ b/en/advanced_config/esc_calibration.md
@@ -48,6 +48,6 @@ To calibrate the ESCs:
 
 :::note
 High-quality controllers come with a factory calibration. 
-In *theory* this means that they can be configured by just setting the [PWM_MIN](../advanced_config/parameter_reference.md#PWM_MIN) and [PWM_MAX](../advanced_config/parameter_reference.md#PWM_MAX) parameters to the values provided in the ESC technical specification. 
+In *theory* this means that they can be configured by just setting the [PWM_MAIN_MINn](../advanced_config/parameter_reference.md#PWM_MAIN_MIN) and [PWM_MAIN_MAXn](../advanced_config/parameter_reference.md#PWM_MAIN_MAX) parameters to the values provided in the ESC technical specification. 
 In practice the input range may differ even on high quality controllers, which is why calibration is recommended.
 :::

--- a/en/config_mc/pid_tuning_guide_multicopter_basic.md
+++ b/en/config_mc/pid_tuning_guide_multicopter_basic.md
@@ -42,11 +42,11 @@ Then adjust the sliders (as discussed below) to improve the tracking of the resp
 
 ## Preconditions
 
-- You are using the QGroundControl [ **daily build**](https://docs.qgroundcontrol.com/master/en/releases/daily_builds.html) (the latest tuning UI will be in the next release build after March 2021).
+- You are using the QGroundControl [**daily build**](https://docs.qgroundcontrol.com/master/en/releases/daily_builds.html) (the latest tuning UI will be in the next release build after March 2021).
 - You have selected the closest matching [default airframe configuration](../config/airframe.md) for your vehicle.
   This should give you a vehicle that already flies.
 - You should have done an [ESC calibration](../advanced_config/esc_calibration.md).
-- If using PWM output: [PWM_MIN](../advanced_config/parameter_reference.md#PWM_MIN) is set correctly.
+- If using PWM output: [PWM_MAIN_MIN](../advanced_config/parameter_reference.md#PWM_MAIN_MIN) is set correctly.
   It needs to be set low, but such that the **motors never stop** when the vehicle is armed.
 
   This can be tested in [Acro mode](../flight_modes/acro_mc.md) or in [Manual/Stabilized mode](../flight_modes/manual_stabilized_mc.md):

--- a/en/config_mc/racer_setup.md
+++ b/en/config_mc/racer_setup.md
@@ -79,7 +79,7 @@ Go through the [Basic Configuration Guide](../config/README.md).
 In particular, set the [Airframe](../config/airframe.md) that most closely matches your frame (typically you will choose the [Generic 250 Racer](../airframes/airframe_reference.md#copter_quadrotor_x_generic_250_racer) airframe, which sets some racer-specific parameters by default).
 
 These parameters are important:
-- Enable One-Shot (set [PWM_RATE](../advanced_config/parameter_reference.md#PWM_RATE) to 0) or DShot ([DSHOT_CONFIG](../advanced_config/parameter_reference.md#DSHOT_CONFIG)).
+- Enable One-Shot (set [PWM_MAIN_RATE](../advanced_config/parameter_reference.md#PWM_MAIN_RATE) to 0) or DShot ([DSHOT_CONFIG](../advanced_config/parameter_reference.md#DSHOT_CONFIG)).
 - Set the maximum roll-, pitch- and yaw rates for Manual/Stabilized mode as
   desired: [MC_ROLLRATE_MAX](../advanced_config/parameter_reference.md#MC_ROLLRATE_MAX), [MC_PITCHRATE_MAX](../advanced_config/parameter_reference.md#MC_PITCHRATE_MAX) and [MC_YAWRATE_MAX](../advanced_config/parameter_reference.md#MC_YAWRATE_MAX).
   The maximum tilt angle is configured with [MPC_MAN_TILT_MAX](../advanced_config/parameter_reference.md#MPC_MAN_TILT_MAX).
@@ -135,7 +135,7 @@ These are the factors that affect the latency:
 - PX4 software internals: the sensor signals need to be read in the driver and then pass through the controller to the output driver.
 - The IO chip (MAIN pins) adds about 5.4 ms latency compared to using the AUX pins (this does not apply to a *Pixracer* or *Omnibus F4*, but does apply to a Pixhawk).
   To avoid the IO delay, disable [SYS_USE_IO](../advanced_config/parameter_reference.md#SYS_USE_IO) and attach the motors to the AUX pins instead.
-- PWM output signal: enable One-Shot to reduce latency ([PWM_RATE](../advanced_config/parameter_reference.md#PWM_RATE)=0).
+- PWM output signal: enable One-Shot to reduce latency ([PWM_MAIN_RATE](../advanced_config/parameter_reference.md#PWM_MAIN_RATE)=0).
 
 ### Filter Tuning
 

--- a/en/flight_controller/snapdragon_flight_configuration.md
+++ b/en/flight_controller/snapdragon_flight_configuration.md
@@ -97,4 +97,4 @@ sudo reboot
 | MC_RAWRATE_P      | 0.08                        |
 | EKF2_IMU_POS_Z    | 0.030m                      |
 | EKF2_EV_POS_Z     | 0.03m                       |
-| PWM_MIN           | 1150us                      |
+| PWM_MAIN_MIN      | 1150us                      |

--- a/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.md
+++ b/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.md
@@ -259,7 +259,7 @@ The final assembly step is to check the vehicle is stable and that the motors ha
    <img src="../../assets/airframes/vtol/falcon_vertigo/falcon_vertigo_35_quad_motor_directions.png" width="200px" title="Quad motor order/directions" />
 
    :::note
-   If necessary the servo direction can be reversed using the `PWM_REV` parameters in the `PWM_OUTPUT` group of QGroundControl (cogwheel tab, last item in the left menu).
+   If necessary the servo direction can be reversed using the [PWM_MAIN_REVn](../advanced_config/parameter_reference.md#PWM_MAIN_REV1) parameters in the `PWM_OUTPUT` group of QGroundControl (cogwheel tab, last item in the left menu).
    :::
  
 1. Check the vehicle is balanced around the expected centre of gravity

--- a/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.md
+++ b/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.md
@@ -42,7 +42,7 @@ The structure is made out of aluminum booms as shown below.
 The outputs of Pixhawk should be wired like this (orientation as seen like "sitting in the plane").
 
 :::tip
-The servo direction can be reversed using the PWM\_REV parameters in the PWM_OUTPUT group of *QGroundControl* (cogwheel tab, last item in the left menu)
+The servo direction can be reversed using the [PWM_MAIN_REVn](../advanced_config/parameter_reference.md#PWM_MAIN_REV1) parameters in the PWM_OUTPUT group of *QGroundControl* (cogwheel tab, last item in the left menu).
 :::
  
 Port | Connection

--- a/en/modules/modules_command.md
+++ b/en/modules/modules_command.md
@@ -506,7 +506,7 @@ minimum value they should spin.
 Channels are assigned to a group. Due to hardware limitations, the update rate can only be set per group. Use
 `pwm status` to display the groups. If the `-c` argument is used, all channels of any included group must be included.
 
-The parameters `-p` and `-r` can be set to a parameter instead of specifying an integer: use -p p:PWM_MIN for example.
+The parameters `-p` and `-r` can be set to a parameter instead of specifying an integer: use -p p:PWM_MAIN_MIN for example.
 
 Note that in OneShot mode, the PWM range [1000, 2000] is automatically mapped to [125, 250].
 

--- a/en/peripherals/pwm_escs_and_servo.md
+++ b/en/peripherals/pwm_escs_and_servo.md
@@ -91,7 +91,7 @@ See the first section of this page explains for other power connection considera
 
 Some ESCs need to see a special low value pulse before switching on (to protect users who have the throttle stick in the middle position on power-up).
 
-PX4 sends a value of [PWM_DISARMED](../advanced_config/parameter_reference.md#PWM_DISARMED) pulse when the vehicle is disarmed, which silences the ESCs when they are disarmed and ensures that ESCs initialise correctly. 
+PX4 sends a value of [PWM_MAIN_DISARM](../advanced_config/parameter_reference.md#PWM_MAIN_DISARM) pulse when the vehicle is disarmed, which silences the ESCs when they are disarmed and ensures that ESCs initialise correctly. 
 
 This value should be set correctly for the ESC (correct values vary between roughly 1200 and 900 us). 
 
@@ -99,7 +99,7 @@ This value should be set correctly for the ESC (correct values vary between roug
 
 Some ESCs may time out (preventing motor activation) if they have not received a valid low pulse within a few seconds of power on. 
 
-PX4 flight stack sends the [PWM_DISARMED](../advanced_config/parameter_reference.md#PWM_DISARMED) pulse idle/disarmed pulse right after power on.
+PX4 flight stack sends the [PWM_MAIN_DISARM](../advanced_config/parameter_reference.md#PWM_MAIN_DISARM) pulse idle/disarmed pulse right after power on.
 Provided this is configured correctly, ESCs will not time out.
 
 ### Valid Pulse Shape, Voltage and Update Rate


### PR DESCRIPTION
PWM_MIN and friends go to PWM_MAIN_MIN. 

@bresch I'm going to merge this. But can you please sanity check. Specifically, we now have PWM_MAIN_MIN which is a default for PWM_MAIN_MIN1, etc. If you think we need to capture that case then please let me know. I have inferred it in a few places using the text `PWM_MAIN_MINn` but still linking to the default item `PWM_MAIN_MIN`