### PR TITLE
Remove Gradle dependency

### DIFF
--- a/en/dev_setup/fast-dds-installation.md
+++ b/en/dev_setup/fast-dds-installation.md
@@ -44,16 +44,6 @@ If you have ROS 2 installed (and `rmw-fasrtps` as its default middleware), you c
 Java is required to build and use eProsima's RTPS/DDS from IDL code generation tool - *Fast-RTPS-Gen*.
 [Java JDK 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html) is recommended, and it is installed through the setup scripts made available in [Ubuntu Development Environment](../dev_setup/dev_env_linux.md).
 
-### Gradle
-
-You also need to [install Gradle](https://gradle.org/install/) to build *Fast-RTPS-Gen*.
-We recommend you install Gradle via [sdkman](https://sdkman.io).
-
-:::warning
-Do not install Gradle version 7 or higher.
-The recommended version is 6.3.
-:::
-
 ### Foonathan memory
 
 In order to build Fast DDS you need to install the Foonathan Memory dependency.
@@ -108,12 +98,23 @@ The following additional arguments can be used when calling *CMake*:
 It should be installed after Fast RTPS (DDS) and made sure the `fastrtpsgen` application is in your `PATH`.
 You can check with `which fastrtpsgen`.
 
-Then install Fast-RTPS-Gen 1.0.4 (Gradle is required for this):
+Then clone Fast-RTPS-Gen 1.0.4:
 ```
 git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git -b v1.0.4 ~/Fast-RTPS-Gen \
-    && cd ~/Fast-RTPS-Gen \
-    && gradle assemble \
-    && sudo env "PATH=$PATH" gradle install
+
+&& cd ~/Fast-RTPS-Gen/gradle/wrapper
+```
+
+After that, modify the distribution version  of gradle inside the gradle-wrapper.properties file to gradle-6.8.3 such that the distributionUrl file becomes as follows:
+
+```
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+```
+Now you should run the following commands:
+
+```
+    cd ~/Fast-RTPS-Gen 
+    ./gradlew assemble && sudo env "PATH=$PATH" ./gradlew install
 ```
 
 ## Installation from Binaries


### PR DESCRIPTION
I found that there is no need to install Gradle in order to build Fast-RTPS-Gen, Gradle Wrapper could be used instead.

After cloning v1.0.4
`git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git -b v1.0.4 ~/Fast-RTPS-Gen
`
"gradlew assemble" and "gradlew install" can be used instead of using gradle.

However, the version of gradle should be modified inside the "gradle-wrapper.properties " file which lies in "~/Fast-RTPS-Gen/gradle/wrapper" directory.
I changed the distributionUrl line to be:

distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip

which uses a newer version of gradle compared to the old 5.*.* that was cloned by default.