### PR TITLE
Add disclaimer about Telega FOC tuning

### DIFF
--- a/en/uavcan/escs.md
+++ b/en/uavcan/escs.md
@@ -38,25 +38,27 @@ These have a number of advantages over [PWM ESCs](../peripherals/pwm_escs_and_se
 </div>
 
 
-
 ## PX4 Supported ESC
 
-PX4 is compatible with any/all UAVCAN ESCs (UAVCAN is generally speaking a plug'n'play protocol).
+PX4 is compatible with any/all UAVCAN v0 ESCs.
+At time of writing PX4 does not yet support UAVCAN v1.0.
 
-:::note
-At time of writing PX4 supports UAVCAN v0 (not v1.0).
-:::
-
-The only difference between UAVCAN ESCs from a setup perspective is that the physical connectors and the software tools used to configure the motor order and direction may be different. 
-
+UAVCAN is generally speaking a plug'n'play protocol.
+The main difference between UAVCAN ESCs from a setup perspective is that the physical connectors and the software tools used to configure the motor order and direction may be different.
 
 Some popular UAVCAN ESC firmware/products include:
 - [Sapog](https://github.com/PX4/sapog#px4-sapog) firmware; an advanced open source sensorless PMSM/BLDC motor controller firmware designed for use in propulsion systems of electric unmanned vehicles.
   - [Zubax Orel 20](https://zubax.com/products/orel_20)
   - [Holybro Kotleta20](https://shop.holybro.com/kotleta20_p1156.html)
-- [Mitochondrik](https://zubax.com/products/mitochondrik) - integrated sensorless PMSM/BLDC motor controller chip (used in ESCs and integrated drives)
+- [Zubax Myxa](https://zubax.com/products/myxa) - High-end PMSM/BLDC motor controller (FOC ESC) for light unmanned aircraft and watercraft.
+  :::note
+  ESC based on the Zubax Telega sensorless FOC motor control technology (e.g., Zubax Myxa, Mitochondrik, Komar, etc.) require non-trivial tuning of the propulsion system in order to deliver adequate performance and ensure robust operation.
+
+  Users who lack the necessary tuning expertise are advised to either [purchase pre-tuned UAV propulsion kits](https://zubax.com/products/uav_propulsion_kits) or to use Zubax Robotic's professional tuning service.
+  Questions on this matter should be addressed to: [support@zubax.com](mailto:support@zubax.com).
+  :::
+- [Zubax Mitochondrik](https://zubax.com/products/mitochondrik) - integrated sensorless PMSM/BLDC motor controller chip (used in ESCs and integrated drives)
   - [Zubax Sadulli Integrated Drive](https://shop.zubax.com/collections/integrated-drives/products/sadulli-integrated-drive-open-hardware-reference-design-for-mitochondrik?variant=27740841181283)
-- [Myxa](https://zubax.com/products/myxa) - High-end PMSM/BLDC motor controller (FOC ESC) for light unmanned aircraft and watercraft.
 - [VESC Project ESCs](https://vesc-project.com/) (see also [Benjamin Vedder's blog](http://vedder.se) - project owner)
 - [OlliW’s UC4H ESC-Actuator Node](http://www.olliw.eu/2017/uavcan-for-hobbyists/#chapterescactuator)
 - A number of others are [listed here](https://forum.uavcan.org/t/uavcan-esc-options/452/3?u=pavel.kirienko)
@@ -98,7 +100,6 @@ For more information see [UAVCAN > Wiring](../uavcan/README.md#wiring).
 All UAVCAN ESCs share the same connection architecture/are wired the same way.
 Note however that the actual connectors differ (e.g. *Zubax Orel 20* and *Holybro Kotleta20* use Dronecode standard connectors (JST-GH 4 Pin) - while VESCs do not).
 :::
-
 
 ## PX4 Configuration
 


### PR DESCRIPTION
This adds a note that Zubax telega sensorless FOC ESC require non-trivial tuning. I have not generalised this because 
- we only have support details for Zubax
- While all FOC ESC require more tuning, Telega appear (anecdotally) to be more sensitive to this issue.

If more data is provided on this issue in future we might split out an FOC ESC tuning section