### PR TITLE
Communicating with individual vehicles using ROS2

### DIFF
--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -97,7 +97,9 @@ To build an example setup, follow the steps below:
    micrortps_agent -t UDP -r 2024 -s 2023 &
    micrortps_agent -t UDP -r 2026 -s 2025 &
    ```
-
+   :::note
+   In order to communicate with the different instances of PX4 individually using ROS2, you can use the `-n <namespace>` option. E.g. running `micrortps_agent -t UDP -r 2020 -s 2019 -n vhcl0` will result in the agent publishing all its topics with the namespace prefix `/vhcl0`. You can then subscribe and publish to each vehicles topics individually.
+   :::
 
 <a id="with_ros"></a>
 ## Multiple Vehicles with ROS and Gazebo

--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -98,7 +98,9 @@ To build an example setup, follow the steps below:
    micrortps_agent -t UDP -r 2026 -s 2025 &
    ```
    :::note
-   In order to communicate with the different instances of PX4 individually using ROS2, you can use the `-n <namespace>` option. E.g. running `micrortps_agent -t UDP -r 2020 -s 2019 -n vhcl0` will result in the agent publishing all its topics with the namespace prefix `/vhcl0`. You can then subscribe and publish to each vehicles topics individually.
+   In order to communicate with the different instances of PX4 individually using ROS2, you can use the `-n <namespace>` option.
+   For example, running `micrortps_agent -t UDP -r 2020 -s 2019 -n vhcl0` will result in the agent publishing all its topics with the namespace prefix `/vhcl0`.
+   You can then subscribe and publish to each vehicle's topics individually.
    :::
 
 <a id="with_ros"></a>


### PR DESCRIPTION
I added a note on how to publish and subscribe to the topics of a specific instance of PX4 using ROS2. I found the explanation in [this answer](https://discuss.px4.io/t/how-to-isolate-topics-of-different-urtps-agent-if-i-have-multiplel-instance/21576/2) by @TSC21 and thought it might be easier to find for others in the docs.