### PR TITLE
Separate out Failure Injection

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -346,7 +346,7 @@
     * [SWD/JLink Debug Interface](debug/swd_debug.md)
     * [Autopilot Debugging](debug/gdb_debugging.md)
     * [Eclipse/JLink Hardware Debugging](debug/eclipse_jlink.md)
-	* [Failure Injection](debug/failure_injection.md)
+    * [Failure Injection](debug/failure_injection.md)
     * [Sensor/Topic Debugging](debug/sensor_uorb_topic_debugging.md)
     * [Simulation Debugging](debug/simulation_debugging.md)
     * [Sending Debug Values](debug/debug_values.md)

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -346,6 +346,7 @@
     * [SWD/JLink Debug Interface](debug/swd_debug.md)
     * [Autopilot Debugging](debug/gdb_debugging.md)
     * [Eclipse/JLink Hardware Debugging](debug/eclipse_jlink.md)
+	* [Failure Injection](debug/failure_injection.md)
     * [Sensor/Topic Debugging](debug/sensor_uorb_topic_debugging.md)
     * [Simulation Debugging](debug/simulation_debugging.md)
     * [Sending Debug Values](debug/debug_values.md)

--- a/en/debug/failure_injection.md
+++ b/en/debug/failure_injection.md
@@ -1,0 +1,49 @@
+# System Failure Injection
+
+System failure injection allows you to cause different types of sensor and system failures using the [MAVLink shell](../debug/mavlink_shell.md#mavlink-shell) or other PX4 console.
+This enables easier testing of [safety failsafe](../config/safety.md#safety-configuration-failsafes) behaviour, and more generally, of how PX4 behaves when systems and sensors stop working correctly.
+
+Failure injection is disabled by default, and can be enabled using the [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN) parameter.
+Failures are then injected using the [failure](../modules/modules_command.md#failure) system command, specifying both the target and type of the failure.
+
+:::warning
+Failure injection still in development.
+At time of writing (PX4 v1.12):
+- It can only be used in simulation (support for both failure injection in real flight is planned).
+- Many failure types are not broadly implemented. In those cases the command will return with an "unsupported" message.
+:::
+
+## Syntax 
+
+The full syntax of the [failure](../modules/modules_command.md#failure) command is:
+```
+failure <component> <failure_type> [-i <instance_number>]
+```
+where:
+- _component_: `gyro` | `accel` | `mag` | `baro` | `gps` | `optical_flow` | `vio` | `distance_sensor` | `airspeed` | `battery` | `motor` | `servo` | `avoidance` | `rc_signal` | `mavlink_signal`
+- _failure_type_: 
+  - `ok`: Publish as normal (Disable failure injection).
+  - `off`: Stop publishing.
+  - `stuck`: Report same value every time (_could_ indicate a malfunctioning sensor).
+  - `garbage`: Publish random noise. This looks like reading uninitialized memory.
+  - `wrong`: Publish invalid values (that still look reasonable/aren't "garbage").
+  - `slow`: Publish at a reduced rate.
+  - `delayed`: Publish valid data with a significant delay.
+  - `intermittent`: Publish intermittently. 
+- _instance number_ (optional): Instance number of affected sensor.
+   0 (default) indicates all sensors of specified type.  
+
+   
+## Example
+
+To simulate losing RC signal without having to turn off your RC controller:
+
+1. Enable the parameter [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN).
+1. Enter the following commands on the MAVLink console or SITL *pxh shell*:
+   ```bash
+   # Fail RC (turn publishing off)
+   failure rc_signal off
+   
+   # Restart RC publishing
+   failure rc_signal ok
+   ```

--- a/en/simulation/failsafes.md
+++ b/en/simulation/failsafes.md
@@ -50,9 +50,12 @@ By changing [SIM_BAT_MIN_PCT](../advanced_config/parameter_reference.md#SIM_BAT_
 
 ## Sensor/System Failure
 
-System failure injection can be used to simulate different types of failures in many sensors and systems (e.g. GPS, barometer, gyro, avoidance etc.):
+[Failure injection](../debug/failure_injection.md) can be used to simulate different types of failures in many sensors and systems.
+For example, this can be used to simulate absent or intermittent GPS, RC signal that has stopped or got stuck on a particular value, failure of the avoidance system, and much more.
+
+For example, to simulate GPS failure:
 1. Enable the parameter [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN).
-1. For example, to simulate losing and regaining GPS you might enter the following commands on the SITL instance *pxh shell* (or MAVLink console).
+1. Enter the following commands on the SITL instance *pxh shell*:
    ```bash
    # Turn (all) GPS off
    failure gps off
@@ -61,12 +64,4 @@ System failure injection can be used to simulate different types of failures in 
    failure gps ok
    ```
 
-The full syntax of the [failure](../modules/modules_command.md#failure) command is:
-```
-failure <component> <failure_type> [-i <instance_number>]
-```
-where:
-- _component_: `gyro` | `accel` | `mag` | `baro` | `gps` | `optical_flow` | `vio` | `distance_sensor` | `airspeed` | `battery` | `motor` | `servo` | `avoidance` | `rc_signal` | `mavlink_signal`
-- _failure_type_: `ok` | `off` | `stuck` | `garbage` | `wrong` | `slow` | `delayed` | `intermittent`
-- _instance number_ (optional): Instance number of affected sensor.
-   0 (default) indicates all sensors of specified type.   
+See [System Failure Injection](../debug/failure_injection.md) for a list of supported target sensors and failure modes.


### PR DESCRIPTION
This allows it to be evolved separately of simulation topics, which makes sense as it is intended to be supported on real hardware/flight eventually.

@julianoes I will merge this, but would appreciate your sanity check. 