### PR TITLE
Pixracer telemetry documentation

### DIFF
--- a/en/flight_controller/pixracer.md
+++ b/en/flight_controller/pixracer.md
@@ -60,6 +60,12 @@ Setup and telemetry are already available, firmware upgrade is already supported
 * [Custom ESP8266 MAVLink firmware](https://github.com/dogmaphobic/mavesp8266)
 
 
+### Configuring Wifi telemetry
+The pictures in the wiring diagram below suggest, that a Wifi module can optionally also be plugged into TELEM2. This is possible, but requires further configuration, for example by modifying the parameter [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG) to specify that second mavlink instance should be running on the TELEM2 port.
+
+For more information on configuring mavlink instances, see the page on [Mavlink peripherals](../peripherals/mavlink_peripherals.md#mavlink-instances). And for additional information on configuring serial ports in general, see the instructions for [configuring serial ports](../peripherals/serial_configuration.md).
+
+
 ## Wiring Diagrams
 
 ![Grau setup pixracer top](../../assets/flight_controller/pixracer/grau_setup_pixracer_top.jpg)

--- a/en/flight_controller/pixracer.md
+++ b/en/flight_controller/pixracer.md
@@ -52,7 +52,7 @@ The Pixracer is designed to use a separate avionics power supply. This is necess
 One of the main features of the board is its ability to use Wifi for flashing new firmware, system setup and in-flight telemetry. 
 This frees it of the need of any desktop system.
 
-::note ToDo
+:::note ToDo:
 Setup and telemetry are already available, firmware upgrade is already supported by the default bootloader but not yet enabled
 :::
 

--- a/en/peripherals/serial_configuration.md
+++ b/en/peripherals/serial_configuration.md
@@ -43,9 +43,9 @@ All the serial drivers/ports are configured in the same way:
 The [GPS/Compass > Secondary GPS](../gps_compass/README.md#dual_gps) section provides a practical example of how to configure a port in *QGroundControl* (it shows how to use `GPS_2_CONFIG` to run a secondary GPS on the `TELEM 2` port).
 
 
-## Deconficting Ports
+## Deconflicting Ports
 
-Port conflicts are handled by system startup, which ensures that at most one service is run on a specific port.
+Port conflicts are handled by system startup, which ensures that at most one service is run on a specific port. For example, it is not possible to start a mavlink instance on a specific serial device, and then launch a driver that uses the same serial device.
 
 :::warning
 At time of writing there is no user feedback about conflicting ports.

--- a/en/telemetry/esp8266_wifi_module.md
+++ b/en/telemetry/esp8266_wifi_module.md
@@ -39,6 +39,7 @@ Using *QGroundControl*:
 - [Load recent PX4 firwmare onto the flight controller](../config/firmware.md).
 - [Configure the serial port](../peripherals/serial_configuration.md) used to connect the ESP8266.
   Remember to set the baud rate to 921600 in order to match the value set for the ESP8266.
+- [Configure mavlink](../peripherals/mavlink_peripherals.md) on the corresponding serial port in order to receive telemetry and transmit commands over the ESP8266.
 
 Once you have configured the flight controller serial port used for connecting to the radio, you can remove the physical USB connection between the ground station and the vehicle.
 


### PR DESCRIPTION
As explained on slack, I found the configuration of the telemetry on the pixracer non-trivial when using any other port than the default port. 

Here's the original slack message:
> 
> I just struggled for half an hour to setup the Pixracer with an ESP8266 WiFi module. I had the module connected to the TELEM2 port, but the documentation I saw did not mention what I'd have to do afterwards.
> 
> The solution was to change parameter MAV_2_CONFIG from WiFi Port, to TELEM 2 . After a reboot, PX4 will then successfully open a mavlink stream on /dev/ttyS2 instead of /dev/ttyS0 on the pixracer.
> 
> I was particularly confused because the Pixracer page https://docs.px4.io/master/en/flight_controller/pixracer.html even mentions (text in the image), that when plugging a wifi module into telem2, it should work out of the box.
> The page on ESP8266 Wifi modules https://docs.px4.io/master/en/telemetry/esp8266_wifi_module.html also does not mention how to configure mavlink streams.
> The page on mavlink telemetry https://docs.px4.io/master/en/peripherals/mavlink_peripherals.html#mavlink-instances explains exactly the step I had to perform. 