### PR TITLE
Precision landing - note can use landing target protocol

### DIFF
--- a/en/advanced_features/precland.md
+++ b/en/advanced_features/precland.md
@@ -1,17 +1,108 @@
 # Precision Landing
 
-PX4 supports precision landing for *multicopters* using a landing beacon/target.
-
-This requires an [IR-LOCK Sensor](https://irlock.com/products/ir-lock-sensor-precision-landing-kit) and downward facing [distance sensor](../sensor/rangefinders.md) connected to the flight controller, and an IR beacon as a target (e.g. [IR-LOCK MarkOne](https://irlock.com/collections/markone)).
-This enables landing with a precision of roughly 10 cm (GPS precision, by contrast, may be as large as several meters).
-
-Alternatively, precision landing can be supported "offboard", using a positioning system that implements the MAVLink [Landing Target Protocol](https://mavlink.io/en/services/landing_target.html).
+PX4 supports precision landing for *multicopters* on either stationary or moving targets.
+The target may be provided by an onboard IR sensor and a landing beacon, or by an offboard positioning system.
  
-Precision landing can be [started/initiated](#initiating-a-precision-landing) by entering the *Precision Land* flight mode, or as part of a [mission](#mission).
+Precision landing can be [started/initiated](#initiating-a-precision-landing) as part of a [mission](#mission), in a [Return mode](#return-mode-precision-landing) landing, or by entering the [*Precision Land* flight mode](#precision-landing-flight-mode).
 
-## Setup
+:::note
+Precision landing is only possible with a valid global position (due to a limitation in the current implementation of the position controller).
+:::
 
-### Hardware Setup
+## Overview
+
+### Land Modes
+
+A precision landing can be configured to either be "required" or "opportunistic".
+The choice of mode affects how a precision landing is performed.
+
+#### Required Mode
+
+In *Required Mode* the vehicle will search for a target if none is visible when landing is initiated.
+The vehicle will perform a precision landing if a target is located.
+
+The search procedure consists of climbing to the search altitude ([PLD_SRCH_ALT](../advanced_config/parameter_reference.md#PLD_SRCH_ALT)).
+If the target is still not visible at the search altitude and after a search timeout ([PLD_SRCH_TOUT](../advanced_config/parameter_reference.md#PLD_SRCH_TOUT)), a normal landing is initiated at the current position.
+
+:::note
+If using an offboard positioning system PX4 assumes that the target is visible when it is recieving MAVLink [LANDING_TARGET](https://mavlink.io/en/messages/common.html#LANDING_TARGET) messages.
+:::
+
+#### Opportunistic Mode
+
+In *Opportunistic Mode* the vehicle will use precision landing *if* (and only if) the target is visible when landing is initiated.
+If it is not visible the vehicle immediately performs a *normal* landing at the current position.
+
+### Landing Phases
+
+A precision landing has three phases:
+
+1. **Horizontal approach:** The vehicle approaches the target horizontally while keeping its current altitude.
+   Once the position of the target relative to the vehicle is below a threshold ([PLD_HACC_RAD](../advanced_config/parameter_reference.md#PLD_HACC_RAD)), the next phase is entered.
+   If the target is lost during this phase (not visible for longer than [PLD_BTOUT](../advanced_config/parameter_reference.md#PLD_BTOUT)), a search procedure is initiated (during a required precision landing) or the vehicle does a normal landing (during an opportunistic precision landing).
+
+1. **Descent over target:** The vehicle descends, while remaining centered over the target.
+   If the target is lost during this phase (not visible for longer than `PLD_BTOUT`), a search procedure is initiated (during a required precision landing) or the vehicle does a normal landing (during an opportunistic precision landing).
+
+1. **Final approach:** When the vehicle is close to the ground (closer than [PLD_FAPPR_ALT](../advanced_config/parameter_reference.md#PLD_FAPPR_ALT)), it descends while remaining centered over the target.
+   If the target is lost during this phase, the descent is continued independent of the kind of precision landing.
+
+Search procedures are initiated in the first and second steps, and will run at most [PLD_MAX_SRCH](../advanced_config/parameter_reference.md#PLD_MAX_SRCH) times.
+Landing Phases Flow Diagram
+
+A flow diagram showing the phases can be found in [landing phases flow Diagram](#landing-phases-flow-diagram) below.
+
+## Initiating a Precision Landing
+
+Precision landing can be used in missions, during the landing phase in *Return mode*, or by entering the *Precision Land* mode.
+
+<span id="mission"></span>
+### Mission Precision Landing
+
+Precision landing can be initiated as part of a [mission](../flying/missions.md) using [MAV_CMD_NAV_LAND](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND) with `param2` set appropriately:
+
+- `0`: Normal landing without using the target.
+- `1`: [Opportunistic](#opportunistic-mode) precision landing.
+- `2`: [Required](#required-mode) precision landing.
+
+### Return Mode Precision Landing
+
+Precision landing can be used in the [Return mode](../flight_modes/return.md) landing phase.
+
+This is enabled using the parameter [RTL_PLD_MD](../advanced_config/parameter_reference.md#RTL_PLD_MD), which takes the following values:
+
+- `0`: Precision landing disabled (land as normal).
+- `1`: [Opportunistic](#opportunistic-mode) precision landing.
+- `2`: [Required](#required-mode) precision landing.
+
+
+### Precision Landing Flight Mode
+
+Precision landing can be enabled by switching to the *Precision Landing* flight mode.
+
+You can verify this using the [*QGroundControl* MAVLink Console](../debug/mavlink_shell.md#qgroundcontrol-mavlink-console) to enter the following command:
+```
+commander mode auto:precland
+```
+
+:::note
+When switching to the mode in this way, the precision landing is always "required"; there is no way to specify the type of landing.
+:::
+
+:::note
+At time of writing is no _convenient_ way to directly invoke precision landing (other than commanding return mode):
+- *QGroundControl* does not provide it as a UI option.
+- [MAV_CMD_NAV_LAND](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND) only works in missions.
+- [MAV_CMD_SET_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_SET_MODE) should work, but you will need to determine the appropriate base and custom modes used by PX4 to represent the precision landing mode.
+:::
+
+
+## Hardware Setup
+
+### IR Sensor/Beacon Setup
+
+The IR sensor/landing beacon solution requires an [IR-LOCK Sensor](https://irlock.com/products/ir-lock-sensor-precision-landing-kit) and downward facing [distance sensor](../sensor/rangefinders.md) connected to the flight controller, and an IR beacon as a target (e.g. [IR-LOCK MarkOne](https://irlock.com/collections/markone)).
+This enables landing with a precision of roughly 10 cm (GPS precision, by contrast, may be as large as several meters).
 
 Install the IR-LOCK sensor by following the [official guide](https://irlock.readme.io/v2.0/docs).
 Ensure that the sensor's x axis is aligned with the vehicle's y axis and the sensor's y axis aligned with the vehicle's -x direction (this is the case if the camera is pitched down 90 degrees from facing forward).
@@ -23,7 +114,18 @@ Many infrared based range sensors do not perform well in the presence of the IR-
 Refer to the IR-LOCK guide for other compatible sensors.
 :::
 
-### Firmware Configuration
+## Offboard Positioning
+
+The offboard solution requires a positioning system that implements the MAVLink [Landing Target Protocol](https://mavlink.io/en/services/landing_target.html).
+This can use any positioning mechanism to determine the landing target, for example computer vision and a visual marker.
+
+The system must publish the coordinates of the target in the [LANDING_TARGET](https://mavlink.io/en/messages/common.html#LANDING_TARGET) message.
+Note that PX4 _requires_ `LANDING_TARGET.frame` to be [MAV_FRAME_LOCAL_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_NED) and only populates the fields `x`, `y`, and `z`.
+The origin of the local NED frame [0,0] is the home position (you can map this home position to global coordinates using [GPS_GLOBAL_ORIGIN](https://mavlink.io/en/messages/common.html#GPS_GLOBAL_ORIGIN)).
+
+PX4 does not explicitly require a [distance sensor](../sensor/rangefinders.md) or other sensors, but will perform better if it can more precisely determine its own position.
+
+## Firmware Configuration
 
 Precision landing requires the modules `irlock` and `landing_target_estimator`, which are not included in the PX4 firmware by default.
 They can be included by adding (or uncommenting) the following lines in the relevant configuration file for your flight controller (e.g. [PX4-Autopilot/boards/px4/fmu-v5/default.cmake](https://github.com/PX4/PX4-Autopilot/blob/master/boards/px4/fmu-v5/default.cmake)):
@@ -36,18 +138,30 @@ modules/landing_target_estimator
 The two modules should also be started on system boot.
 For instructions see: [customizing the system startup](../concept/system_startup.md#customizing-the-system-startup).
 
+## PX4 Configuration (Parameters)
 
-## Software Configuration (Parameters)
+[LTEST_MODE](../advanced_config/parameter_reference.md#LTEST_MODE) determines if the target is assumed to be stationary or moving.
+If `LTEST_MODE` is set to moving (e.g. it is installed on a vehicle on which the multicopter is to land), target measurements are only used to generate position setpoints in the precision landing controller.
+If `LTEST_MODE` is set to stationary, the target measurements are also used by the vehicle position estimator (EKF2 or LPE).
 
-Precision landing is configured with the [Landing_target estimator](../advanced_config/parameter_reference.md#landing-target-estimator) and [Precision land](../advanced_config/parameter_reference.md#precision-land) parameters.
-The most important parameters are discussed below.
+Other relevant parameters are listed in the parameter reference under [Landing_target estimator](../advanced_config/parameter_reference.md#landing-target-estimator) and [Precision land](../advanced_config/parameter_reference.md#precision-land) parameters.
+Some of the most useful ones are listed below.
 
-[LTEST_MODE](../advanced_config/parameter_reference.md#LTEST_MODE) determines if the beacon is assumed to be stationary or moving.
-If `LTEST_MODE` is set to moving (e.g. it is installed on a vehicle on which the multicopter is to land), beacon measurements are only used to generate position setpoints in the precision landing controller.
-If `LTEST_MODE` is set to stationary, the beacon measurements are also used by the vehicle position estimator (EKF2 or LPE).
+Parameter | Description
+--- | ---
+<a id="LTEST_MODE"></a>[LTEST_MODE](../advanced_config/parameter_reference.md#LTEST_MODE) | Landing target is moving (`0`) or stationary (`1`). Default is moving.
+<a id="PLD_HACC_RAD"></a>[PLD_HACC_RAD](../advanced_config/parameter_reference.md#PLD_HACC_RAD) | Horizontal acceptance radius, within which the vehicle will start descending. Default is 0.2m.
+<a id="PLD_BTOUT"></a>[PLD_BTOUT](../advanced_config/parameter_reference.md#PLD_BTOUT) | Landing Target Timeout, after which the target is assumed lost. Default is 5 seconds.
+<a id="PLD_FAPPR_ALT"></a>[PLD_FAPPR_ALT](../advanced_config/parameter_reference.md#PLD_FAPPR_ALT) | Final approach altitude. Default is 0.1 metres.
+<a id="PLD_MAX_SRCH"></a>[PLD_MAX_SRCH](../advanced_config/parameter_reference.md#PLD_MAX_SRCH) | Maximum number of search attempts in an required landing.
+<a id="RTL_PLD_MD"></a>[RTL_PLD_MD](../advanced_config/parameter_reference.md#RTL_PLD_MD) | RTL precision land mode. `0`: disabled, `1`: [Opportunistic](#opportunistic-mode), `2`: [Required](#required-mode).
+
+
+### IR Beacon Scaling
+
+Measurement scaling may be necessary due to lens distortions of the IR-LOCK sensor.
 
 [LTEST_SCALE_X](../advanced_config/parameter_reference.md#LTEST_SCALE_X) and [LTEST_SCALE_Y](../advanced_config/parameter_reference.md#LTEST_SCALE_Y) can be used to scale beacon measurements before they are used to estimate the beacon's position and velocity relative to the vehicle.
-Measurement scaling may be necessary due to lens distortions of the IR-LOCK sensor.
 Note that `LTEST_SCALE_X` and `LTEST_SCALE_Y` are considered in the sensor frame, not the vehicle frame.
 
 To calibrate these scale parameters, set `LTEST_MODE` to moving, fly your multicopter above the beacon and perform forward-backward and left-right motions with the vehicle, while [logging](../dev_log/logging.md#configuration) `landing_target_pose` and `vehicle_local_position`.
@@ -55,47 +169,6 @@ Then, compare `landing_target_pose.vx_rel` and `landing_target_pose.vy_rel` to `
 If the estimated beacon velocities are consistently smaller or larger than the vehicle velocities, adjust the scale parameters to compensate.
 
 If you observe slow sideways oscillations of the vehicle while doing a precision landing with `LTEST_MODE` set to stationary, the beacon measurements are likely scaled too high and you should reduce the scale parameter in the relevant direction.
-
-## Precision Land Modes
-
-A precision landing can be configured to either be "required" or "opportunistic".
-The choice of mode affects how a precision landing is performed.
-
-### Required Mode
-
-In *Required Mode* the vehicle will search for a beacon if none is visible when landing is initiated.
-The vehicle will perform a precision landing if a beacon is located.
-
-The search procedure consists of climbing to the search altitude ([PLD_SRCH_ALT](../advanced_config/parameter_reference.md#PLD_SRCH_ALT)).
-If the beacon is still not visible at the search altitude and after a search timeout ([PLD_SRCH_TOUT](../advanced_config/parameter_reference.md#PLD_SRCH_TOUT)), a normal landing is initiated at the current position.
-
-### Opportunistic Mode
-
-In *Opportunistic Mode* the vehicle will use precision landing *if* (and only if) the beacon is visible when landing is initiated.
-If it is not visible the vehicle immediately performs a *normal* landing at the current position.
-
-## Initiating a Precision Landing
-
-:::note
-Precision landing is only possible with a valid global position (due to a limitation in the current implementation of the position controller).
-:::
-
-<span id="mission"></span>
-### In a Mission
-
-Precision landing can be initiated as part of a [mission](../flying/missions.md) using [MAV_CMD_NAV_LAND](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND) with `param2` set appropriately:
-
-- `0`: Normal landing without using the beacon.
-- `1`: [Opportunistic](#opportunistic-mode) precision landing.
-- `2`: [Required](#required-mode) precision landing.
-
-### Command Line
-
-Precision landing can be initiated through the command line interface with:
-```
-commander mode auto:precland
-```
-In this case, the precision landing is always considered "required".
 
 ## Simulation
 
@@ -115,33 +188,24 @@ You can change the location of the beacon either by moving it in the Gazebo GUI 
 
 The `landing_target_estimator` takes measurements from the `irlock` driver as well as the estimated terrain height to estimate the beacon's position relative to the vehicle.
 
-The measurements in `irlock_report` contain the tangent of the angles from the image center to the beacon. In other words, the measurements are the x and y components of the vector pointing towards the beacon, where the z component has length "1".
+The measurements in `irlock_report` contain the tangent of the angles from the image center to the beacon.
+In other words, the measurements are the x and y components of the vector pointing towards the beacon, where the z component has length "1".
 This means that scaling the measurement by the distance from the camera to the beacon results in the vector from the camera to the beacon.
 This relative position is then rotated into the north-aligned, level body frame using the vehicle's attitude estimate.
 Both x and y components of the relative position measurement are filtered in separate Kalman Filters, which act as simple low-pass filters that also produce a velocity estimate and allow for outlier rejection.
 
-The `landing_target_estimator` publishes the estimated relative position and velocity whenever a new `irlock_report` is fused into the estimate. Nothing is published if the beacon is not seen or beacon measurements are rejected.
+The `landing_target_estimator` publishes the estimated relative position and velocity whenever a new `irlock_report` is fused into the estimate.
+Nothing is published if the beacon is not seen or beacon measurements are rejected.
 The landing target estimate is published in the `landing_target_pose` uORB message.
 
 ### Enhanced Vehicle Position Estimation
 
-If the beacon is specified to be stationary using the parameter `LTEST_MODE`, the vehicle's position/velocity estimate can be improved with the help of the beacon measurements.
-This is done by fusing the beacon's velocity as a measurement of the negative velocity of the vehicle.
+If the target is specified to be stationary using the parameter `LTEST_MODE`, the vehicle's position/velocity estimate can be improved with the help of the target measurements.
+This is done by fusing the target's velocity as a measurement of the negative velocity of the vehicle.
 
-### Precision Land Procedure
 
-The precision land procedure consists of three phases:
+### Landing Phases Flow Diagram
 
-1. **Horizontal approach:** The vehicle approaches the beacon horizontally while keeping its current altitude.
-   Once the position of the beacon relative to the vehicle is below a threshold ([PLD_HACC_RAD](../advanced_config/parameter_reference.md#PLD_HACC_RAD)), the next phase is entered.
-   If the beacon is lost during this phase (not visible for longer than [PLD_BTOUT](../advanced_config/parameter_reference.md#PLD_BTOUT)), a search procedure is initiated (during a required precision landing) or the vehicle does a normal landing (during an opportunistic precision landing).
-
-1. **Descent over beacon:** The vehicle descends, while remaining centered over the beacon.
-   If the beacon is lost during this phase (not visible for longer than `PLD_BTOUT`), a search procedure is initiated (during a required precision landing) or the vehicle does a normal landing (during an opportunistic precision landing).
-
-1. **Final approach:** When the vehicle is close to the ground (closer than [PLD_FAPPR_ALT](../advanced_config/parameter_reference.md#PLD_FAPPR_ALT)), it descends while remaining centered over the beacon.
-   If the beacon is lost during this phase, the descent is continued independent of the kind of precision landing.
-
-Search procedures are initiated in 1. and 2. a maximum of [PLD_MAX_SRCH](../advanced_config/parameter_reference.md#PLD_MAX_SRCH) times.
+This image shows the [landing phases](#landing-phases) as a flow diagram.
 
 ![Precision Landing Flow Diagram](../../assets/precision_land/precland-flow-diagram.png)


### PR DESCRIPTION
This is minimal changes to make it clear that Precision landing supports the MAVLink [Landing Target protocol](https://mavlink.io/en/services/landing_target.html) as well as the IRLock. Attempts to address https://github.com/PX4/PX4-Autopilot/issues/18025

Next step is a more complete "how do you implement that" but I have some questions/statements - see notes.