### PR TITLE
Add further information on vehicle_local_position

### DIFF
--- a/en/msg_docs/README.md
+++ b/en/msg_docs/README.md
@@ -173,7 +173,7 @@ the field 'timestamp' is for the position & velocity (microseconds)
 - [vehicle_imu](vehicle_imu.md) — IMU readings in SI-unit form.
 - [vehicle_imu_status](vehicle_imu_status.md)
 - [vehicle_land_detected](vehicle_land_detected.md)
-- [vehicle_local_position](vehicle_local_position.md) — Fused local position in NED.
+- [vehicle_local_position](vehicle_local_position.md) — Fused local position in NED. The origin of the coordinate system is the vehicle's position at the time when the EKF2-module was started.
 - [vehicle_local_position_setpoint](vehicle_local_position_setpoint.md) — Local position setpoint in NED frame
 setting something to NaN means the state should not be controlled
 - [vehicle_magnetometer](vehicle_magnetometer.md)


### PR DESCRIPTION
It wasn't clear to me, where the origin of vehicle_local_position is. When I asked in slack @bresch confirmed, that it is the vehicle's position at boot time (start of EKF2 mdoule). I thought the information might be helpful to others, too.