### PR TITLE
Clarified rate requirements for external vision fusion

### DIFF
--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -35,7 +35,8 @@ EFK2 is the default estimator used by PX4.
 It is better tested and supported than LPE, and should be used by preference.
 :::
 
-The messages should be streamed at between 30Hz (if containing covariances) and 50 Hz.
+The messages should be streamed at between 30Hz (if containing covariances) and 50 Hz. If the message rate is too slow,
+EKF2 will not fuse the external vision messages.
 
 The following MAVLink "vision" messages are not currently supported by PX4:
 [GLOBAL_VISION_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#GLOBAL_VISION_POSITION_ESTIMATE),

--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -35,8 +35,8 @@ EFK2 is the default estimator used by PX4.
 It is better tested and supported than LPE, and should be used by preference.
 :::
 
-The messages should be streamed at between 30Hz (if containing covariances) and 50 Hz. If the message rate is too slow,
-EKF2 will not fuse the external vision messages.
+The messages should be streamed at between 30Hz (if containing covariances) and 50 Hz.
+If the message rate is too low, EKF2 will not fuse the external vision messages.
 
 The following MAVLink "vision" messages are not currently supported by PX4:
 [GLOBAL_VISION_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#GLOBAL_VISION_POSITION_ESTIMATE),


### PR DESCRIPTION
Explicitly stating that EKF2 will not fuse external vision data if the rate is not high enough. While this will not be an issue for most Mocap systems, VIO framerates of 10-20Hz are not uncommon.