### PR TITLE
Removed link to inactive webshop

### DIFF
--- a/en/peripherals/companion_computer_peripherals.md
+++ b/en/peripherals/companion_computer_peripherals.md
@@ -24,7 +24,6 @@ Options are listed below:
 
 Device | 3.3v IO (Default) | Flow Control | Tx/Rx LEDs | JST-GH
 --- | --- | --- | --- | ---
-[PixDev FTDI JST-GH Breakout](https://pixdev.myshopify.com/products/ftdi-breakout-jst-gh) | Yes | Yes | Yes | Yes
 [mRo USB FTDI Serial to JST-GH (Basic)](https://store.mrobotics.io/USB-FTDI-Serial-to-JST-GH-p/mro-ftdi-jstgh01-mr.htm) | Capable | Capable | No | Yes
 [SparkFun FTDI Basic Breakout](https://www.sparkfun.com/products/9873) | Yes | No | Yes | No
 


### PR DESCRIPTION
Reason: The linked webshop still seems to operate (based on the website), but the shop itself is not. I ordered through the webshop but nothing ever shipped and emails are not being answered. According to a forum posts ( https://community.shopify.com/c/shopify-discussions/how-to-reach-out-a-non-performing-vendor-how-to-understand-a/m-p/1266655/highlight/true#M252691 ) on the web this is not the first instance of not delivered products.