### PR TITLE
Updated message IDs and required messages

### DIFF
--- a/en/ros/ros2_offboard_control.md
+++ b/en/ros/ros2_offboard_control.md
@@ -32,8 +32,12 @@ Besides that:
        id: 44
        receive: true
      ...
+     - msg: vehicle_local_position_setpoint
+       id: 97
+       receive: true
+     ...
      - msg: trajectory_setpoint
-       id: 186
+       id: 196
        alias: vehicle_local_position_setpoint
        receive: true
    ```
@@ -44,8 +48,12 @@ Besides that:
        msg: OffboardControlMode
        receive: true
      ...
+     - msg: VehicleLocalPositionSetpoint
+       id: 97
+       receive: true
+     ...
      - alias: VehicleLocalPositionSetpoint
-       id: 186
+       id: 196
        msg: TrajectorySetpoint
        receive: true
    ```


### PR DESCRIPTION
- Offboard control with just `offboard_control_mode` and `trajectory_setpoint` enabled didn't work. ` vehicle_local_position_setpoint` had to be set to `receive: true` as well.
- `trajectory_setpoint` had `id: 186` in the docs, but has been changed to `id: 196` in updates without docs reflecting this.

Links: 
 - https://github.com/PX4/PX4-Autopilot/blob/607be59fd5b47160326052dea8eea7edc7619d66/msg/tools/uorb_rtps_message_ids.yaml#L401