### PR TITLE
Fixed wing manual pid - remove PSP_OFFSET

### DIFF
--- a/en/config_fw/pid_tuning_guide_fixedwing.md
+++ b/en/config_fw/pid_tuning_guide_fixedwing.md
@@ -56,7 +56,6 @@ To tune this gain, set the other gains to zero.
 
 - FW_RR_I = 0
 - FW_RR_P = 0
-- FW_RSP_OFF = 0
 
 
 #### Gains to tune
@@ -88,8 +87,6 @@ To tune this gain, set the other gains to zero.
 
 - FW_PR_I = 0
 - FW_PR_P = 0
-- FW_PSP_OFF = 0
-
 
 #### Gains to tune
 

--- a/en/config_fw/pid_tuning_guide_fixedwing.md
+++ b/en/config_fw/pid_tuning_guide_fixedwing.md
@@ -8,13 +8,10 @@ It is intended for advanced users / experts, as incorrect PID tuning may crash y
 Manual tuning is recommended for frames where autotuning does not work, or where fine-tuning is essential.
 :::
 
-:::tip
-Tuning parameters are documented in the [Parameter Reference](../advanced_config/parameter_reference.md).
-The most important parameters are covered in this guide.
-:::
-
 ## Preconditions
 
+- Trims must be configured first (before PID turning).
+  The [Fixed-Wing Trimming Guide](../config_fw/trimming_guide_fixedwing.md) explains how.
 - Incorrectly set gains during tuning can make attitude control unstable.
   A pilot tuning gains should therefore be able to fly and land the plane in [manual](../flight_modes/manual_fw.md) (override) control.
 - Excessive gains (and rapid servo motion) can violate the maximum forces of your airframe - increase gains carefully.
@@ -113,3 +110,9 @@ The default of 0.5 seconds should be fine for normal fixed-wing setups and usual
 
 - [FW_P_TC](../advanced_config/parameter_reference.md#FW_P_TC) - set to a default of 0.5 seconds, increase to make the Pitch response softer, decrease to make the response harder.
 - [FW_R_TC](../advanced_config/parameter_reference.md#FW_R_TC) - set to a default of 0.5 seconds, increase to make the Roll response softer, decrease to make the response harder.
+
+
+## Other Tuning Parameters
+
+The most important parameters are covered in this guide.
+Additional tuning parameters are documented in the [Parameter Reference](../advanced_config/parameter_reference.md).


### PR DESCRIPTION
Fixes #1709

@sfuhrer I am not at all sure this is correct. Your response in https://github.com/PX4/PX4-user_guide/issues/1709#issuecomment-1004701509 was

> ... let's remove this line. In my eyes the PSP_OFFSET is independent of the tuning gains, so I would set it first thing and then don't though it again.

So, line removed. I also removed `FW_RSP_OFF ` when tuning roll.

But you said "I would set it first thing". How do we set it? This does not appear to be covered in the document?