### PR TITLE
Fix uorb graph - add script type

### DIFF
--- a/en/middleware/uorb_graph.md
+++ b/en/middleware/uorb_graph.md
@@ -16,11 +16,12 @@ Preset: <select id ="select-graph" name="select-graph">
 </select>
 <br/>
 <svg id="svg-graph" width="1200" height="1400" style="text-align: center; margin-left: -230px; margin-right: -230px;"></svg>
-<script src="https://d3js.org/d3.v4.min.js"></script>
-<script src="uorb_graph.js"></script>
+<script type="application/javascript" src="https://d3js.org/d3.v4.min.js" asysc></script>
+<script type="application/javascript" src="uorb_graph.js" asysc></script>
 
 
 ## Graph Properties
+
 The graph has the following properties:
 
 - Modules are shown in gray with rounded corners while topics are displayed as coloured rectangular boxes.


### PR DESCRIPTION
Scripts are assumed to be element tags unless the type is specified. Results in stupid unhelpful vuepress error. This works in dev build. 