### PR TITLE
Additional Python packages for building PX4 on Mac

### DIFF
--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -57,9 +57,9 @@ Install the required Python packages
 
 ```sh
 # install required packages using pip3
-python3 -m pip install --user pyserial empy toml numpy pandas jinja2 pyyaml pyros-genmsg packaging
+python3 -m pip install --user pyserial empy toml numpy pandas jinja2 pyyaml pyros-genmsg packaging kconfiglib future jsonschema
 # if this fails with a permissions error, your Python install is in a system path - use this command instead:
-sudo -H python3 -m pip install --user pyserial empy toml numpy pandas jinja2 pyyaml pyros-genmsg packaging
+sudo -H python3 -m pip install --user pyserial empy toml numpy pandas jinja2 pyyaml pyros-genmsg packaging kconfiglib future jsonschema
 ```
 
 ## Gazebo Simulation


### PR DESCRIPTION
After going through the documentation I found that to get a build of PX4 it was necessary to add the following packages:

pip3 install kconfiglib
pip3 install future
pip3 install jsonschema

After installing these packages I was able to build successfully.