### PR TITLE
Autotune video and cross links

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -124,7 +124,7 @@
   * [Multicopter Config/Tuning](config_mc/README.md)
     * [MC Filter/Control Latency Tuning](config_mc/filter_tuning.md)
     * [MC PID Tuning (Manual/Basic)](config_mc/pid_tuning_guide_multicopter_basic.md)
-    * [MC PID Tuning Guide (Manual/Detailed)](config_mc/pid_tuning_guide_multicopter.md)
+    * [MC PID Tuning Guide (Manual/Advanced)](config_mc/pid_tuning_guide_multicopter.md)
     * [MC Setpoint Tuning (Trajectory Generator)](config_mc/mc_trajectory_tuning.md)
       * [MC Jerk-limited Type Trajectory](config_mc/mc_jerk_limited_type_trajectory.md)
     * [Multicopter Racer Setup](config_mc/racer_setup.md)

--- a/en/config/autotune.md
+++ b/en/config/autotune.md
@@ -13,11 +13,8 @@ The airframe must fly well enough handle moderate disturbances, and should be cl
 - Verify that the vehicle flies well after tuning.
 :::
 
-<!--
-Overview of the auto-tuning workflow
+@[youtube](https://youtu.be/5xswOhhqrIQ)
 
-@[youtube](https://youtu.be/uHVlIIydcpg)
--->
 
 ## Pre-tuning Test
 

--- a/en/config_fw/pid_tuning_guide_fixedwing.md
+++ b/en/config_fw/pid_tuning_guide_fixedwing.md
@@ -1,24 +1,25 @@
 # Fixed-wing PID Tuning Guide
 
-This guide explains how to tune the fixed_wing PID loop. 
-
-:::warning
-This guide is for advanced users / experts only.
-Incorrect PID tuning may crash your aircraft.
-:::
+This guide explains how to manually tune the fixed wing PID loop.
+It is intended for advanced users / experts, as incorrect PID tuning may crash your aircraft.
 
 :::note
+[Autotune](config/autotune.md) is recommended for most users, as it is far faster, easier and provides good tuning for most frames.
+Manual tuning is recommended for frames where autotuning does not work, or where fine-tuning is essential.
+:::
+
+:::tip
+Tuning parameters are documented in the [Parameter Reference](../advanced_config/parameter_reference.md).
+The most important parameters are covered in this guide.
+:::
+
+## Preconditions
+
 - Incorrectly set gains during tuning can make attitude control unstable.
   A pilot tuning gains should therefore be able to fly and land the plane in [manual](../flight_modes/manual_fw.md) (override) control.
 - Excessive gains (and rapid servo motion) can violate the maximum forces of your airframe - increase gains carefully.
 - Roll and pitch tuning follow the same sequence.
   The only difference is that pitch is more sensitive to trim offsets, so [trimming](../config_fw/trimming_guide_fixedwing.md) has to be done carefully and integrator gains need more attention to compensate this.
-:::
-
-:::tip
-All parameters are documented in the [Parameter Reference](../advanced_config/parameter_reference.md).
-The most important parameters are covered in this guide.
-:::
 
 ## Establishing the Airframe Baseline
 
@@ -30,7 +31,8 @@ Even if you can't note all the quantities immediately on paper, the log file wil
 All these quantities will be automatically logged.
  You only need to take notes if you want to directly move on to tuning without looking at the log files.
   
-- Fly level with a convenient airspeed. Note throttle stick position and airspeed (example: 70% → 0.7 throttle, 15 m/s airspeed).
+- Fly level with a convenient airspeed.
+  Note throttle stick position and airspeed (example: 70% → 0.7 throttle, 15 m/s airspeed).
 - Climb with maximum throttle and sufficient airspeed for 10-30 seconds (example: 12 m/s airspeed, climbed 100 m in 30 seconds).
 - Descend with zero throttle and reasonable airspeed for 10-30 seconds (example: 18 m/s airspeed, descended 80 m in 30 seconds).
 - Bank hard right with full roll stick until 60 degrees roll, then bank hard left with full roll stick until 60 degrees in the opposite side.

--- a/en/config_mc/README.md
+++ b/en/config_mc/README.md
@@ -1,3 +1,10 @@
 # Multicopter Configuration
 
 This section contains topics related to multicopter configuration and tuning.
+
+* [MC Filter/Control Latency Tuning](../config_mc/filter_tuning.md)
+* [MC PID Tuning (Manual/Basic)](../config_mc/pid_tuning_guide_multicopter_basic.md)
+* [MC PID Tuning Guide (Manual/Detailed)](../config_mc/pid_tuning_guide_multicopter.md)
+* [MC Setpoint Tuning (Trajectory Generator)](../config_mc/mc_trajectory_tuning.md)
+  * [MC Jerk-limited Type Trajectory](../config_mc/mc_jerk_limited_type_trajectory.md)
+* [Multicopter Racer Setup](../config_mc/racer_setup.md)

--- a/en/config_mc/pid_tuning_guide_multicopter.md
+++ b/en/config_mc/pid_tuning_guide_multicopter.md
@@ -1,13 +1,14 @@
-# Multicopter PID Tuning Guide (Advanced/Detailed)
+# Multicopter PID Tuning Guide (Manual/Advanced)
 
 This topic provides detailed information about PX4 controllers, and how they are tuned.
 
 :::tip
-We recommend that you follow the [basic PID tuning guide](pid_tuning_guide_multicopter_basic.md) for tuning the vehicles _around the hover thrust point_, as the approach described is intuitive, easy, and fast.
+[Autotune](config/autotune.md) is recommended for tuning the vehicles _around the hover thrust point_, as the approach described is intuitive, easy, and fast.
 This is all that is required for many vehicles.
 :::
 
-Use this topic when tuning around the hover thrust point is not sufficient (e.g. on vehicles where there are non-linearities and oscillations at higher thrusts). It is also useful for a deeper understanding of how the basic tuning works, and to understand how to use the [airmode](#airmode-mixer-saturation) setting.
+Use this topic when tuning around the hover thrust point is not sufficient (e.g. on vehicles where there are non-linearities and oscillations at higher thrusts).
+It is also useful for a deeper understanding of how the basic tuning works, and to understand how to use the [airmode](#airmode-mixer-saturation) setting.
 
 ## Tuning Steps
 

--- a/en/config_mc/pid_tuning_guide_multicopter_basic.md
+++ b/en/config_mc/pid_tuning_guide_multicopter_basic.md
@@ -1,19 +1,16 @@
-# Multicopter PID Tuning Guide
+# Multicopter PID Tuning Guide (Manual/Basic)
 
-This tutorial explains how to tune the PID loops on PX4 for all [multicopter setups](../airframes/airframe_reference.md#copter) (Quads, Hexa, Octo etc).
-
-Tuning is recommended for all new vehicle setups, because relatively small hardware and assembly changes can affect the gains required tuning gains for optimal flight.
-For example, different ESCs or motors require different tuning gains.
+This tutorial explains how to _manually_ tune the PID loops on PX4 for all [multicopter setups](../airframes/airframe_reference.md#copter) (Quads, Hexa, Octo etc).
 
 :::tip
-Generally if you're using an appropriate [supported airframe configuration](../airframes/airframe_reference.md#copter) (selected from [QGroundControl > Airframe](../config/airframe.md)), the default tuning should allow you to fly the vehicle safely.
-To get the _very best_ performance we recommend you tune your new vehicle.
+[Autotune](config/autotune.md) is recommended for most users, as it is far faster, easier and provides good tuning for most frames.
+Manual tuning is recommended for frames where autotuning does not work, or where fine-tuning is essential.
 :::
 
-:::warning
-Poorly tuned vehicles are likely to be unstable, and easy to crash.
-Make sure to have assigned a [Kill switch](../config/safety.md#emergency-switches).
-:::
+Generally if you're using an appropriate [supported airframe configuration](../airframes/airframe_reference.md#copter), the default tuning should allow you to fly the vehicle safely.
+Tuning is recommended for all new vehicle setups to get the _very best_ performance, because relatively small hardware and assembly changes can affect the gains required tuning gains for optimal flight.
+For example, different ESCs or motors change the optimal tuning gains.
+
 
 ## Introduction
 
@@ -42,7 +39,6 @@ Then adjust the sliders (as discussed below) to improve the tracking of the resp
 
 ## Preconditions
 
-- You are using the QGroundControl [**daily build**](https://docs.qgroundcontrol.com/master/en/releases/daily_builds.html) (the latest tuning UI will be in the next release build after March 2021).
 - You have selected the closest matching [default airframe configuration](../config/airframe.md) for your vehicle.
   This should give you a vehicle that already flies.
 - You should have done an [ESC calibration](../advanced_config/esc_calibration.md).
@@ -57,6 +53,11 @@ Then adjust the sliders (as discussed below) to improve the tracking of the resp
 - Use a high-rate telemetry link such as WiFi if at all possible (a typical low-range telemetry radio is not fast enough for real-time feedback and plots).
   This is particularly important for the rate controller.
 - Disable [MC_AIRMODE](../advanced_config/parameter_reference.md#MC_AIRMODE) before tuning a vehicle (there is an options for this in the PID tuning screen).
+
+:::warning
+Poorly tuned vehicles are likely to be unstable, and easy to crash.
+Make sure to have assigned a [Kill switch](../config/safety.md#emergency-switches).
+:::
 
 ## Tuning Procedure
 


### PR DESCRIPTION
This adds a video for autotuning. It also updates the manual PID tuning topics with links to the autotuning topic and information on when you would want to use the manual topic.

Essentially it says "use autotune" unless you can't.