### PR TITLE
events-interface - suggested minor improvements

### DIFF
--- a/en/concept/events_interface.md
+++ b/en/concept/events_interface.md
@@ -58,7 +58,7 @@ events::send<uint8_t, float>(events::ID("event_name"),
 
 Explanations and requirements:
 - `/* EVENT`: This tag indicates that a comment defines metadata for the following event.
-- **event_name**: the event name.
+- **event_name**: the event name (`events::ID(event_name)`).
   - must be unique within the whole source code of PX4.
     As a general convention, prefix it with the module name, or the source file for larger modules.
   - must be a valid variable name, i.e. must not contain spaces, colons, etc.
@@ -84,14 +84,15 @@ Explanations and requirements:
 	For example an RTL failsafe action: the user should see it as Warning/Error, whereas in the log, it is an expected system response, so it can be set to `Info`.
 - **Event Message**:
   - Single-line, short message of the event.
-    It may contain arguments (see below).
+    It may contain template placeholders for arguments (e.g. `{1}`). For more information see below..
 - **Event Description**:
   - Detailed, optional event description.
   - Can be multiple lines/paragraphs.
+  - It may contain template placeholders for arguments (e.g. `{2}`) and supported tags (see below)
 
 #### Arguments and Enums
 
-Events can have a fixed set of arguments that can be shown in the message or description.
+Events can have a fixed set of arguments that can be inserted into the message or description using template placeholders (e.g. `{2:.1m}` - see next section).
 
 Valid types: `uint8_t`, `int8_t`, `uint16_t`, `int16_t`, `uint32_t`, `int32_t`, `uint64_t`, `int64_t` and `float`.
 
@@ -111,10 +112,10 @@ Text format for event message description:
     `CONTENT` will only be shown if the name matches the configured profile.
 	This can be used for example to hide developer information from end-users.
   - URLs: `<a [href="URL"]>CONTENT</a>`.
-    If href is not set, use `CONTENT` as `URL`
+    If `href` is not set, use `CONTENT` as `URL` (i.e.`<a>https://docs.px4.io</a>` is interpreted as `<a href="https://docs.px4.io">https://docs.px4.io</a>`)
   - Parameters: `<param>PARAM_NAME</param>`
   - no nested tags of the same type are allowed
-- arguments: following python syntax, with 1-based indexing (instead of 0)
+- arguments: template placeholders that follow python syntax, with 1-based indexing (instead of 0)
   - general form: `{ARG_IDX[:.NUM_DECIMAL_DIGITS][UNIT]}`
 
     UNIT:
@@ -123,6 +124,7 @@ Text format for event message description:
       - m^2: area in m^2
       - m/s: speed in m/s
       - C: temperature in degrees celcius
+  - `NUM_DECIMAL_DIGITS` only makes sense for real number arguments.
 
 ## Logging
 

--- a/en/concept/events_interface.md
+++ b/en/concept/events_interface.md
@@ -84,7 +84,7 @@ Explanations and requirements:
 	For example an RTL failsafe action: the user should see it as Warning/Error, whereas in the log, it is an expected system response, so it can be set to `Info`.
 - **Event Message**:
   - Single-line, short message of the event.
-    It may contain template placeholders for arguments (e.g. `{1}`). For more information see below..
+    It may contain template placeholders for arguments (e.g. `{1}`). For more information see below.
 - **Event Description**:
   - Detailed, optional event description.
   - Can be multiple lines/paragraphs.


### PR DESCRIPTION
I've tried to make some minor updates to the events documentation prevent the sort of confusion I had in https://github.com/PX4/PX4-user_guide/pull/1396#discussion_r669186140

The most important part of this is to use the term "template placeholder" for arguments. I'd understand if you think this unnecessary.

FWIW I think this might also be improved by separating out the description of what gets built from the method, and what extra is added by the description comment. However this probably isn't worth doing until the section on compatibility can be removed. 