### PR TITLE
Fix link for typhoon_h480 range finder

### DIFF
--- a/de/sensor/rangefinders.md
+++ b/de/sensor/rangefinders.md
@@ -140,7 +140,7 @@ If you need to use a different vehicle you can include the model in its configur
           </axis>
         </joint>
 
-- [typhoon_h480.sdf](https://github.com/PX4/sitl_gazebo/blob/master/models/typhoon_h480/typhoon_h480.sdf#L1144) 
+- [typhoon_h480.sdf](https://github.com/PX4/PX4-SITL_gazebo/blob/master/models/typhoon_h480/typhoon_h480.sdf.jinja#L1131-L1145) 
         xml
         <include>
           <uri>model://sonar</uri>


### PR DESCRIPTION
**Problem Description**
This fixes the link for the `typhoon_h480` range finder