### PR TITLE
Improve instructions for building mavlink custom messages

### DIFF
--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -2,7 +2,7 @@
 
 [MAVLink](https://mavlink.io/en/) is a very lightweight messaging protocol that has been designed for the drone ecosystem.
 
-PX4 uses *MAVLink* to communicate with *QGroundControl* (and other ground stations), and as the integration mechanism for connecting to drone components outside of the flight controller: companion computers, MAVLink enabled cameras etc. 
+PX4 uses *MAVLink* to communicate with *QGroundControl* (and other ground stations), and as the integration mechanism for connecting to drone components outside of the flight controller: companion computers, MAVLink enabled cameras etc.
 
 The protocol defines a number of standard [messages](https://mavlink.io/en/messages/) and [microservices](https://mavlink.io/en/services/) for exchanging data (many, but not all, messages/services have been implemented in PX4).
 
@@ -14,21 +14,27 @@ The tutorial assumes you have a [custom uORB](../middleware/uorb.md) `ca_traject
 
 ## Defining Custom MAVLink Messages
 
+PX4 includes the [mavlink/mavlink](https://github.com/mavlink/mavlink) repo as a submodule under [/src/modules/mavlink](https://github.com/PX4/PX4-Autopilot/tree/master/src/modules/mavlink), and generates the MAVLink 2 C library at build time from [/mavlink/messages/1.0/development.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/development.xml) (by default).
+The dialect that is built is specified using the variable `MAVLINK_DIALECT` in [/src/modules/mavlink/CMakeLists.txt](https://github.com/PX4/PX4-Autopilot/blob/master/src/modules/mavlink/CMakeLists.txt#L34).
+
+In order to add your message we recommend that you create your messages in a new dialect file in the same directory, for example `PX4-Autopilot/src/modules/mavlink/mavlink/message_definitions/v1.0/custom_messages.xml`, and set `MAVLINK_DIALECT` to build the new file.
+This dialect file should include `development.xml`.
+
+:::note
+You might alternatively add your messages to `common.xml` or `development.xml`.
+Either way, remember that the same dialect file must be eventually be built in QGroundControl (or whatever software you use to communicate with PX4).
+:::
+
 The MAVLink developer guide explains how to define new messages and build them into new programming-specific libraries:
+
 - [How to Define MAVLink Messages & Enums](https://mavlink.io/en/guide/define_xml_element.html)
-- [Generating MAVLink Libraries](https://mavlink.io/en/getting_started/generate_libraries.html)
+- [Install MAVLink Toolchain](https://mavlink.io/en/getting_started/installation.html)
+- [Generating MAVLink Libraries](https://mavlink.io/en/getting_started/generate_libraries.html).
 
-Your message needs to be generated as a C-library for MAVLink 2.
-Once you've [installed MAVLink](https://mavlink.io/en/getting_started/installation.html) you can do this on the command line using the command:
+Even though PX4 will build the files for you, you should test that your messages are correctly defined by building your XML file on the command line:
 ```sh
-python -m pymavlink.tools.mavgen --lang=C --wire-protocol=2.0 --output=generated/include/mavlink/v2.0 message_definitions/v1.0/custom_messages.xml
+python -m pymavlink.tools.mavgen --lang=C --wire-protocol=2.0 --output=generated/include/mavlink/v2.0 message_definitions/v1.0/https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/development.xml
 ```
-
-For your own use/testing you can just copy the generated headers into **PX4-Autopilot/mavlink/include/mavlink/v2.0**.
-
-To make it easier for others to test your changes, a better approach is to add your generated headers to a fork of https://github.com/mavlink/c_library_v2.
-PX4 developers can then update the submodule to your fork in the PX4-Autopilot repo before building.
-
 
 ## Sending Custom MAVLink Messages
 
@@ -203,9 +209,27 @@ Instead of creating a custom MAVLink message `CA_TRAJECTORY`, you can send a mes
 See [this tutorial](../debug/debug_values.md). for an example usage of debug messages.
 
 :::note
-This solution is not efficient as it sends character string over the network and involves comparison of strings. 
+This solution is not efficient as it sends character string over the network and involves comparison of strings.
 It should be used for development only!
 :::
+
+## Testing
+
+Ultimately you'll want to test your new MAVLink interface is working by providing the corresponding ground station or MAVSDK implemention.
+As a first step, and while debugging, commonly you'll just want to confirm that any messages you've created are being sent/recieved as you expect.
+
+There are several approaches you can use to view traffic:
+- Create a [Wireshark MAVLink plugin](https://mavlink.io/en/guide/wireshark.html) for your dialect.
+  This allows you to inspect MAVLink traffic on an IP interface - for example between *QGroundControl* or MAVSDK and your real or simulated verson of PX4. 
+- [Log uORB topics](../dev_log/logging.md) associate with your MAVLink message.
+- View received messages in the QGroundControl [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_inspector.html).
+  For the messages to appear you will need to [Build QGroundControl](https://dev.qgroundcontrol.com/master/en/getting_started/) including a pre-built C library that contains your custom messages.
+  - QGC uses a pre-built C library that must be located at [/qgroundcontrol/libs/mavlink/include/mavlink](https://github.com/mavlink/qgroundcontrol/tree/master/libs/mavlink/include/mavlink) in the QGC source.
+    By default this is pre-included as a submodule from https://github.com/mavlink/c_library_v2 but you can [generate your own MAVLink Libraries](https://mavlink.io/en/getting_started/generate_libraries.html)
+  - QGC uses the ArduPilotMega.xml dialect by default, which includes **common.xml**.
+    You can include your messages in either file or in your own dialect.
+    However if you use your own dialect then it should include ArduPilotMega.xml (or it will miss all the existing messages), and you will need to change the dialect used by setting it in [`MAVLINK_CONF`](https://github.com/mavlink/qgroundcontrol/blob/master/QGCExternalLibs.pri#L52) when running *qmake*.
+
 
 ## General
 

--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -14,27 +14,28 @@ The tutorial assumes you have a [custom uORB](../middleware/uorb.md) `ca_traject
 
 ## Defining Custom MAVLink Messages
 
-PX4 includes the [mavlink/mavlink](https://github.com/mavlink/mavlink) repo as a submodule under [/src/modules/mavlink](https://github.com/PX4/PX4-Autopilot/tree/master/src/modules/mavlink), and generates the MAVLink 2 C library at build time from [/mavlink/messages/1.0/development.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/development.xml) (by default).
-The dialect that is built is specified using the variable `MAVLINK_DIALECT` in [/src/modules/mavlink/CMakeLists.txt](https://github.com/PX4/PX4-Autopilot/blob/master/src/modules/mavlink/CMakeLists.txt#L34).
+PX4 includes the [mavlink/mavlink](https://github.com/mavlink/mavlink) repo as a submodule under [/src/modules/mavlink](https://github.com/PX4/PX4-Autopilot/tree/master/src/modules/mavlink), and generates the MAVLink 2 C header files at build time.
+
+There are are number of XML dialect files in [/mavlink/messages/1.0/](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/).
+The dialect that is built is specified using the variable `MAVLINK_DIALECT` in [/src/modules/mavlink/CMakeLists.txt](https://github.com/PX4/PX4-Autopilot/blob/master/src/modules/mavlink/CMakeLists.txt#L34); by default this is [development.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/development.xml).
+The files are generated into the build directory: `/build/<build target>/mavlink/`.
 
 In order to add your message we recommend that you create your messages in a new dialect file in the same directory, for example `PX4-Autopilot/src/modules/mavlink/mavlink/message_definitions/v1.0/custom_messages.xml`, and set `MAVLINK_DIALECT` to build the new file.
 This dialect file should include `development.xml`.
 
+You can alternatively add your messages to `common.xml` or `development.xml`.
+Whatever dialect file you use must eventually be built in QGroundControl (or whatever software you use to communicate with PX4).
+
+The MAVLink developer guide explains how to define new messages in [How to Define MAVLink Messages & Enums](https://mavlink.io/en/guide/define_xml_element.html).
+
+You can check that your new messages are built by inspecting the headers generated in the build directory.
+If your messages are not built they may be incorrectly formatted, or use clashing ids.
+Inspect the build log for information.
+
 :::note
-You might alternatively add your messages to `common.xml` or `development.xml`.
-Either way, remember that the same dialect file must eventually be built in QGroundControl (or whatever software you use to communicate with PX4).
+The [MAVLink Developer guide](https://mavlink.io/en/getting_started/) has more information about using the MAVLink toolchain.
 :::
 
-The MAVLink developer guide explains how to define new messages and build them into new programming-specific libraries:
-
-- [How to Define MAVLink Messages & Enums](https://mavlink.io/en/guide/define_xml_element.html)
-- [Install MAVLink Toolchain](https://mavlink.io/en/getting_started/installation.html)
-- [Generating MAVLink Libraries](https://mavlink.io/en/getting_started/generate_libraries.html).
-
-Even though PX4 will build the files for you, you should test that your messages are correctly defined by building your XML file on the command line:
-```sh
-python -m pymavlink.tools.mavgen --lang=C --wire-protocol=2.0 --output=generated/include/mavlink/v2.0 message_definitions/v1.0/https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/development.xml
-```
 
 ## Sending Custom MAVLink Messages
 

--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -22,7 +22,7 @@ This dialect file should include `development.xml`.
 
 :::note
 You might alternatively add your messages to `common.xml` or `development.xml`.
-Either way, remember that the same dialect file must be eventually be built in QGroundControl (or whatever software you use to communicate with PX4).
+Either way, remember that the same dialect file must eventually be built in QGroundControl (or whatever software you use to communicate with PX4).
 :::
 
 The MAVLink developer guide explains how to define new messages and build them into new programming-specific libraries:


### PR DESCRIPTION
Fixes #1741 

@bkueng This does basic fixes to mavlink doc for PX4, explaining how messages are build and how they are tested.
It is a bit abstract as I have not actually tried it yet. 

Would appreciate your sanity check on the flow and concepts.