### PR TITLE
Crowdin-Remove validations

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,3 @@
 files:
   - source: /en/**/*.md
     translation: /%two_letters_code%/**/%original_file_name%
-    update_option: update_as_unapproved


### PR DESCRIPTION
What I envisaged when I set this up was that only approved strings would be published. When the source file changes the translation would be marked as unapproved but the translation would be saved. Because we publish only approved strings this would result in the English string being displayed but the old translation being available for immediate approval and republishing.
In other words, someone makes a minor change to the English that does revert the translation to English, but the translation is not lost.

However none of the strings are validated, so we never "only published validated strings" and hence impact on of updating the English is no change in he published translation.

What I have done is removed this option in the crowdin yaml file
```
    update_option: update_as_unapproved
```

Now when a string changes in the underlying Engish version the translation will be dumped in the translation. 

Docs on the setting are here: https://support.crowdin.com/configuration-file/?q=configuration%20file#changed-strings-update