### PR TITLE
Document FW_T_CLMB_R_SP and FW_T_SINK_R_SP tecs parameters - v2

### DIFF
--- a/en/config_fw/advanced_tuning_guide_fixedwing.md
+++ b/en/config_fw/advanced_tuning_guide_fixedwing.md
@@ -56,6 +56,11 @@ Set the following parameters:
 
 #### 3rd: Pitch & Climb Rate Limits
 
+:::warning
+Do not use [FW_T_CLMB_MAX](../advanced_config/parameter_reference.md#FW_T_CLMB_MAX), [FW_T_SINK_MAX](../advanced_config/parameter_reference.md#FW_T_SINK_MAX) or [FW_T_SINK_MIN](../advanced_config/parameter_reference.md#FW_T_SINK_MIN) to specify the desired climb or sink performance you would like to get from the vehicle!
+The parameters define the operating limitations and they should be set during the tuning phase, as described below.
+:::
+
 Fly in stabilized mode, apply full throttle (`FW_THR_MAX`) and slowly increase the pitch angle of the vehicle until the airspeed reaches `FW_AIRSPD_TRIM`.
 - [FW_P_LIM_MAX](../advanced_config/parameter_reference.md#FW_P_LIM_MAX) - set to the pitch angle required to climb at trim airspeed when applying `FW_THR_MAX`.
 - [FW_T_CLMB_MAX](../advanced_config/parameter_reference.md#FW_T_CLMB_MAX) - set to the climb rate achieved during the climb at `FW_AIRSPD_TRIM`.
@@ -66,6 +71,11 @@ Fly in stabilized mode, reduce the throttle to `FW_THR_MIN` and slowly decrease 
 
 Fly in stabilized mode, reduce throttle to `FW_THR_MIN` and adjust the pitch angle such that the plane maintains `FW_AIRSPD_TRIM`.
 - [FW_T_SINK_MIN](../advanced_config/parameter_reference.md#FW_T_SINK_MIN) - set to the sink rate achieved while maintaining `FW_AIRSPD_TRIM`.
+
+Specify the target climb and sink rate for autonomous missions by adjusting [FW_T_CLMB_R_SP](../advanced_config/parameter_reference.md#FW_T_CLMB_R_SP) and [FW_T_SINK_R_SP](../advanced_config/parameter_reference.md#FW_T_SINK_R_SP).
+These specify the height rates at which the vehicle will climb or descend in order to change altitude.
+Furthermore, these two values define the height rate limits commanded by the user in [Altitude mode](../flight_modes/altitude_fw.md) and [Position mode](../flight_modes/position_fw.md).
+
 
 ### L1 Controller Tuning (Position)
 


### PR DESCRIPTION
This replaces #1527, which was updating the German translation. Moves the warning to top of section and fixes links to point to FW rather than MC mode docs.

@RomanBapst FYI, would be good if you could scan how this ended up :-). I will merge. CI not working, but I'll build this next week. 