### PR TITLE
Update microRTPS and ROS 2 docs

### DIFF
--- a/en/dev_setup/fast-dds-installation.md
+++ b/en/dev_setup/fast-dds-installation.md
@@ -5,10 +5,16 @@
 Fast DDS enables an RTPS/DDS interface that allows PX4 uORB topics to be shared with offboard components, including robotics and simulator tools, that participate in same DDS domain.
 In particular, Fast DDS is the default middleware implementation for Robot Operating System 2 (ROS 2), and is essential for integrating PX4 with ROS2.
 
-This topic explains how to install Fast DDS for use with PX4.
+This topic explains how to install Fast DDS and *Fast-RTPS-Gen* for usage in the PX4 build system and with the microRTPS bridge.
+
+:::note
+If you have ROS 2 Dashing (Ubuntu 18.04) or ROS 2 Foxy (Ubuntu 20.04) installed, you do not have to install Fast DDS, as it comes included with the default `base` or `desktop` installations through the `ros-<distro>-rmw-fastrtps` package. This means you just need to install *Fast-RTPS-Gen* and have your ROS 2 environment sourced (`source /opt/ros/<distro>/setup.bash`) so to be able to compile the `rtps` targets in the PX4-Autopilot repo.
+
+Note though that for ROS2 Galatic and above, one has to install the `rmw` implementation through `apt` using `apt install ros-galatic-rmw-fastrtps`, since the default middleware for Galatic and above is CycloneDDS and the FastDDS middleware doesn't come installed by default.
+:::
 
 :::tip
-Fast DDS is not an essential component of the PX4 Autopilot and should only be installed if you plan to use the PX4 Autopilot with another Fast RTPS/DDS system such as ROS 2.
+Fast DDS is not an essential component of the PX4 Autopilot and should only be installed if you plan to interface the PX4 Autopilot with Fast RTPS/DDS participants. ROS 2 nodes are an example of these, though Fast DDS middleware and C++ implementations are installed by default on ROS 2 Foxy and bellow, as mentioned above.
 :::
 
 :::note
@@ -22,18 +28,26 @@ Fast DDS was previously named FastRTPS (the name was changed in version 2.0.0 as
 
 :::note
 At time of writing you will need to install *from source* for:
-- **Ubuntu 18.04:** Fast RTPS 1.8.2 (or later) and Fast-RTPS-Gen 1.0.4 (not later!).
-- **Ubuntu 20.04:** Fast DDS 2.0.0 (or later) and Fast-RTPS-Gen 1.0.4 (not later!).
+- **Ubuntu 18.04:** Fast RTPS 1.8.4 (or later) and Fast-RTPS-Gen 1.0.4 (not later!).
+- **Ubuntu 20.04:** Fast DDS 2.0.2 (or later) and Fast-RTPS-Gen 1.0.4 (not later!).
+:::
+
+:::tip
+Further reminder that you only need to install Fast DDS in case you are not using ROS 2 and want to just leverage non-ROS2 DDS networks and applications. If you have ROS 2 installed (and `rmw-fasrtps` as the default middleware of it), you can skip to [Fast-RTPS-Gen build and install](#fast-rtps-gen).
 :::
 
 ### Java
 
-Java is required to use our built-in code generation tool - *fastrtpsgen*.
-[Java JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) is recommended.
+Java is required to build and use eProsima's RTPS/DDS from IDL code generation tool - *Fast-RTPS-Gen*.
+[Java JDK 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html) is recommended, and it is installed through the setup scripts made available in [Ubuntu Development Environment](../dev_setu/dev_env_linux.md).
 
 ### Gradle
 
-You also need to [install Gradle](https://gradle.org/install/) to build the source generators (Fast-RTPS-Gen), we recommend you install Gradle via [sdkman](https://sdkman.io).
+You also need to [install Gradle](https://gradle.org/install/) to build *Fast-RTPS-Gen*. We recommend you install Gradle via [sdkman](https://sdkman.io).
+
+:::warning
+Do not install Gradle version greater or equal to 7. Recommended version is 6.3.
+:::
 
 ### Foonathan memory
 
@@ -48,26 +62,19 @@ cmake --build . --target install
 ```
 
 :::note
-If the last step fails, try running the command with the proper user privileges (sudo)
+If the last step fails, try running the command with the proper user privileges (`sudo`).
 :::
-
-### Windows 7 32-bit and 64-bit
-
-#### Visual C++ 2013 or 2015 Redistributable Package
-
-*eProsima Fast DDS* requires the Visual C++ Redistributable packages for the Visual Studio version you chose during the installation or compilation.
-The installer gives you the option of downloading and installing them.
 
 
 ## Installation from Sources
 
-### Fast-RTPS (DDS)
+### Fast DDS
 
 Clone the project from Github:
 
 ```sh
-$ git clone --recursive https://github.com/eProsima/Fast-DDS.git -b v2.0.0 ~/FastDDS-2.0.0
-$ cd ~/FastDDS-2.0.0
+$ git clone --recursive https://github.com/eProsima/Fast-DDS.git -b v2.0.2 ~/FastDDS-2.0.2
+$ cd ~/FastDDS-2.0.2
 $ mkdir build && cd build
 ```
 
@@ -82,19 +89,13 @@ $ sudo make install
 This will install Fast DDS to `/usr/local`, with secure communications support.
 If you need to install to a custom location you can use: `-DCMAKE_INSTALL_PREFIX=<path>`.
 
-If you are on Windows, choose your version of *Visual Studio*:
-
-```sh
-> cmake -G "Visual Studio 14 2015 Win64" -DTHIRDPARTY=ON -DSECURITY=ON ..
-> cmake --build . --target install
-```
-
 #### Compile Options
 
 The following additional arguments can be used when calling *CMake*:
 
 - `-DCOMPILE_EXAMPLES=ON`: Compile the examples
 - `-DPERFORMANCE_TESTS=ON`: Compile the performance tests
+
 
 ### Fast-RTPS-Gen
 
@@ -106,8 +107,8 @@ Then install Fast-RTPS-Gen 1.0.4 (Gradle is required for this):
 ```
 git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git -b v1.0.4 ~/Fast-RTPS-Gen \
     && cd ~/Fast-RTPS-Gen \
-    && ./gradlew assemble \
-    && sudo ./gradlew install
+    && gradle assemble \
+    && sudo env "PATH=$PATH" gradle install
 ```
 
 ## Installation from Binaries
@@ -120,53 +121,13 @@ The latest binary release of *eProsima Fast DDS* can be downloaded from the [com
 
 Documentation on how to do this can be found here: [Installation from Binaries on Linux](https://fast-dds.docs.eprosima.com/en/latest/installation/binaries/binaries_linux.html) and [Installation from Binaries on Windows](https://fast-dds.docs.eprosima.com/en/latest/installation/binaries/binaries_windows.html) (*eProsima Fast DDS* official documentation)
 
-
-### Windows 7 32-bit and 64-bit
-
-Execute the installer and follow the instructions, choosing your preferred *Visual Studio* version and architecture when prompted.
-
-#### Environmental Variables
-
-*eProsima Fast DDS* requires the following environmental variable setup in order to function properly
-
-* `FASTRTPSHOME`: Root folder where *eProsima Fast DDS* is installed.
-* `FASTRTPSGEN_DIR`: Root folder where *eProsima Fast-RTPS-Gen* is installed.
-* Additions to the `PATH`: the **/bin** folder and the subfolder for your Visual Studio version of choice should be appended to the PATH.
-
-These variables are set automatically by checking the corresponding box during the installation process.
-
-
-### Linux
-
-Extract the contents of the package.
-It will contain both *eProsima Fast DDS* and its required package *eProsima Fast CDR*. You will have follow the same procedure for both packages, starting with *Fast CDR*.
-
-Configure the compilation:
-
-```sh
-$ ./configure --libdir=/usr/lib
-```
-
-If you want to compile with debug symbols (which also enables verbose mode):
-
-```sh
-$ ./configure CXXFLAGS="-g -D__DEBUG"  --libdir=/usr/lib
-```
-
-After configuring the project compile and install the library:
-
-```sh
-$ sudo make install
-```
-
 #### Environmental Variables
 
 * `FASTRTPSGEN_DIR`: Root folder where *eProsima Fast-RTPS-Gen* is installed, usually set to `/usr/local`, which is the default installation directory.
-  If the user sets a different install directory in the `gradle install` step, it must set it here as well.
+  If the user sets a different install directory in the `gradle install` step, it must set this variable to that same directory as well. Otherwise, the code generation step, and consequently, the build of the `rtps` targets in PX4 will fail.
 
 
 ## Further Information
-
 
 - [RTPS/DDS Interface: PX4-Fast RTPS(DDS) Bridge](../middleware/micrortps.md)
 - [PX4-ROS 2 bridge](../ros/ros2_comm.md)

--- a/en/dev_setup/fast-dds-installation.md
+++ b/en/dev_setup/fast-dds-installation.md
@@ -2,19 +2,21 @@
 
 <img alt="logo" src="../../assets/fastrtps/eprosima_logo.png" style="float:left;"/> [eProsima Fast DDS](https://github.com/eProsima/Fast-DDS) is a C++ implementation of the Object Management Group's (OMG) Data Distribution Service (DDS) specification and the Real Time Publish Subscribe (RTPS) protocol.
 
-Fast DDS enables an RTPS/DDS interface that allows PX4 uORB topics to be shared with offboard components, including robotics and simulator tools, that participate in same DDS domain.
+Fast DDS enables an RTPS/DDS interface that allows PX4 uORB topics to be shared with offboard components that participate in same DDS domain, including robotics and simulator tools.
 In particular, Fast DDS is the default middleware implementation for Robot Operating System 2 (ROS 2), and is essential for integrating PX4 with ROS2.
 
-This topic explains how to install Fast DDS and *Fast-RTPS-Gen* for usage in the PX4 build system and with the microRTPS bridge.
+This topic explains how to install Fast DDS and *Fast-RTPS-Gen* to use in the PX4 build system and with the microRTPS bridge.
 
 :::note
-If you have ROS 2 Dashing (Ubuntu 18.04) or ROS 2 Foxy (Ubuntu 20.04) installed, you do not have to install Fast DDS, as it comes included with the default `base` or `desktop` installations through the `ros-<distro>-rmw-fastrtps` package. This means you just need to install *Fast-RTPS-Gen* and have your ROS 2 environment sourced (`source /opt/ros/<distro>/setup.bash`) so to be able to compile the `rtps` targets in the PX4-Autopilot repo.
+You do not have to install Fast DDS if you have ROS 2 Dashing (Ubuntu 18.04) or ROS 2 Foxy (Ubuntu 20.04) installed, as it comes included with the default `base` or `desktop` installations through the `ros-<distro>-rmw-fastrtps` package.
+This means you just need to install *Fast-RTPS-Gen* and have your ROS 2 environment sourced (`source /opt/ros/<distro>/setup.bash`) in order to be able to compile the `rtps` targets in the PX4-Autopilot repo.
 
-Note though that for ROS2 Galatic and above, one has to install the `rmw` implementation through `apt` using `apt install ros-galatic-rmw-fastrtps`, since the default middleware for Galatic and above is CycloneDDS and the FastDDS middleware doesn't come installed by default.
+For *ROS2 Galactic and above*, one has to install the `rmw` implementation through `apt` using `apt install ros-galatic-rmw-fastrtps`, since the default middleware for Galactic and above is CycloneDDS and the FastDDS middleware doesn't come installed by default.
 :::
 
 :::tip
-Fast DDS is not an essential component of the PX4 Autopilot and should only be installed if you plan to interface the PX4 Autopilot with Fast RTPS/DDS participants. ROS 2 nodes are an example of these, though Fast DDS middleware and C++ implementations are installed by default on ROS 2 Foxy and bellow, as mentioned above.
+Fast DDS is not an essential component of the PX4 Autopilot and should only be installed if you plan to interface the PX4 Autopilot with Fast RTPS/DDS participants.
+ROS 2 nodes are an example of these, though Fast DDS middleware and C++ implementations are installed by default on ROS 2 Foxy and below, as mentioned above.
 :::
 
 :::note
@@ -33,7 +35,8 @@ At time of writing you will need to install *from source* for:
 :::
 
 :::tip
-Further reminder that you only need to install Fast DDS in case you are not using ROS 2 and want to just leverage non-ROS2 DDS networks and applications. If you have ROS 2 installed (and `rmw-fasrtps` as the default middleware of it), you can skip to [Fast-RTPS-Gen build and install](#fast-rtps-gen).
+Remember (again) you only need to install Fast DDS if you are not using ROS 2 and just want to leverage non-ROS2 DDS networks and applications.
+If you have ROS 2 installed (and `rmw-fasrtps` as its default middleware), you can skip to [Fast-RTPS-Gen build and install](#fast-rtps-gen).
 :::
 
 ### Java
@@ -43,10 +46,12 @@ Java is required to build and use eProsima's RTPS/DDS from IDL code generation t
 
 ### Gradle
 
-You also need to [install Gradle](https://gradle.org/install/) to build *Fast-RTPS-Gen*. We recommend you install Gradle via [sdkman](https://sdkman.io).
+You also need to [install Gradle](https://gradle.org/install/) to build *Fast-RTPS-Gen*.
+We recommend you install Gradle via [sdkman](https://sdkman.io).
 
 :::warning
-Do not install Gradle version greater or equal to 7. Recommended version is 6.3.
+Do not install Gradle version 7 or higher.
+The recommended version is 6.3.
 :::
 
 ### Foonathan memory
@@ -124,7 +129,8 @@ Documentation on how to do this can be found here: [Installation from Binaries o
 #### Environmental Variables
 
 * `FASTRTPSGEN_DIR`: Root folder where *eProsima Fast-RTPS-Gen* is installed, usually set to `/usr/local`, which is the default installation directory.
-  If the user sets a different install directory in the `gradle install` step, it must set this variable to that same directory as well. Otherwise, the code generation step, and consequently, the build of the `rtps` targets in PX4 will fail.
+  If the user sets a different install directory in the `gradle install` step, it must set this variable to that same directory as well.
+  Otherwise, the code generation step, and consequently, the build of the `rtps` targets in PX4 will fail.
 
 
 ## Further Information

--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -8,7 +8,7 @@ It provides an overview of the ROS2-PX4 bridge architecture and application pipe
 :::note
 The Fast DDS interface in the PX4 Autopilot can be leveraged by any applications running and linked in DDS domains (including ROS nodes).
 
-For information about using the *microRTPS bridge* without ROS 2, see the [RTPS/DDS Interface section](../middleware/micrortps.md).
+For information about using the *microRTPS bridge* **without ROS 2**, see the [RTPS/DDS Interface section](../middleware/micrortps.md).
 :::
 
 :::note
@@ -20,31 +20,38 @@ For a more detailed and visual explanation on how to use PX4 with ROS 2 see thes
 ## Overview
 
 The application pipeline for ROS 2 is very straightforward, thanks to the native communications middleware (DDS/RTPS).
-The [microRTPS Bridge](../middleware/micrortps.md) consists of a client running on PX4 and an agent running on the ROS computer, which communicate to provide bi-direction message translation between UORB and ROS 2 message formats.
-This allows you to create ROS 2 listener or advertiser nodes that publish and subscribe directly to and from PX4 UORB data!
+The [microRTPS Bridge](../middleware/micrortps.md) consists of a client running on PX4 and an agent running on the Mission/Companion Computer, which communicate to provide bi-directional data exchange and message translation between UORB and ROS 2 message formats.
+This allows you to create ROS 2 subscribers or publisher nodes that interface directly with PX4 UORB topics!
 This is shown in the diagram below.
 
 ![Architecture with ROS 2](../../assets/middleware/micrortps/architecture_ros2.png)
 
 ROS 2 uses the [`px4_msgs`](https://github.com/PX4/px4_msgs) and [`px4_ros_com`](https://github.com/PX4/px4_ros_com) packages to ensure that matching message definitions are used for creating both the client and the agent code (this is important), and also to remove the requirement for PX4 to be present when building ROS code.
-- `px4_msgs` contains PX4 client message definitions. When this project is built it generates the corresponding ROS 2-compatible IDL files.
-- `px4_ros_com` builds the `px4_msgs` project, and then uses the generated IDL files to create (and build) the ROS 2 agent.
+- `px4_msgs` contains PX4 ROS message definitions. When this project is built it generates the corresponding ROS 2-compatible typesupport, used by ROS 2 nodes, and IDL files, used by `fastddsgen` to generate the microRTPS agent code.
+- `px4_ros_com` contains the microRTPS agent code templates for the agent publishers and subscribers. The build process runs a `fastddsgen` instance to generate the code that gets compiled into a single executable that composes the `micrortps_agent`.
 
-The PX4 Autopilot project automatically updates [`px4_msgs`](https://github.com/PX4/px4_msgs) with new message definitions whenever they are changed (in the master branch).
+The PX4 Autopilot project automatically updates [`px4_msgs`](https://github.com/PX4/px4_msgs) with new message definitions whenever they are changed (in the `master` branch).
 
 :::note
-The subset of uORB topics that will be accessible to ROS applications can be found in [px4_msgs/msg](https://github.com/PX4/px4_msgs/tree/master/msg).
+The subset of uORB topics that will be accessible to ROS applications can be found in the (bridge configuration yaml file)[https://github.com/PX4/px4_ros_com/blob/master/templates/urtps_bridge_topics.yaml].
 :::
 
-PX4 firmware contains a microRTPS client based on its build-time message definitions.
-Astute readers will note that since the generated agent might not have been built to that same set of definitions (unless they were both built of the same 'master' commit).
-Right now this is not a problem because the PX4 message set/definitions are relatively stable.
-In the near future the intention is that branches will be created to match with specific PX4 releases.
+PX4 firmware contains the microRTPS client based on its build-time message definitions.
+
+:::note
+Astute readers will note that the generated agent might not have been built with that same set of definitions (unless they were both built of the same 'master' commit).
+
+Right now this is not a problem because 1. the PX4 message set/definitions are relatively stable and 2. the updated/new messages get automatically deployed to `px4_msgs`.
+
+In the near future the intention is to:
+1. Create also a branch per release in both `px4_ros_com` and `px4_msgs`, so both the message definitions and agent code match the ones present on the PX4/client side by the time of the release.
+2. Have an initial message exchange of the brige configuration, using the messages structs MD5SUMs to verify if the messages definitions are the same, and if not, disable their stream and warn the user.
+:::
 
 :::warning
-You cannot use an agent generated as part of a "normal" PX4 build with ROS 2.
-While microRTPS client is the same, the IDL files used by ROS 2 are slightly different than used by normal DDS.
-We use the `px4_msg` to generate appropriate IDL files.
+You cannot use an agent generated as part of a "normal" PX4 build with ROS 2 (e.g. if the user uses `BUILD_MICRORTPS_AGENT=1 make px4_sitl_rtps`).
+While microRTPS client is the same, the IDL files used by ROS 2 are slightly different from the custom ones with generate in PX4. The other detail is that the "normal" PX4 build doesn't use `fastddsgen` with typesupport for ROS 2 networks - and that's also one of the main reasons we have a separate microRTPS agent in `px4_ros_com`, which is completely compatible with ROS 2 networks.
+We use the `px4_msg` to generate appropriate IDL files for the `micrortps_agent` in `px4_ros_com`.
 :::
 
 
@@ -58,7 +65,7 @@ To setup ROS 2 for use with PX4 you will need to:
 
 ### Install Fast DDS
 
-Follow the [Fast DDS Installation Guide](../dev_setup/fast-dds-installation.md) to install **Fast RTPS(DDS) 2.0.0** (or later) and **Fast-RTPS-Gen 1.0.4** (not later!) and their dependencies.
+Follow the [Fast DDS Installation Guide](../dev_setup/fast-dds-installation.md) to install **Fast RTPS(DDS) 2.0.2** (or later) and **Fast-RTPS-Gen 1.0.4** (not later!) and their dependencies.
 
 :::note
 Check the guide to confirm the latest dependencies!
@@ -143,15 +150,11 @@ We can do this by running the bridge against PX4 running in the simulator.
    ```sh
    make px4_sitl_rtps gazebo
    ```
-   Once PX4 has fully started the terminal will display the [NuttShell/System Console](../debug/system_console.md).
+   Once PX4 has fully started the terminal will display the [NuttShell/System Console](../debug/system_console.md). Note also that PX4 SITL will automatically start the `micrortps_client` connected to UDP ports 2019 and 2020.
 1. On a *new* terminal, `source` the ROS 2 workspace and then start the `micrortps_agent` daemon with UDP as the transport protocol:
    ```sh
    $ source ~/px4_ros_com_ros2/install/setup.bash
    $ micrortps_agent -t UDP
-   ```
-1. On the original terminal (System console) start the `micrortps_client` daemon with UDP:
-   ```sh
-   pxh> micrortps_client start -t UDP
    ```
 1. Open a new terminal and start a "listener" using the provided launch file:
    ```sh
@@ -178,7 +181,7 @@ We can do this by running the bridge against PX4 running in the simulator.
    ```
 
 You can also verify the rate of the message using `ros2 topic hz`.
-E.g. in the case of `sensor_combined` use `ros2 topic hz /SensorCombined_PubSubTopic`:
+E.g. in the case of `sensor_combined` use `ros2 topic hz /fmu/sensor_combined/out`:
    ```sh
    average rate: 248.187
    	min: 0.000s max: 0.012s std dev: 0.00147s window: 2724
@@ -227,7 +230,7 @@ This creates a callback function for when the `sensor_combined` uORB messages ar
 public:
 	explicit SensorCombinedListener() : Node("sensor_combined_listener") {
 		subscription_ = this->create_subscription<px4_msgs::msg::SensorCombined>(
-			"SensorCombined_PubSubTopic",
+			"fmu/sensor_combined/out",
 			10,
 			[this](const px4_msgs::msg::SensorCombined::UniquePtr msg) {
 			std::cout << "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n";
@@ -247,7 +250,7 @@ public:
 	}
 ```
 
-The lines below create a subscription to the `sensor_combined_topic` which can be matched with one or more compatible ROS publishers.
+The lines below create a publisher to the `sensor_combined` uORB topic which can be matched with one or more compatible ROS2 subscribers to the `fmu/sensor_combined/out` ROS2 topic.
 
 ```cpp
 private:
@@ -298,7 +301,7 @@ The messages are sent based on a timed callback, which sends two messages per se
 ```cpp
 public:
 	DebugVectAdvertiser() : Node("debug_vect_advertiser") {
-		publisher_ = this->create_publisher<px4_msgs::msg::DebugVect>("DebugVect_PubSubTopic", 10);
+		publisher_ = this->create_publisher<px4_msgs::msg::DebugVect>("fmu/debug_vect/in", 10);
 		auto timer_callback =
 		[this]()->void {
 			auto debug_vect = px4_msgs::msg::DebugVect();
@@ -342,10 +345,10 @@ int main(int argc, char *argv[])
 For a complete reference example on how to use Offboard control with PX4, see: [ROS 2 Offboard control example](../ros/ros2_offboard_control.md).
 
 
-## Manual Workspace Setup (FYI Only)
+## Manual Workspace Setup with a ROS1 compatible workspace (FYI Only)
 
 :::note
-This is provided to help you better understand the build process.
+This is provided to help you better understand the build process and how to include the ROS1 workspace.
 It is not needed to build or use ROS 2.
 It additionally includes instructions for building the `ros1_bridge` package, which is used in [ROS (1) via ROS 2 Bridge](../ros/ros1_via_ros2.md).
 :::

--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -69,7 +69,7 @@ Follow the [Fast DDS Installation Guide](../dev_setup/fast-dds-installation.md) 
 
 :::note
 Check the guide to confirm the latest dependencies!
-You won't be able to continue with this guide until the correct versions of **Fast RTPS(DDS)** and **Fast-RTPS-Gen have been installed.
+You won't be able to continue with this guide until the correct versions of **Fast RTPS(DDS)** and **Fast-RTPS-Gen** have been installed.
 :::
 
 

--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -4,7 +4,6 @@ This topic explains how to setup and use ROS 2 with PX4.
 
 It provides an overview of the ROS2-PX4 bridge architecture and application pipeline, along with instructions on how to install all the needed software and build ROS 2 applications.
 
-
 :::note
 The Fast DDS interface in the PX4 Autopilot can be leveraged by any applications running and linked in DDS domains (including ROS nodes).
 
@@ -28,12 +27,13 @@ This is shown in the diagram below.
 
 ROS 2 uses the [`px4_msgs`](https://github.com/PX4/px4_msgs) and [`px4_ros_com`](https://github.com/PX4/px4_ros_com) packages to ensure that matching message definitions are used for creating both the client and the agent code (this is important), and also to remove the requirement for PX4 to be present when building ROS code.
 - `px4_msgs` contains PX4 ROS message definitions. When this project is built it generates the corresponding ROS 2-compatible typesupport, used by ROS 2 nodes, and IDL files, used by `fastddsgen` to generate the microRTPS agent code.
-- `px4_ros_com` contains the microRTPS agent code templates for the agent publishers and subscribers. The build process runs a `fastddsgen` instance to generate the code that gets compiled into a single executable that composes the `micrortps_agent`.
+- `px4_ros_com` contains the microRTPS agent code templates for the agent publishers and subscribers.
+  The build process runs a `fastddsgen` instance to generate the code for the `micrortps_agent`, which compiles into a single executable.
 
 The PX4 Autopilot project automatically updates [`px4_msgs`](https://github.com/PX4/px4_msgs) with new message definitions whenever they are changed (in the `master` branch).
 
 :::note
-The subset of uORB topics that will be accessible to ROS applications can be found in the (bridge configuration yaml file)[https://github.com/PX4/px4_ros_com/blob/master/templates/urtps_bridge_topics.yaml].
+The subset of uORB topics that will be accessible to ROS applications can be found in the [bridge configuration yaml file](https://github.com/PX4/px4_ros_com/blob/master/templates/urtps_bridge_topics.yaml).
 :::
 
 PX4 firmware contains the microRTPS client based on its build-time message definitions.
@@ -41,16 +41,17 @@ PX4 firmware contains the microRTPS client based on its build-time message defin
 :::note
 Astute readers will note that the generated agent might not have been built with that same set of definitions (unless they were both built of the same 'master' commit).
 
-Right now this is not a problem because 1. the PX4 message set/definitions are relatively stable and 2. the updated/new messages get automatically deployed to `px4_msgs`.
+Right now this is not a problem because the PX4 message set/definitions are relatively stable and the updated/new messages get automatically deployed to `px4_msgs`.
 
 In the near future the intention is to:
 1. Create also a branch per release in both `px4_ros_com` and `px4_msgs`, so both the message definitions and agent code match the ones present on the PX4/client side by the time of the release.
-2. Have an initial message exchange of the brige configuration, using the messages structs MD5SUMs to verify if the messages definitions are the same, and if not, disable their stream and warn the user.
+2. Have an initial message exchange of the bridge configuration, using the messages structs MD5SUMs to verify if the messages definitions are the same, and if not, disable their stream and warn the user.
 :::
 
 :::warning
 You cannot use an agent generated as part of a "normal" PX4 build with ROS 2 (e.g. if the user uses `BUILD_MICRORTPS_AGENT=1 make px4_sitl_rtps`).
-While microRTPS client is the same, the IDL files used by ROS 2 are slightly different from the custom ones with generate in PX4. The other detail is that the "normal" PX4 build doesn't use `fastddsgen` with typesupport for ROS 2 networks - and that's also one of the main reasons we have a separate microRTPS agent in `px4_ros_com`, which is completely compatible with ROS 2 networks.
+While microRTPS client is the same, the IDL files used by ROS 2 are slightly different from the custom ones with generate in PX4.
+The other detail is that the "normal" PX4 build doesn't use `fastddsgen` with typesupport for ROS 2 networks - and that's also one of the main reasons we have a separate microRTPS agent in `px4_ros_com`, which is completely compatible with ROS 2 networks.
 We use the `px4_msg` to generate appropriate IDL files for the `micrortps_agent` in `px4_ros_com`.
 :::
 
@@ -67,7 +68,7 @@ To setup ROS 2 for use with PX4 you will need to:
 
 Follow the [Fast DDS Installation Guide](../dev_setup/fast-dds-installation.md) to install **Fast RTPS(DDS) 2.0.2** (or later) and **Fast-RTPS-Gen 1.0.4** (not later!) and their dependencies.
 
-:::note
+:::warning
 Check the guide to confirm the latest dependencies!
 You won't be able to continue with this guide until the correct versions of **Fast RTPS(DDS)** and **Fast-RTPS-Gen** have been installed.
 :::
@@ -150,7 +151,8 @@ We can do this by running the bridge against PX4 running in the simulator.
    ```sh
    make px4_sitl_rtps gazebo
    ```
-   Once PX4 has fully started the terminal will display the [NuttShell/System Console](../debug/system_console.md). Note also that PX4 SITL will automatically start the `micrortps_client` connected to UDP ports 2019 and 2020.
+   Once PX4 has fully started the terminal will display the [NuttShell/System Console](../debug/system_console.md).
+   Note also that PX4 SITL will automatically start the `micrortps_client` connected to UDP ports 2019 and 2020.
 1. On a *new* terminal, `source` the ROS 2 workspace and then start the `micrortps_agent` daemon with UDP as the transport protocol:
    ```sh
    $ source ~/px4_ros_com_ros2/install/setup.bash
@@ -161,8 +163,7 @@ We can do this by running the bridge against PX4 running in the simulator.
    $ source ~/px4_ros_com_ros2/install/setup.bash
    $ ros2 launch px4_ros_com sensor_combined_listener.launch.py
    ```
-
-
+   
    If the bridge is working correctly you will be able to see the data being printed on the terminal/console where you launched the ROS listener:
 
    ```sh
@@ -196,7 +197,6 @@ E.g. in the case of `sensor_combined` use `ros2 topic hz /fmu/sensor_combined/ou
    average rate: 247.485
    	min: 0.000s max: 0.012s std dev: 0.00148s window: 3960
    ```
-
 
 
 ## ROS 2 Example Applications
@@ -250,7 +250,7 @@ public:
 	}
 ```
 
-The lines below create a publisher to the `sensor_combined` uORB topic which can be matched with one or more compatible ROS2 subscribers to the `fmu/sensor_combined/out` ROS2 topic.
+The lines below create a publisher to the `sensor_combined` uORB topic, which can be matched with one or more compatible ROS2 subscribers to the `fmu/sensor_combined/out` ROS2 topic.
 
 ```cpp
 private:

--- a/en/ros/ros2_offboard_control.md
+++ b/en/ros/ros2_offboard_control.md
@@ -153,12 +153,13 @@ void OffboardControl::publish_trajectory_setpoint() const {
 }
 ```
 
-The above functions exemplify how the fields on both `offboard_control_mode` and `trajectory_setpoint` messages can be set.
+The above functions show how the fields on both `offboard_control_mode` and `trajectory_setpoint` messages can be set.
 Notice that the above example is applicable for offboard position control, where on the `offboard_control_mode` message, the `position` field is set to `true`, while all the others get set to `false`.
 Also, in this case, the `x`, `y`, `z` and `yaw` fields are hardcoded to certain values, but they can be updated dynamically according to an algorithm or even by a subscription callback for messages coming from another node.
 
 :::tip
-The position is already being published in the NED coordinate frame for simplicity, but in the case of the user wanting to subscribe to data coming from other nodes, and since the standard frame of reference in ROS/ROS 2 is ENU, the user can use the available helper functions in the [`frame_transforms` library](https://github.com/PX4/px4_ros_com/blob/master/src/lib/frame_transforms.cpp).
+The position is published in the NED coordinate frame for simplicity.
+If a user wants to subscribe to data coming from nodes that publish in a different frame (for example the ENU, which is the standard frame of reference in ROS/ROS 2), they can use the helper functions in the [frame_transforms](https://github.com/PX4/px4_ros_com/blob/master/src/lib/frame_transforms.cpp) library.
 :::
 
 ```cpp

--- a/en/ros/ros2_offboard_control.md
+++ b/en/ros/ros2_offboard_control.md
@@ -6,13 +6,13 @@ If you are operating on a real vehicle be sure to have a way of gaining back man
 :::
 
 :::warning
-ROS 2 interaction with PX4 through the [*microRTPS* bridge](../middleware/micrortps.md) requires that the user understands how the PX4 internals work!
+ROS 2 interaction with PX4, done through the [*microRTPS* bridge](../ros/ros2_comm.md), requires that the user understands how the PX4 internals work!
 The same understanding is required for PX4 offboard control via ROS 2, where the user publishes directly to the required uORB topics (without any level of abstraction between ROS and PX4 data formats/conventions).
 
 If you are unsure of PX4 internals work, we recommend that you instead use a workflow that depends on the MAVLink microservices and abstraction layer to execute offboard control or any other kind of interaction through the *microRTPS* bridge.
 :::
 
-The following C++ example shows how to use the *microRTPS* bridge to do offboard position control from a ROS 2 node.
+The following C++ example shows how to use the *microRTPS* bridge and the *px4_ros_com* package to do offboard position control from a ROS 2 node.
 
 ## Requirements
 
@@ -21,45 +21,57 @@ Besides that:
 
 1. The user already has their ROS 2 environment properly configured
    Check the [PX4-ROS 2 bridge](../ros/ros2_comm.md) document for details on how to do it.
-1. `px4_msgs` and `px4_ros_com` should be already on your colcon workspace.
+1. *px4_msgs* and *px4_ros_com* should be already on your colcon workspace `src` directory.
    See the link in the previous point for details.
-1. `offboard_control_mode` and `trajectory_setpoint` messages are configured in the `uorb_rtps_message_ids.yaml` file both in the PX4-Autopilot and
+1. `offboard_control_mode` and `trajectory_setpoint` messages are configured in the `urtps_bridge_topics.yaml` file both in the PX4-Autopilot and
 *px4_ros_com* package to be *received* in the Autopilot.
 
-   In *PX4-Autopilot/msg/tools/uorb_rtps_message_ids.yaml*:
+   In *PX4-Autopilot/msg/tools/urtps_bridge_topics.yaml*:
    ```yaml
-     - msg: offboard_control_mode
-       id: 44
-       receive: true
-     ...
-     - msg: vehicle_local_position_setpoint
-       id: 97
-       receive: true
-     ...
-     - msg: trajectory_setpoint
-       id: 196
-       alias: vehicle_local_position_setpoint
-       receive: true
+   - msg:     offboard_control_mode
+     receive: true
+   ...
+   - msg:     vehicle_command
+     receive: true
+   ...
+   - msg:     vehicle_local_position_setpoint
+     receive: true
+   - msg:     trajectory_setpoint # multi-topic / alias of vehicle_local_position_setpoint
+     base:    vehicle_local_position_setpoint
+     receive: true
    ```
 
-   In *path_to_colcon_ws/src/px4_ros_com/templates/uorb_rtps_message_ids.yaml*:
+   In *path_to_colcon_ws/src/px4_ros_com/templates/urtps_bridge_topics.yaml*:
    ```yaml
-     - id: 44
-       msg: OffboardControlMode
-       receive: true
-     ...
-     - msg: VehicleLocalPositionSetpoint
-       id: 97
-       receive: true
-     ...
-     - alias: VehicleLocalPositionSetpoint
-       id: 196
-       msg: TrajectorySetpoint
-       receive: true
+   - msg:     OffboardControlMode
+     receive: true
+   ...
+   - msg:     VehicleCommmand
+     receive: true
+   ...
+   - msg:     VehicleLocalPositionSetpoint
+     receive: true
+   - msg:     TrajectorySetpoint
+     base:    VehicleLocalPositionSetpoint
+     receive: true
    ```
+ 1. `vehicle_command` message is configured in the `urtps_bridge_topics.yaml` file both in the PX4-Autopilot and
+ *px4_ros_com* package to *send* to the Autopilot.
+
+    In *PX4-Autopilot/msg/tools/urtps_bridge_topics.yaml*:
+    ```yaml
+    - msg:     vehicle_command
+      receive: true
+    ```
+
+    In *path_to_colcon_ws/src/px4_ros_com/templates/uorb_rtps_message_ids.yaml*:
+    ```yaml
+    - msg:     VehicleCommmand
+      receive: true
+    ```
 
    :::note
-   At time of writing, the above topics are already configured to be received.
+   At time of writing, the above topic is already configured to be sent.
    :::
 
 ## Implementation
@@ -69,7 +81,7 @@ The source code of the offboard control example can be found in [offboard_contro
 Here are some details about the implementation:
 
 ```cpp
-timesync_sub_ = this->create_subscription<px4_msgs::msg::Timesync>("Timesync_PubSubTopic",
+timesync_sub_ = this->create_subscription<px4_msgs::msg::Timesync>("/fmu/timesync/out",
     10,
     [this](const px4_msgs::msg::Timesync::UniquePtr msg) {
         timestamp_.store(msg->timestamp);
@@ -102,8 +114,8 @@ auto timer_callback = [this]() -> void {
 	}
 ```
 
-The above is the main loop spining on the ROS 2 node.
-It first sends 10 setpoint messages before sending the command to change to offboard mode
+The above is the main loop spinning on the ROS 2 node.
+It first sends 10 setpoint messages before sending the command to allow PX4 to change to offboard mode.
 At the same time, both `offboard_control_mode` and `trajectory_setpoint` messages are sent to the flight controller.
 
 ```cpp
@@ -146,7 +158,7 @@ Notice that the above example is applicable for offboard position control, where
 Also, in this case, the `x`, `y`, `z` and `yaw` fields are hardcoded to certain values, but they can be updated dynamically according to an algorithm or even by a subscription callback for messages coming from another node.
 
 :::tip
-The position is already being published in the NED coordinate frame for simplicity, but in the case of the user wanting to subscribe to data coming from other nodes, and since the standard frame of reference in ROS/ROS 2 is ENU, the user can use the available helper functions in the [`frame_transform` library](https://github.com/PX4/px4_ros_com/blob/master/src/lib/frame_transforms.cpp).
+The position is already being published in the NED coordinate frame for simplicity, but in the case of the user wanting to subscribe to data coming from other nodes, and since the standard frame of reference in ROS/ROS 2 is ENU, the user can use the available helper functions in the [`frame_transforms` library](https://github.com/PX4/px4_ros_com/blob/master/src/lib/frame_transforms.cpp).
 :::
 
 ```cpp
@@ -173,15 +185,11 @@ void OffboardControl::publish_vehicle_command(uint16_t command, float param1,
 }
 ```
 
-As the description suggests, the above code serves the purpose of sending `vehicle_command_publisher` messages with commands to the flight controller.
-
-:::note
-By the time of writing, `vehicle_command_publisher` is also already configured to be received.
-:::
+As the description suggests, the above code serves the purpose of sending `vehicle_command` messages with commands to the flight controller.
 
 ## Usage
 
-After building the colcon workspace, and after starting PX4 SITL and both the microRTPS bridge client and agent:
+After building the colcon workspace, and after starting PX4 SITL (`make px4_sitl_rtps gazebo`, which starts the microRTPS client automatically on UDP ports 2019 and 2020) and the microRTPS agent (`micrortps_agent -t UDP`, starting the agent connected to UDP ports 2020 and 2019):
 
 ```sh
 $ source path_to_colcon_workspace/install/setup.bash

--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -57,11 +57,11 @@ The `MAV_SYS_ID` and various UDP ports are allocated in the SITL rcS: [init.d-po
 
 To simulate multiple vehicles based on RTPS/DDS in Gazebo, use the `gazebo_sitl_multiple_run.sh` command in the terminal with the `-t px4_sitl_rtps` option from the root of the *PX4-Autopilot* tree (as described above).
 Here we will use the `-t px4_sitl_rtps` option, which sets that we will use RTPS for communicating with PX4 rather than the MAVLink Simulation API.
-This will build and run the `iris_rtps` model (the only model that is currently implemented for use with RTPS).
+This will build and runs the `iris` model (can be changed by the `-m` parameter), and **by default also starts the microRTPS client**.
 
 :::note
-You will need to have installed *eProsima Fast DDS* and the `micrortps_agent` should be run in the different terminals for each vehicle.
-For more information see: [RTPS/DDS Interface: PX4-Fast RTPS(DDS) Bridge](../middleware/micrortps.md).
+You will need to have installed or *eProsima Fast DDS* or ROS 2 Foxy or above and the `micrortps_agent` should be run in the different terminals for each vehicle.
+For more information see: [RTPS/DDS Interface: PX4-Fast RTPS(DDS) Bridge](../middleware/micrortps.md), for how to use the interaction with non-ROS2 DDS participant applications, or [ROS 2 User Guide (PX4-ROS 2 Bridge)](../ros/ros2_comm.md), for interfacing with ROS2 nodes.
 :::
 
 To build an example setup, follow the steps below:
@@ -81,7 +81,7 @@ To build an example setup, follow the steps below:
    For example, to spawn 4 vehicles, run:
 
    ```bash
-   ./Tools/gazebo_sitl_multiple_run.sh -t px4_sitl_rtps -m iris -l rtps -n 4
+   ./Tools/gazebo_sitl_multiple_run.sh -t px4_sitl_rtps -m iris -n 4
    ```
 
    :::note
@@ -92,14 +92,14 @@ To build an example setup, follow the steps below:
    For example, to connect 4 vehicles, run:
 
    ```bash
-   micrortps_agent -t UDP -r 2020 -s 2019 &
-   micrortps_agent -t UDP -r 2022 -s 2021 &
-   micrortps_agent -t UDP -r 2024 -s 2023 &
-   micrortps_agent -t UDP -r 2026 -s 2025 &
+   micrortps_agent -t UDP -r 2020 -s 2019 -n vhcl0 &
+   micrortps_agent -t UDP -r 2022 -s 2021 -n vhcl1 &
+   micrortps_agent -t UDP -r 2024 -s 2023 -n vhcl2 &
+   micrortps_agent -t UDP -r 2026 -s 2025 -n vhcl3 &
    ```
    :::note
    In order to communicate with a specific instance of PX4 using ROS2, you must use the `-n <namespace>` option.
-   For example, running `micrortps_agent -t UDP -r 2020 -s 2019 -n vhcl0` will result in the agent publishing all its topics with the namespace prefix `/vhcl0`.
+   For example, running `micrortps_agent -t UDP -r 2020 -s 2019 -n vhcl0` will result in the agent publishing all its topics with the namespace prefix `/vhcl0` (eg. `sensor_combined` data from `vhcl0` will be published on the topic `/vhcl0/fmu/sensor_combined/out`, while if one wants to send commands to the same vehicle, it has to publish to topic `/vhcl0/fmu/vehicle_command/in`).
    You can then subscribe and publish to just that vehicle's topics.
    :::
 

--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -57,7 +57,7 @@ The `MAV_SYS_ID` and various UDP ports are allocated in the SITL rcS: [init.d-po
 
 To simulate multiple vehicles based on RTPS/DDS in Gazebo, use the `gazebo_sitl_multiple_run.sh` command in the terminal with the `-t px4_sitl_rtps` option from the root of the *PX4-Autopilot* tree (as described above).
 Here we will use the `-t px4_sitl_rtps` option, which sets that we will use RTPS for communicating with PX4 rather than the MAVLink Simulation API.
-This will build and runs the `iris` model (can be changed by the `-m` parameter), and **by default also starts the microRTPS client**.
+This builds and runs the `iris` model and **by default also starts the microRTPS client** (you can change the model using the `-m` parameter).
 
 :::note
 You will need to have installed or *eProsima Fast DDS* or ROS 2 Foxy or above and the `micrortps_agent` should be run in the different terminals for each vehicle.


### PR DESCRIPTION
Brings some updates and cleanup to relevant parts of the the documentation for the install and usage of microRTPS and ROS2 with PX4, also following the updates in the latest big updates to the bridge UX and functionalities.