### PR TITLE
Preflight high accel bias fixes

### DIFF
--- a/en/flying/pre_flight_checks.md
+++ b/en/flying/pre_flight_checks.md
@@ -49,7 +49,7 @@ The EKF IMU acceleration bias is the difference between the measured acceleratio
 This bias may change when the sensor is turned on (“turn-on bias”) and over time due to noise and temperature differences (“in-run bias”).
 The number should generally be very small (near zero), indicating that measurements from different sources all agree on the acceleration.
 
-The warning indicates that the bias is higher than some arbitrary threshold.
+The warning indicates that the bias is higher than some arbitrary threshold (the vehicle will not be allowed to take off).
 It is most likely a sign that accelerometer or thermal calibration are required:
 
 - If you _sometimes_ get the warning: [re-calibrate the accelerometer](../config/accelerometer.md).
@@ -70,7 +70,7 @@ It should only be attempted if you have data showing it will improve the perform
 
 Parameter | Description
 --- | ---
-<a id="EKF2_ABL_LIM"></a>[EKF2_ABL_LIM](../advanced_config/parameter_reference.md#EKF2_ABL_LIM) | The maximum value that the EKF is allowed to estimate. The autopilot will report a “high accel bias” if the estimated bias exceeds 75% of this parameter during a preflight check. The current value of 0.4m/s2 is already quite high and increasing it would make the autopilot less likely to detect an issue.
+<a id="EKF2_ABL_LIM"></a>[EKF2_ABL_LIM](../advanced_config/parameter_reference.md#EKF2_ABL_LIM) | The maximum bias value that the EKF is allowed to estimate (above this value the bias will be clipped and EKF will attempt to reset itself, possibly even switching to a more healthy EKF with a working IMU in a multi-EKF system). The autopilot will report a “high accel bias” if the estimated bias exceeds 75% of this parameter during a preflight check and prevent takeoff. The current value of 0.4m/s2 is already quite high and increasing it would make the autopilot less likely to detect an issue.
 <a id="EKF2_ABIAS_INIT"></a>[EKF2_ABIAS_INIT](../advanced_config/parameter_reference.md#EKF2_ABIAS_INIT) | Initial bias uncertainty (if perfectly calibrated, this is related to the “turn-on bias” of the sensor). Some users might want to reduce that value if they know that the sensor is well calibrated and that the turn-on bias is small.
 <a id="EKF2_ACC_B_NOISE"></a>[EKF2_ACC_B_NOISE](../advanced_config/parameter_reference.md#EKF2_ACC_B_NOISE) | The expected “in-run bias” of the accelerometer or “how fast do we expect the bias to change per second”. By default, this value is large enough to include the drift due to a temperature change. If the IMU is temperature calibrated, the user might want to reduce this parameter.
 <a id="EKF2_ABL_ACCLIM"></a>[EKF2_ABL_ACCLIM](../advanced_config/parameter_reference.md#EKF2_ABL_ACCLIM) | The maximum acceleration at which the estimator will try to learn an acceleration bias. This is to prevent the estimator from learning a bias due to non-linearity and scale factor errors. (Almost no user should need to change that parameter except if they really know what they are doing).


### PR DESCRIPTION
EKF2_ABL_LIM is a bias value, not an acceleration value. Note what happens if exceeded.