### PR TITLE
dev_env_mac.md note on brew update breaking make

### DIFF
--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -29,6 +29,11 @@ To build other targets you will need to use a [different OS](../dev_setup/dev_en
 
 The installation of Homebrew is quick and easy: [installation instructions](https://brew.sh).
 
+Note that with PX4 make, the exact versions of tools like CMake are cached in the build. If you do a `brew update` it will automatically 
+delete older versions and your build can fail searching for executables in `/usr/local/Cellar` the fix is to run `make clean` which
+will update all the links into Homebrew with the correct versions. Alternatively if you want to pin the Cmake or other version, you can do a 
+`brew install cmake@3.21.2` for example to ensure that the link is always there.
+
 ## Enable more open files (Handle "LD: too many open files" error)
 
 Create the `~/.zshenv` file or append it (by running `open ~/.zshenv` on the terminal) and add this line:


### PR DESCRIPTION
If you do a brew update after you initially run make, then all the hard links that CMAke has into /usr/local/Cellar may point to older versions like as an example
recently, a brew update bumped Cmake to ../Cellar/cmake/3.21.3/bin/cmake and so the hard link that PX4 make has to /usr/local/Cellar/camke/3.21.2/cmake will become invalid and the make will fail.the 

The fix is to run make clean when you get not found messages. (You could also do a brew install cmake@3.21.2 if you want to hard install and pin the cmake build