### PR TITLE
Adding TF-G2 autogyro to list of fully assembled vehicles

### DIFF
--- a/en/complete_vehicles/README.md
+++ b/en/complete_vehicles/README.md
@@ -12,6 +12,8 @@ You can find others on [px4.io](https://px4.io/ecosystem/commercial-systems/) an
 
 This section lists vehicles that are sold fully assembled and ready to fly (RTF), with PX4 installed.
 
+* Autogyro
+  * [ThunderFly TF-G2](https://www.thunderfly.cz/tf-g2.html)
 * Multicopter
   * [Teal One](https://tealdrones.com/teal-one/)
   * [ModalAI m500](https://modalai.com/products/voxl-m500)
@@ -20,7 +22,7 @@ This section lists vehicles that are sold fully assembled and ready to fly (RTF)
 
 ## Fully Assembled (PX4 Compatible)
 
-This section lists fully assembed vehicles where you can update the software to run PX4.
+This section lists fully assembled vehicles where you can update the software to run PX4.
 
 - Multicopter
   - [Bitcraze Crazyflie 2.1](../complete_vehicles/crazyflie21.md)
@@ -66,4 +68,3 @@ These may or may not be updatable to run "vanilla" PX4.
 * VTOL
   * [WingtraOne Tailsitter VTOL](https://px4.io/portfolio/wingtraone-tailsitter-vtol/)
   * [Flightwave Edge](https://px4.io/portfolio/flywave-edge/)
-    


### PR DESCRIPTION
Simply expanding the "Fully Assembled (PX4 Preinstalled)" section. 