### PR TITLE
Update cuav_v5.md

### DIFF
--- a/en/flight_controller/cuav_v5.md
+++ b/en/flight_controller/cuav_v5.md
@@ -11,7 +11,7 @@ This flight controller has been [discontinued](../flight_controller/autopilot_ex
 
 *CUAV v5*<sup>&reg;</sup> (previously "Pixhack v5") is an advanced autopilot designed and made by CUAV<sup>&reg;</sup>. 
 The board is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv5** open hardware design. 
-It runs PX4 on the [NuttX](http://nuttx.org) OS, and is fully compatible with PX4 firmware. 
+It runs PX4 on the [NuttX](https://nuttx.apache.org/) OS, and is fully compatible with PX4 firmware. 
 It is intended primarily for academic and commercial developers.
 
 ![CUAV v5](../../assets/flight_controller/cuav_v5/pixhack_v5.jpg)


### PR DESCRIPTION
Change Nuttx to the correct url: https://nuttx.apache.org/

This url is indeed in many pages in the documentation, and if this was really a wrong url in the documentation, is there an easy way to change all the urls instead of manually changing them?