### PR TITLE
Improve broadcasting descriptions 

### DIFF
--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -269,15 +269,6 @@ Instead it routes traffic internally - to "localhost".
 
 There are a number of ways to make the UDP packets available on external interfaces, as outlined below.
 
-
-### Enable MAV_BROADCAST
-
-Enable UDP broadcast of heartbeats on the local network by calling the [mavlink](../modules/modules_communication.md#mavlink) with the `-p` flag.
-This should be done in an appropriate configuration file where `mavlink start` is called. For example: [/ROMFS/px4fmu_common/init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS).
-
-A remote computer can then connect to the simulator by listening to the appropriate port (i.e. 14550 for *QGroundControl*).
-
-
 ### Use MAVLink Router
 
 The [mavlink-router](https://github.com/intel/mavlink-router) can be used to route packets from localhost to an external interface.
@@ -305,10 +296,24 @@ To route packets between SITL running on one computer (sending MAVLink traffic t
 More information about *mavlink-router* configuration can be found [here](https://github.com/intel/mavlink-router/#running).
 :::
 
+### Enable Broadcasting
 
-### Modify Configuration for External Broadcasting
+The [mavlink module](../modules/modules_communication.md#mavlink_usage) routes to *localhost* by default, but you enable UDP broadcasting of heartbeats using its `-p` option.
+Any remote computer on the network can then connect to the simulator by listening to the appropriate port (i.e. 14550 for *QGroundControl*).
 
-The [mavlink](../modules/modules_communication.md#mavlink_usage) module routes to *localhost* by default, but you can specify an external IP address to broadcast to using its `-t` option.
+:::note
+UDP broadcasting provides a simple way to set up the connection when there is only one simulation running on the network.
+Do not use this approach if there are multiple simulations running on the network (you might instead [publish to a specific computer](#enable-external-publishing)).
+:::
+
+This should be done in an appropriate configuration file where `mavlink start` is called.
+For example: [/ROMFS/px4fmu_common/init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS).
+
+
+### Enable External Publishing
+
+The [mavlink module](../modules/modules_communication.md#mavlink_usage) routes to *localhost* by default, but you can specify an external IP address to broadcast to using its `-t` option.
+The specified remote computer can then connect to the simulator by listening to the appropriate port (i.e. 14550 for *QGroundControl*).
 
 This should be done in various configuration files where `mavlink start` is called.
 For example: [/ROMFS/px4fmu_common/init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS).

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -296,21 +296,21 @@ To route packets between SITL running on one computer (sending MAVLink traffic t
 More information about *mavlink-router* configuration can be found [here](https://github.com/intel/mavlink-router/#running).
 :::
 
-### Enable Broadcasting
+### Enable UDP Broadcasting
 
 The [mavlink module](../modules/modules_communication.md#mavlink_usage) routes to *localhost* by default, but you enable UDP broadcasting of heartbeats using its `-p` option.
 Any remote computer on the network can then connect to the simulator by listening to the appropriate port (i.e. 14550 for *QGroundControl*).
 
 :::note
 UDP broadcasting provides a simple way to set up the connection when there is only one simulation running on the network.
-Do not use this approach if there are multiple simulations running on the network (you might instead [publish to a specific computer](#enable-external-publishing)).
+Do not use this approach if there are multiple simulations running on the network (you might instead [publish to a specific computer](#enable-broadcast-to-specific-address)).
 :::
 
 This should be done in an appropriate configuration file where `mavlink start` is called.
 For example: [/ROMFS/px4fmu_common/init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS).
 
 
-### Enable External Publishing
+### Enable Broadcast to Specific Address
 
 The [mavlink module](../modules/modules_communication.md#mavlink_usage) routes to *localhost* by default, but you can specify an external IP address to broadcast to using its `-t` option.
 The specified remote computer can then connect to the simulator by listening to the appropriate port (i.e. 14550 for *QGroundControl*).


### PR DESCRIPTION
This fixes the headings and descriptions of the mav broadcasting section of simulation doc. Essentially it makes things more clear about when to use UDP broadcasting vs broadcast to a specific external computer. 

@bkueng I will publish, but a sanity check would be nice.