### PR TITLE
Improve quadchute docs

### DIFF
--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -250,7 +250,7 @@ If triggered, the vehicle will immediately switch to multicopter mode.
 If the vehicle was in [Mission mode](../flight_modes/mission.md) it enters failsafe [Return mode](../flight_modes/return.md).
 
 :::note
-The quadchote can also be triggered by sending a MAVLINK [MAV_CMD_DO_VTOL_TRANSITION](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_VTOL_TRANSITION) message with `param2` set to `1`.
+The quadchute can also be triggered by sending a MAVLINK [MAV_CMD_DO_VTOL_TRANSITION](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_VTOL_TRANSITION) message with `param2` set to `1`.
 :::
 
 The parameters that control when the quadchute will trigger are listed in the table below.

--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -245,19 +245,22 @@ Parameter | Description
 
 ### QuadChute Failsafe
 
-Failsafe for when a pusher motor fails (or airspeed sensor or control surface) and a VTOL vehicle can no longer fly in fixed-wing mode.
-If triggered, the vehicle will immediately switch to multicopter mode. If the vehicle was in [Mission mode](../flight_modes/mission.md) it enters failsafe [Return mode](../flight_modes/return.md).
+Failsafe for when a VTOL vehicle can no longer fly in fixed-wing mode, perhaps because a pusher motor, airspeed sensor or control surface failed.
+If triggered, the vehicle will immediately switch to multicopter mode.
+If the vehicle was in [Mission mode](../flight_modes/mission.md) it enters failsafe [Return mode](../flight_modes/return.md).
 
-A quadchute can be triggered on several parametrized conditions, see the table below. It can also be triggered by sending a MAVLINK [MAV_CMD_DO_VTOL_TRANSITION](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_VTOL_TRANSITION) message with Param2 set to 1.
+:::note
+The quadchote can also be triggered by sending a MAVLINK [MAV_CMD_DO_VTOL_TRANSITION](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_VTOL_TRANSITION) message with `param2` set to `1`.
+:::
 
-The relevant parameters are shown below:
+The parameters that control when the quadchute will trigger are listed in the table below.
 
 Parameter | Description
 --- | ---
 [VT_FW_ALT_ERR](../advanced_config/parameter_reference.md#VT_FW_ALT_ERR) | Maximum negative altitude error for fixed wing flight. If the altitude drops more than this value below the altitude setpoint the vehicle will transition back to MC mode and enter failsafe RTL.
-[VT_FW_MIN_ALT](../advanced_config/parameter_reference.md#VT_FW_MIN_ALT) | Minimum altitude for fixed wing flight, when in fixed wing the altitude drops below this altitude the vehicle will transition back to MC mode and enter failsafe RTL.
-[VT_FW_QC_P](../advanced_config/parameter_reference.md#VT_FW_QC_P) | Maximum pitch angle before QuadChute engages Above this the vehicle will transition back to MC mode and enter failsafe RTL.
-[VT_FW_QC_R](../advanced_config/parameter_reference.md#VT_FW_QC_R) | Maximum roll angle before QuadChute engages Above this the vehicle will transition back to MC mode and enter failsafe RTL.
+[VT_FW_MIN_ALT](../advanced_config/parameter_reference.md#VT_FW_MIN_ALT) | Minimum altitude for fixed wing flight. When the altitude drops below this value in fixed wing flight the vehicle will transition back to MC mode and enter failsafe RTL.
+[VT_FW_QC_P](../advanced_config/parameter_reference.md#VT_FW_QC_P) | Maximum pitch angle before QuadChute engages. Above this the vehicle will transition back to MC mode and enter failsafe RTL.
+[VT_FW_QC_R](../advanced_config/parameter_reference.md#VT_FW_QC_R) | Maximum roll angle before QuadChute engages. Above this the vehicle will transition back to MC mode and enter failsafe RTL.
 
 
 <span id="failure_detector"></span>

--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -243,21 +243,21 @@ Parameter | Description
 --- | ---
 [NAV_TRAFF_AVOID](../advanced_config/parameter_reference.md#NAV_TRAFF_AVOID) | Set the failsafe action: Disabled, Warn, Return mode, Land mode.
 
-### Adaptive QuadChute Failsafe
+### QuadChute Failsafe
 
-Failsafe for when a pusher motor fails (or airspeed sensor) and a VTOL vehicle can no longer achieve a desired altitude setpoint in fixed-wing mode.
-If triggered, the vehicle will transition to multicopter mode and enter failsafe [Return mode](../flight_modes/return.md).
+Failsafe for when a pusher motor fails (or airspeed sensor or control surface) and a VTOL vehicle can no longer fly in fixed-wing mode.
+If triggered, the vehicle will immediately switch to multicopter mode. If the vehicle was in [Mission mode](../flight_modes/mission.md) it enters failsafe [Return mode](../flight_modes/return.md).
 
-:::note
-You can pause *Return mode* and transition back to fixed wing if desired.
-Note that if the condition that caused the failsafe still exists, it may trigger again!
-:::
+A quadchute can be triggered on several parametrized conditions, see the table below. It can also be triggered by sending a MAVLINK [MAV_CMD_DO_VTOL_TRANSITION](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_VTOL_TRANSITION) message with Param2 set to 1.
 
 The relevant parameters are shown below:
 
 Parameter | Description
 --- | ---
 [VT_FW_ALT_ERR](../advanced_config/parameter_reference.md#VT_FW_ALT_ERR) | Maximum negative altitude error for fixed wing flight. If the altitude drops more than this value below the altitude setpoint the vehicle will transition back to MC mode and enter failsafe RTL.
+[VT_FW_MIN_ALT](../advanced_config/parameter_reference.md#VT_FW_MIN_ALT) | Minimum altitude for fixed wing flight, when in fixed wing the altitude drops below this altitude the vehicle will transition back to MC mode and enter failsafe RTL.
+[VT_FW_QC_P](../advanced_config/parameter_reference.md#VT_FW_QC_P) | Maximum pitch angle before QuadChute engages Above this the vehicle will transition back to MC mode and enter failsafe RTL.
+[VT_FW_QC_R](../advanced_config/parameter_reference.md#VT_FW_QC_R) | Maximum roll angle before QuadChute engages Above this the vehicle will transition back to MC mode and enter failsafe RTL.
 
 
 <span id="failure_detector"></span>


### PR DESCRIPTION
I specified the different ways of triggering a quadchute. 

I also took out the note that you can retransition to FW mode again as it wasn't really true the way it was written. The real situation is more complex as you need to reset the `transition_failure` flag either by switching to MC mode on your transmitter if in manual mode or by sending a transition-to-MC mavlink command if in auto mode.

To note that QGC to my knowledge doesn't send transition-to-MC commands if the drone is already in MC mode. 

So instead of mentioning all of this I thought the page is clearer if we just don't mention it at all.

If you prefer to add it ok for me too.