### PR TITLE
Add instructions to run ignition gazebo

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -289,6 +289,7 @@
       * [Gazebo Vehicles](simulation/gazebo_vehicles.md)
       * [Gazebo Worlds](simulation/gazebo_worlds.md)
       * [Multi-Vehicle Sim with Gazebo](simulation/multi_vehicle_simulation_gazebo.md)
+    * [Ignition Gazebo Simulation](simulation/ignition_gazebo.md)
     * [FlightGear Simulation](simulation/flightgear.md)
       * [FlightGear Vehicles](simulation/flightgear_vehicles.md)
       * [Multi-Vehicle Sim with FlightGear](simulation/multi_vehicle_flightgear.md)

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -26,6 +26,7 @@ Simulator |Description
 [jMAVSim](../simulation/jmavsim.md) | A simple multirotor simulator that allows you to fly *copter* type vehicles around a simulated world. <p>It is easy to set up and can be used to test that your vehicle can take off, fly, land, and responds appropriately to various fail conditions (e.g. GPS failure). It can also be used for [multi-vehicle simulation](../simulation/multi_vehicle_jmavsim.md).</p><p><strong>Supported Vehicles:</strong> Quad</p>
 [AirSim](../simulation/airsim.md) | <p>A cross platform simulator that provides physically and visually realistic simulations. This simulator is resource intensive, and requires a very significantly more powerful computer than the other simulators described here.</p><p><strong>Supported Vehicles:</strong> Iris (MultiRotor model and a configuration for PX4 QuadRotor in the X configuration).</p>
 [Simulation-In-Hardware](../simulation/simulation-in-hardware.md) (SIH) | <p>An alternative to HITL that offers a hard real-time simulation directly on the hardware autopilot.</p><p><strong>Supported Vehicles:</strong> Quad</p>
+[Ignition Gazebo](../simulation/ignition_gazebo.md) | <p>Ignition Gazebo is derived from the popular robotics simulator [Gazebo](./gazebo.md), featuring more advanced rendering, physics and sensor models.</p><p><strong>Supported Vehicles:</strong> Quad</p>
 
 Instructions for how to setup and use the simulators are in the topics linked above.
 

--- a/en/simulation/ignition_gazebo.md
+++ b/en/simulation/ignition_gazebo.md
@@ -1,13 +1,11 @@
 # Ignition Gazebo Simulation
 
 :::warning
-Ignition Gazebo has just been added to PX4 (July 2020) and only has basic support in PX4.
-It supports a single frame and world, and cannot be run in headless mode.
+Ignition Gazebo supports a single frame (quadcopter) and world, and cannot be run in headless mode (July 2021).
 :::
 
-
 [Ignition Gazebo](https://ignitionrobotics.org/libs/gazebo) is an open source robotics simulator from the [Ignition Robotics Project](https://ignitionrobotics.org/home).
-Ignition Gazebo is derived from the popular robotics simulator [Gazebo](./gazebo.md), featuring more advanced rendering, physics and sensor models.
+It is derived from the popular robotics simulator [Gazebo](./gazebo.md), featuring more advanced rendering, physics and sensor models.
 
 **Supported Vehicles:** Quadrotor
 

--- a/en/simulation/ignition_gazebo.md
+++ b/en/simulation/ignition_gazebo.md
@@ -1,5 +1,11 @@
 # Ignition Gazebo Simulation
 
+:::warning
+Ignition Gazebo has just been added to PX4 (July 2020) and only has basic support in PX4.
+It supports a single frame and world, and cannot be run in headless mode.
+:::
+
+
 [Ignition Gazebo](https://ignitionrobotics.org/libs/gazebo) is an open source robotics simulator from the [Ignition Robotics Project](https://ignitionrobotics.org/home).
 Ignition Gazebo is derived from the popular robotics simulator [Gazebo](./gazebo.md), featuring more advanced rendering, physics and sensor models.
 
@@ -18,7 +24,7 @@ These instructions were tested on Ubuntu 18.04 and Ubuntu 20.04
 :::
 
 1. Install the usual [Development Environment on Ubuntu LTS / Debian Linux](../dev_setup/dev_env_linux_ubuntu.md).
-1. Install Ignition Gazebo following the installation [instructions]()
+1. Install Ignition Gazebo following the [installation instructions](https://github.com/Auterion/px4-simulation-ignition#readme) (`sudo` may be required):
    ```sh
    sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
    wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
@@ -29,7 +35,7 @@ These instructions were tested on Ubuntu 18.04 and Ubuntu 20.04
 ## Running the Simulation
 
 Ignition Gazebo SITL simulation can be conveniently run through a `make` command as shown below:
-```sh
+```bash
 cd /path/to/PX4-Autopilot
 make px4_sitl ignition
 ```

--- a/en/simulation/ignition_gazebo.md
+++ b/en/simulation/ignition_gazebo.md
@@ -11,7 +11,6 @@ Ignition Gazebo is derived from the popular robotics simulator [Gazebo](./gazebo
 See [Simulation](../simulation/README.md) for general information about simulators, the simulation environment, and simulation configuration (e.g. supported vehicles).
 :::
 
-<a id="installation"></a>
 ## Installation (Ubuntu Linux)
 
 :::note
@@ -27,7 +26,6 @@ These instructions were tested on Ubuntu 18.04 and Ubuntu 20.04
    apt install ignition-edifice
    ```
 
-<a id="running"></a>
 ## Running the Simulation
 
 Ignition Gazebo SITL simulation can be conveniently run through a `make` command as shown below:

--- a/en/simulation/ignition_gazebo.md
+++ b/en/simulation/ignition_gazebo.md
@@ -1,0 +1,52 @@
+# Ignition Gazebo Simulation
+
+[Ignition Gazebo](https://ignitionrobotics.org/libs/gazebo) is an open source robotics simulator from the [Ignition Robotics Project](https://ignitionrobotics.org/home).
+Ignition Gazebo is derived from the popular robotics simulator [Gazebo](./gazebo.md), featuring more advanced rendering, physics and sensor models.
+
+**Supported Vehicles:** Quadrotor
+
+@[youtube](https://youtu.be/38UJqrNQChg)
+
+:::note
+See [Simulation](../simulation/README.md) for general information about simulators, the simulation environment, and simulation configuration (e.g. supported vehicles).
+:::
+
+<a id="installation"></a>
+## Installation (Ubuntu Linux)
+
+:::note
+These instructions were tested on Ubuntu 18.04 and Ubuntu 20.04
+:::
+
+1. Install the usual [Development Environment on Ubuntu LTS / Debian Linux](../dev_setup/dev_env_linux_ubuntu.md).
+1. Install Ignition Gazebo following the installation [instructions]()
+   ```sh
+   sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+   wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+   apt update
+   apt install ignition-edifice
+   ```
+
+<a id="running"></a>
+## Running the Simulation
+
+Ignition Gazebo SITL simulation can be conveniently run through a `make` command as shown below:
+```sh
+cd /path/to/PX4-Autopilot
+make px4_sitl ignition
+```
+This will run both the PX4 SITL instance and the ignition gazebo client
+
+The supported vehicles and `make` commands are listed below (click on the links to see the vehicle images).
+
+Vehicle | Command
+--- | ---
+quadrotor(iris) | `make px4_sitl ignition`
+
+The commands above launch a single vehicle with the full UI.
+*QGroundControl* should be able to automatically connect to the simulated vehicle.
+
+
+## Further Information
+
+* [px4-simulation-ignition](https://github.com/Auterion/px4-simulation-ignition)


### PR DESCRIPTION
**Problem Description**
This PR adds instructions on how to run `ignition` gazebo, which is a new simulation that is supported for SITL testing in PX4.

The PR was merged in: https://github.com/PX4/PX4-Autopilot/pull/17889

A demonstration of the simulator can be found in the following video
[![ignition gazebo sitl](https://img.youtube.com/vi/38UJqrNQChg/0.jpg)](https://youtu.be/38UJqrNQChg "Circular trajectory tracking")