### PR TITLE
Assorted broken link fixes

### DIFF
--- a/en/advanced_features/traffic_avoidance_adsb.md
+++ b/en/advanced_features/traffic_avoidance_adsb.md
@@ -11,7 +11,7 @@ PX4 traffic avoidance works with ADS-B or FLARM products that supply transponder
 
 It has been tested with the following devices:
 - [PingRX ADS-B Receiver](https://uavionix.com/product/pingrx/) (uAvionix)
-- [FLARM](https://flarm.com/products/powerflarm/uav/)
+- [FLARM](https://flarm.com/products/powerflarm/uav/) 
 
 
 ## Hardware Setup

--- a/en/complete_vehicles/README.md
+++ b/en/complete_vehicles/README.md
@@ -24,7 +24,7 @@ You can find others on [px4.io](https://px4.io/ecosystem/commercial-systems/) an
 <!--  Whole-vehicle hardware reference platforms that use PX4: -->
 - Consumer drones run a custom version of PX4 (supported by their vendors):
   * Multicopter
-    * [Yuneec Typhoon H Plus](https://us.yuneec.com/typhoon-h-plus.html)
+    * [Yuneec Typhoon H Plus](https://us.yuneec.com/typhoon-h-plus/)
     * [Yuneec Mantis Q](https://px4.io/portfolio/yuneec-mantis-q/)
     * [Yuneec H520](https://px4.io/portfolio/yuneec-h520-hexacopter/)
     * [Airlango Mystic](http://airlango.com/products/)

--- a/en/dev_airframes/adding_a_new_frame.md
+++ b/en/dev_airframes/adding_a_new_frame.md
@@ -9,7 +9,7 @@ Adding a configuration is straightforward: create a new config file in the [init
 Developers who do not want to create their own configuration can instead customize existing configurations using text files on the microSD card, as detailed on the [custom system startup](../concept/system_startup.md) page.
 
 :::note
-To determine which parameters/values need to be set in the configuration file, you can first assign a generic airframe and tune the vehicle, and then use [`param show-for-airframe`](../modules/modules_command.html#param) to list the parameters that changed.
+To determine which parameters/values need to be set in the configuration file, you can first assign a generic airframe and tune the vehicle, and then use [`param show-for-airframe`](../modules/modules_command.md#param) to list the parameters that changed.
 :::
 
 ## Configuration File Overview

--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -89,7 +89,7 @@ brew install px4-sim-jmavsim
 jMAVSim for PX4 v1.11 and beyond we require at least JDK 15.
 
 For earlier versions macOS users might see the error `Exception in thread "main" java.lang.UnsupportedClassVersionError:`.
-You can find the fix in the [jMAVSim with SITL > Troubleshooting](../simulation/jmavsim.html#troubleshooting)).
+You can find the fix in the [jMAVSim with SITL > Troubleshooting](../simulation/jmavsim.md#troubleshooting)).
 :::
 
 ## Next Steps

--- a/en/log/flight_log_analysis.md
+++ b/en/log/flight_log_analysis.md
@@ -129,7 +129,7 @@ Key features:
 The recommended installation procedure is to use [anaconda3](https://conda.io/docs/index.html). See [px4tools github page](https://github.com/dronecrew/px4tools) for details.
 
 Key features:
-* Easy to share, users can view notebooks on Github \(e.g. [https://github.com/jgoppert/lpe-analysis/blob/master/15-09-30%20Kabir%20Log.ipynb](https://github.com/jgoppert/lpe-analysis/blob/master/15-09-30 Kabir Log.ipynb)\)
+* Easy to share, users can view notebooks on Github (e.g. [15-09-30 Kabir Log.ipynb](https://github.com/jgoppert/lpe-analysis/blob/master/15-09-30%20Kabir%20Log.ipynb))
 * Python based, cross platform, works witn anaconda 2 and anaconda3
 * iPython/ jupyter notebooks can be used to share analysis easily
 * Advanced plotting capabilities to allow detailed analysis

--- a/en/ros/offboard_control.md
+++ b/en/ros/offboard_control.md
@@ -59,7 +59,7 @@ Small low power examples:
 Larger high power examples:
 * [Intel NUC](http://www.intel.com/content/www/us/en/nuc/overview.html)
 * [Gigabyte Brix](http://www.gigabyte.com/products/list.aspx?s=47&ck=104)
-* [Nvidia Jetson TK1](https://developer.nvidia.com/jetson-tk1)
+* [Nvidia Jetson TK1](https://developer.nvidia.com/jetson-tk1) 
 
 [![Mermaid diagram: Companion mavlink](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggVEQ7XG4gIGNvbXBbQ29tcGFuaW9uIENvbXB1dGVyXSAtLU1BVkxpbmstLT4gdWFydFtVQVJUIEFkYXB0ZXJdO1xuICB1YXJ0IC0tTUFWTGluay0tPiBBdXRvcGlsb3Q7IiwibWVybWFpZCI6eyJ0aGVtZSI6ImRlZmF1bHQifSwidXBkYXRlRWRpdG9yIjpmYWxzZX0)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggVEQ7XG4gIGNvbXBbQ29tcGFuaW9uIENvbXB1dGVyXSAtLU1BVkxpbmstLT4gdWFydFtVQVJUIEFkYXB0ZXJdO1xuICB1YXJ0IC0tTUFWTGluay0tPiBBdXRvcGlsb3Q7IiwibWVybWFpZCI6eyJ0aGVtZSI6ImRlZmF1bHQifSwidXBkYXRlRWRpdG9yIjpmYWxzZX0)
 

--- a/en/sensor/airspeed.md
+++ b/en/sensor/airspeed.md
@@ -11,11 +11,10 @@ For fixed-wing flight it is the airspeed that guarantees lift not ground speed!
 
 Recommended digital airspeed sensors include:
 * MEAS Spec series (e.g. [MS4525DO](https://www.te.com/usa-en/product-CAT-BLPS0002.html))
-  * [mRo I2C Airspeed Sensor JST-GH MS4525DO](https://store.mrobotics.io/mRo-I2C-Airspeed-Sensor-JST-GH-p/mro-classy-arspd-mr.htm) (mRo store)
+  * [mRo I2C Airspeed Sensor JST-GH MS4525DO](https://store.mrobotics.io/mRo-I2C-Airspeed-Sensor-JST-GH-p/m10030a.htm) (mRo store)
   * [Digital Differential Airspeed Sensor Kit](https://store-drotek.com/793-digital-differential-airspeed-sensor-kit-.html) (Drotek).
   
 * [EagleTree Airspeed MicroSensor V3](http://www.eagletreesystems.com/index.php?route=product/product&product_id=63) (eagletreesystems)
-* [mRo Next-Gen MS5525 Airspeed Sensor](https://store.mrobotics.io/mRo-Next-Gen-MS5525-Airspeed-Sensor-NEW-p/mro-ms5525v2-mr.htm)
 * [Sensirion SDP3X Differential Pressure Sensor](https://www.sensirion.com/en/flow-sensors/differential-pressure-sensors/worlds-smallest-differential-pressure-sensor/)
 * [Holybro Digital Air Speed Sensor](https://shop.holybro.com/digital-air-speed-sensor_p1029.html)
 

--- a/en/sensor/leddar_one.md
+++ b/en/sensor/leddar_one.md
@@ -1,6 +1,6 @@
 # LeddarOne Lidar
 
-[LeddarOne](https://leddartech.com/modules/leddarone/) is small Lidar module with a narrow, yet diffuse beam that offers excellent overall detection range and performance, in a robust, reliable, cost-effective package. 
+[LeddarOne](https://leddartech.com/solutions/leddarone/) is small Lidar module with a narrow, yet diffuse beam that offers excellent overall detection range and performance, in a robust, reliable, cost-effective package. 
 It has a sensing range from 1cm to 40m and needs to be connected to a UART/serial bus.
 
 <img src="../../assets/hardware/sensors/leddar_one.jpg" alt="LeddarOne Lidar rangefinder" width="200px" />

--- a/en/sensor/sfxx_lidar.md
+++ b/en/sensor/sfxx_lidar.md
@@ -14,8 +14,8 @@ The following models are supported by PX4, and can be connected to either the I2
 Model | Range (m) | Bus | Description
 --- | --- | --- | ---
 [SF11/C](https://lightware.co.za/collections/lidar-rangefinders/products/sf11-c-120-m) | 120 | Serial or I2C bus | 
-[LW20/B](https://lightware.co.za/products/lw20-b-50-m) | 50 | I2C bus | Waterproofed (IP67) with servo for sense-and-avoid applications
 [LW20/C](https://lightware.co.za/products/lw20-c-100-m) | 100 | I2C bus | Waterproofed (IP67) with servo for sense-and-avoid applications
+
 
 ### Discontinued
 
@@ -27,6 +27,7 @@ Model | Range | Bus
 [SF10/A](http://documents.lightware.co.za/SF10%20-%20Laser%20Altimeter%20Manual%20-%20Rev%206.pdf) | 25 | Serial or I2C
 [SF10/B](http://documents.lightware.co.za/SF10%20-%20Laser%20Altimeter%20Manual%20-%20Rev%206.pdf) | 50 | Serial or I2C
 SF10/C | 100m | Serial or I2C
+LW20/B | 50 | I2C bus | Waterproofed (IP67) with servo for sense-and-avoid applications
 
 
 ## I2C Setup
@@ -54,7 +55,7 @@ On Linux systems you may be able to determine the address using [i2cdetect](http
 If the I2C address is equal to `0x66` the sensor can be used with PX4.
 :::
 
-<span id="i2c_parameter_setup"></span>
+<a id="i2c_parameter_setup"></a>
 ### Parameter Setup
 
 Set the [SENS_EN_SF1XX](../advanced_config/parameter_reference.md#SENS_EN_SF1XX) parameter to match the rangefinder model and then reboot.
@@ -62,7 +63,7 @@ Set the [SENS_EN_SF1XX](../advanced_config/parameter_reference.md#SENS_EN_SF1XX)
 
 ## Serial Setup
 
-<span id="serial_hardware_setup"></span>
+<a id="serial_hardware_setup"></a>
 ### Hardware
 
 The lidar can be connected to any unused *serial port* (UART), e.g.: TELEM2, TELEM3, GPS2 etc.

--- a/en/sensor/teraranger.md
+++ b/en/sensor/teraranger.md
@@ -4,12 +4,12 @@ TeraRanger provide a number of lightweight distance measurement sensor based on 
 They are typically faster and have greater range than sonar, and smaller and lighter than laser-based systems.
 
 PX4 supports:
-* [TeraRanger One](https://www.terabee.com/shop/lidar-tof-range-finders/teraranger-one/) (0.2 - 14 m) (Requires an [I2C adapter](https://www.terabee.com/shop/accessories/i2c-adapter-for-teraranger-one/))
 * [TeraRanger Evo 60m](https://www.terabee.com/shop/lidar-tof-range-finders/teraranger-evo-60m/) (0.5 – 60 m)
 * [TeraRanger Evo 600Hz](https://www.terabee.com/shop/lidar-tof-range-finders/teraranger-evo-600hz/) (0.75 - 8 m)
 
 :::note
-The *Terranger One* is used in the [Qualcomm Snapdragon Flight](../flight_controller/snapdragon_flight.md).
+PX4 also supports *TeraRanger One* (I2C adapter required).
+This has been discontinued.
 :::
 
 ## Where to Buy
@@ -19,12 +19,9 @@ The *Terranger One* is used in the [Qualcomm Snapdragon Flight](../flight_contro
 ## Pinouts
 
 
-
 ## Wiring
 
 All TeraRanger sensors must be connected via the I2C bus.
-
-While TeraRanger One requires an [I2C adapter](https://www.terabee.com/shop/accessories/i2c-adapter-for-teraranger-one/) any sensor from TeraRanger Evo series can be connected directly to the autopilot.
 
 
 ## Software Configuration

--- a/en/simulation/airsim.md
+++ b/en/simulation/airsim.md
@@ -8,7 +8,7 @@ It provides physically and visually realistic simulations of Pixhawk/PX4 using e
 
 ## PX4 Setup
 
-[PX4 Setup for AirSim](https://microsoft.github.io/AirSim/px4_setup/) describes how to use PX4 with AirSim using both [SITL](https://microsoft.github.io/AirSim/px4_sitl/) and [HITL](https://microsoft.github.io/AirSim/px4_setup/#setting-up-px4-hardware-in-loop).
+[PX4 Setup for AirSim](https://microsoft.github.io/AirSim/px4_setup.html) describes how to use PX4 with AirSim using both [SITL](https://microsoft.github.io/AirSim/px4_sitl.html) and [HITL](https://microsoft.github.io/AirSim/px4_setup.html#setting-up-px4-hardware-in-loop).
 
 
 ## Videos

--- a/en/simulation/flightgear_vehicles.md
+++ b/en/simulation/flightgear_vehicles.md
@@ -63,7 +63,7 @@ Otherwise, the FlightGear crashes because of an unexpected definition of electri
 Rascal JSBsim variant.
 
 This variant does not have a direct `make` option but can be manually selected in the **rascal.json** configuration file (part of [PX4-FlightGear-Bridge](https://github.com/ThunderFly-aerospace/PX4-FlightGear-Bridge)).
-Simply change `Rascal110-YASim` to `Rascal110-JSBSim` in [this file](https://github.com/ThunderFly-aerospace/PX4-FlightGear-Bridge/blob/master/rascal.json#L2).
+Simply change `Rascal110-YASim` to `Rascal110-JSBSim` in [this file](https://github.com/ThunderFly-aerospace/PX4-FlightGear-Bridge/blob/master/models/rascal.json#L2).
 
 <a id="autogyro"></a>
 ## Autogyro

--- a/en/simulation/gazebo.md
+++ b/en/simulation/gazebo.md
@@ -340,7 +340,7 @@ The camera also supports/responds to the following MAVLink commands: [MAV_CMD_RE
 :::
 
 :::note
-The simulated camera is implemented in [PX4/sitl_gazebo/src/gazebo_geotagged_images_plugin.cpp](https://github.com/PX4/sitl_gazebo/blob/master/src/gazebo_geotagged_images_plugin.cpp).
+The simulated camera is implemented in [PX4/sitl_gazebo/src/gazebo_geotagged_images_plugin.cpp](https://github.com/PX4/sitl_gazebo/blob/master/src/gazebo_geotagged_images_plugin.cpp). 
 :::
 
 <a id="flight_termination"></a>

--- a/en/simulation/multi_vehicle_flightgear.md
+++ b/en/simulation/multi_vehicle_flightgear.md
@@ -40,7 +40,7 @@ Ground stations such as *QGroundControl* connect to all instances using the norm
 
 The number of simultaneously running instances is limited mainly by computer resources.
 FlightGear is a single-thread application, but aerodynamics solvers consume a lot of memory.
-Therefore splitting to multiple computers and using a [multiplayer server](http://wiki.flightgear.org/index.php?title=Howto:Multiplayer) is probably required to run *many* vehicle instances.
+Therefore splitting to multiple computers and using a [multiplayer server](https://wiki.flightgear.org/Howto:Multiplayer) is probably required to run *many* vehicle instances.
 
 ## Additional Resources
 

--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -273,7 +273,7 @@ To add a new vehicle, you need to make sure the model can be found (in order to 
 
 1. The `vehicle` argument is used to set the `PX4_SIM_MODEL` environment variable, which is used by the default rcS (startup script) to find the corresponding startup settings file for the model.
   Within PX4 these startup files can be found in the **PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/** directory.
-  For example, here is the plane model's [startup script](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/1030_plane).
+  For example, here is the plane model's [startup script](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane).
   For this to work, the PX4 node in the launch file is passed arguments that specify the *rcS* file (**etc/init.d/rcS**) and the location of the rootfs etc directory (`$(find px4)/build_px4_sitl_default/etc`).
   For simplicity, it is suggested that the startup file for the model be placed alongside PX4's in **PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/**.
 


### PR DESCRIPTION
I keep finding new broken links, by finding better link checker tools. 

FYI me, 
- These were found using https://github.com/tcort/markdown-link-check
- BLC linkcheck (installed via `npm install broken-link-checker -g`) is OK but exclude globs don't appear to work (`blc https://docs.px4.io -rofi --exclude /v1.11 --exclude /v1.10 --exclude /v1.9 --exclude /master/zh --exclude /master/ko --filter-level 3 >blc_linkcheck.log`. Also missing many cases found by markdownlink check.)
- https://github.com/filiph/linkcheck  - installed via dart - works OK using `linkcheck https://docs.px4.io/master/en/ >linkcheck_linklog.txt -i` and `-e`

