### PR TITLE
Clarifications on External Vision EKF2 Delay Tunig

### DIFF
--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -98,13 +98,14 @@ Technically this can be set to 0 if there is correct timestamping (not just arri
 In reality, this needs some empirical tuning since delays in the entire MoCap->PX4 chain are very setup-specific.
 It is rare that a system is setup with an entirely synchronised chain!
 
-A rough estimate of the delay can be obtained from logs by checking the offset between IMU rates and the EV rates:
+A rough estimate of the delay can be obtained from logs by checking the offset between IMU rates and the EV rates.
+To enable logging of EV rates set bit 7 (Computer Vision and Avoidance) of [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE).
 
 ![ekf2_ev_delay log](../../assets/ekf2/ekf2_ev_delay_tuning.png)
 
 
 :::note
-A plot of external data vs. onboard estimate (as above) can be generated using [FlightPlot](../log/flight_log_analysis.md#flightplot) or similar flight analysis tools.
+A plot of external data vs. onboard estimate (as above) can be generated using [FlightPlot](../log/flight_log_analysis.md#flightplot) or similar flight analysis tools. However, neither [Flight Review](../log/flight_log_analysis.md#flight-review-online-tool) nor [MAVGCL](../log/flight_log_analysis.md#mavgcl) currently support this functionality.
 :::
 
 The value can further be tuned by varying the parameter to find the value that yields the lowest EKF innovations during dynamic maneuvers.

--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -103,9 +103,9 @@ To enable logging of EV rates set bit 7 (Computer Vision and Avoidance) of [SDLO
 
 ![ekf2_ev_delay log](../../assets/ekf2/ekf2_ev_delay_tuning.png)
 
-
 :::note
-A plot of external data vs. onboard estimate (as above) can be generated using [FlightPlot](../log/flight_log_analysis.md#flightplot) or similar flight analysis tools. However, neither [Flight Review](../log/flight_log_analysis.md#flight-review-online-tool) nor [MAVGCL](../log/flight_log_analysis.md#mavgcl) currently support this functionality.
+A plot of external data vs. onboard estimate (as above) can be generated using [FlightPlot](../log/flight_log_analysis.md#flightplot) or similar flight analysis tools.
+At time of writing (July 2021) neither [Flight Review](../log/flight_log_analysis.md#flight-review-online-tool) nor [MAVGCL](../log/flight_log_analysis.md#mavgcl) support this functionality.
 :::
 
 The value can further be tuned by varying the parameter to find the value that yields the lowest EKF innovations during dynamic maneuvers.


### PR DESCRIPTION
Explicitly state that SDLOG_PROFILE needs to be correctly set to log data form external vision. The plot shown contains data that is not logged by default.
Explicitly mention that neither the online Flight Review tool nor MAVGCL are able to plot the necessary data. This is not apparent from the flight log analysis page and caused some minor headaches.
This list is not complete, just the first two loggers I tried (and failed) with.