### PR TITLE
- fix flightgear protocol path

### DIFF
--- a/en/simulation/flightgear.md
+++ b/en/simulation/flightgear.md
@@ -50,7 +50,7 @@ These instructions were tested on Ubuntu 18.04
    ```
 1. Set write permissions to the **Protocols** folder in the FlightGear installation directory:
    ```
-   sudo chmod a+w /usr/share/games/flightgear/Protocols
+   sudo chmod a+w /usr/share/games/flightgear/Protocol
    ```
    Setting the permissions is required because the PX4-FlightGear-Bridge puts the communication definition file here. 
 


### PR DESCRIPTION
after following this I found a miss spelling in protocol flight gear path
