### PR TITLE
Fix nuttx links

### DIFF
--- a/en/concept/architecture.md
+++ b/en/concept/architecture.md
@@ -144,7 +144,7 @@ independent_task = px4_task_spawn_cmd(
 
 #### NuttX
 
-[NuttX](http://nuttx.org/) is the primary RTOS for running PX4 on a flight-control board.
+[NuttX](https://nuttx.apache.org//) is the primary RTOS for running PX4 on a flight-control board.
 It is open source (BSD license), light-weight, efficient and very stable.
 
 Modules are executed as tasks: they have their own file descriptor lists, but they share a single address space.

--- a/en/flight_controller/auav_x2.md
+++ b/en/flight_controller/auav_x2.md
@@ -9,7 +9,7 @@ Contact the [manufacturer](https://store.mrobotics.io/) for hardware support or 
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-The [AUAV<sup>&reg;</sup>](http://www.auav.com/) *AUAV-X2 autopilot* is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design. It runs PX4 on the [NuttX](http://nuttx.org) OS.
+The [AUAV<sup>&reg;</sup>](http://www.auav.com/) *AUAV-X2 autopilot* is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design. It runs PX4 on the [NuttX](https://nuttx.apache.org/) OS.
 
 ![AUAVX2_case2](../../assets/flight_controller/auav_x2/auavx2_case2.jpg)
 

--- a/en/flight_controller/dropix.md
+++ b/en/flight_controller/dropix.md
@@ -5,7 +5,7 @@ PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.drotek.com/) for hardware support or compliance issues.
 :::
 
-The Drotek<sup>&reg;</sup> *DroPix autopilot* is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design. It runs the PX4 Flight Stack on the [NuttX](http://nuttx.org) OS.
+The Drotek<sup>&reg;</sup> *DroPix autopilot* is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design. It runs the PX4 Flight Stack on the [NuttX](https://nuttx.apache.org/) OS.
 
 The DroPix system includes integrated multithreading, a Unix/Linux-like programming environment, completely new autopilot functions such as Lua scripting of missions and flight behavior, and a custom PX4 driver layer ensuring tight timing across all processes.
 

--- a/en/flight_controller/holybro_pix32.md
+++ b/en/flight_controller/holybro_pix32.md
@@ -7,7 +7,7 @@ Contact the [manufacturer](https://shop.holybro.com/) for hardware support or co
 
 The Holybro<sup>&reg;</sup> [pix32 autopilot](https://shop.holybro.com/c/pixhawk-2_0460) (also known as "Pixhawk 2", and formerly as HKPilot32) is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design.
 This board is based on hardware version Pixhawk 2.4.6.
-It runs the PX4 flight stack on the [NuttX](http://nuttx.org) OS.
+It runs the PX4 flight stack on the [NuttX](https://nuttx.apache.org/) OS.
 
 ![pix32](../../assets/flight_controller/holybro_pix32/pix32_hero.jpg)
 

--- a/en/flight_controller/holybro_pix32_v5.md
+++ b/en/flight_controller/holybro_pix32_v5.md
@@ -7,7 +7,7 @@ Contact the [manufacturer](https://shop.holybro.com/) for hardware support or co
 
 [Pix32 v5](https://shop.holybro.com/pix32-v5_p1218.html)<sup>&reg;</sup> is an advanced autopilot flight controller designed and made by Holybro<sup>&reg;</sup>.
 It is optimized to run on PX4 firmware, which is intended for both academic and commercial developers.
-It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv5** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.
+It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv5** open hardware design and runs PX4 on the [NuttX](https://nuttx.apache.org/) OS.
 It can be regarded as a variant version of Pixhawk4.
 
 The Pix32 v5 is designed for pilots who need a high power, flexible and customisable flight control system.

--- a/en/flight_controller/mro_pixhawk.md
+++ b/en/flight_controller/mro_pixhawk.md
@@ -5,7 +5,7 @@ PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.mrobotics.io/) for hardware support or compliance issues.
 :::
 
-The *mRo Pixhawk<sup>&reg;</sup>* is a hardware compatible version of the original [Pixhawk 1](../flight_controller/pixhawk.md).  It runs PX4 on the [NuttX](http://nuttx.org) OS. 
+The *mRo Pixhawk<sup>&reg;</sup>* is a hardware compatible version of the original [Pixhawk 1](../flight_controller/pixhawk.md).  It runs PX4 on the [NuttX](https://nuttx.apache.org/) OS. 
 
 :::tip
 The controller can be used as a drop-in replacement for the 3DR<sup>&reg;</sup> [Pixhawk 1](../flight_controller/pixhawk.md).

--- a/en/flight_controller/mro_x2.1.md
+++ b/en/flight_controller/mro_x2.1.md
@@ -5,7 +5,7 @@ PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.mrobotics.io/) for hardware support or compliance issues.
 :::
 
-The [mRo-X2.1 autopilot](http://www.mRobotics.io/) is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design. It runs PX4 on the [NuttX](http://nuttx.org) OS.
+The [mRo-X2.1 autopilot](http://www.mRobotics.io/) is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design. It runs PX4 on the [NuttX](https://nuttx.apache.org/) OS.
 
 ![mRo X2.1](../../assets/flight_controller/mro/mro_x2.1.jpg)
 

--- a/en/flight_controller/pixhack_v3.md
+++ b/en/flight_controller/pixhack_v3.md
@@ -8,7 +8,7 @@ Contact the [manufacturer](https://store.cuav.net/) for hardware support or comp
 The CUAV *Pixhack V3* flight controller board is a flexible autopilot intended primarily for manufacturers of commercial systems.
 
 The board is a variant of the SOLO Pixhawk<sup>&reg;</sup> 2 (PH2) flight controller, which is in turn based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design.
-It runs PX4 on the [NuttX](http://nuttx.org) OS, and is fully compatible with both PX4 or ArduPilot<sup>&reg;</sup> (APM) firmware.
+It runs PX4 on the [NuttX](https://nuttx.apache.org/) OS, and is fully compatible with both PX4 or ArduPilot<sup>&reg;</sup> (APM) firmware.
 
 *Pixhack V3* has significant improvements with respect to the original design, including better interface layout and the addition of vibration damping and a thermostat system.
 

--- a/en/flight_controller/pixhawk-2.md
+++ b/en/flight_controller/pixhawk-2.md
@@ -12,7 +12,7 @@ This flight controller is not following the standard and uses a patented connect
 :::
 
 The [Hex Cube Black](http://www.proficnc.com/61-system-kits2) flight controller (previously known as Pixhawk 2.1) is a flexible autopilot intended primarily for manufacturers of commercial systems. 
-It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.
+It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design and runs PX4 on the [NuttX](https://nuttx.apache.org/) OS.
 
 ![Cube Black](../../assets/flight_controller/cube/cube_black_hero.png)
 

--- a/en/flight_controller/pixhawk.md
+++ b/en/flight_controller/pixhawk.md
@@ -11,7 +11,7 @@ You can use the [mRo Pixhawk](../flight_controller/mro_pixhawk.md) as a drop-in 
 :::
 
 The *3DR Pixhawk<sup>&reg;</sup> 1* autopilot is a popular general purpose flight controller based on the [Pixhawk-project](https://pixhawk.org/) **FMUv2** open hardware design (it combines the functionality of the PX4FMU + PX4IO). 
-It runs PX4 on the [NuttX](http://nuttx.org) OS.
+It runs PX4 on the [NuttX](https://nuttx.apache.org/) OS.
 
 
 ![Pixhawk Image](../../assets/hardware/hardware-pixhawk.png)

--- a/en/flight_controller/pixhawk4.md
+++ b/en/flight_controller/pixhawk4.md
@@ -8,7 +8,7 @@ Contact the [manufacturer](https://shop.holybro.com/) for hardware support or co
 *Pixhawk 4*<sup>&reg;</sup> is an advanced autopilot designed and made in collaboration with Holybro<sup>&reg;</sup> and the PX4 team.
 It is optimized to run PX4 v1.7 and later, and is suitable for academic and commercial developers.
 
-It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv5** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.
+It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv5** open hardware design and runs PX4 on the [NuttX](https://nuttx.apache.org/) OS.
 
 <img src="../../assets/flight_controller/pixhawk4/pixhawk4_hero_upright.jpg" width="200px" title="Pixhawk4 Upright Image" /> <img src="../../assets/flight_controller/pixhawk4/pixhawk4_logo_view.jpg" width="420px" title="Pixhawk4 Image" />
 

--- a/en/flight_controller/pixhawk_series.md
+++ b/en/flight_controller/pixhawk_series.md
@@ -2,7 +2,7 @@
 
 [Pixhawk<sup>&reg;</sup>](https://pixhawk.org/) is an independent open-hardware project providing readily-available, low-cost, and high-end, *autopilot hardware designs* to the academic, hobby and industrial communities.
 
-Pixhawk is the reference hardware platform for PX4, and runs PX4 on the [NuttX](http://nuttx.org) OS.
+Pixhawk is the reference hardware platform for PX4, and runs PX4 on the [NuttX](https://nuttx.apache.org/) OS.
 
 Manufacturers have created many different boards based on the open designs, with form factors that are optimised for applications from cargo carrying though to first person view (FPV) racers.
 


### PR DESCRIPTION
All nuttx links in English translation go to right place (crowdin will automatically fix the translations).

Follows on from #1343