### PR TITLE
Update Kconfig doc to fix build error and clarify Kconfig usage

### DIFF
--- a/en/hardware/porting_guide_config.md
+++ b/en/hardware/porting_guide_config.md
@@ -31,7 +31,8 @@ endif #DRIVERS_UAVCAN_V1
 ```
 
 :::note
-The `menuconfig` property in Kconfig file is the name used for configuration. If you edit the `*.px4board` configuration file manually, make sure you didn't misspell the module name! Otherwise, it won't include the module for the build.
+The `menuconfig` property in Kconfig file is the name used for configuration.
+If you edit the `*.px4board` configuration file manually, make sure you don't misspell a module name (or it won't be included in the build).
 :::
 
 ## PX4 Kconfig Label Inheritance

--- a/en/hardware/porting_guide_config.md
+++ b/en/hardware/porting_guide_config.md
@@ -31,7 +31,6 @@ endif #DRIVERS_UAVCAN_V1
 ```
 
 :::note
-The `menuconfig` property in Kconfig file is the name used for configuration.
 Builds will silently ignore any missing or miss-spelled modules in the  `*.px4board` configuration file.
 :::
 

--- a/en/hardware/porting_guide_config.md
+++ b/en/hardware/porting_guide_config.md
@@ -32,7 +32,7 @@ endif #DRIVERS_UAVCAN_V1
 
 :::note
 The `menuconfig` property in Kconfig file is the name used for configuration.
-If you edit the `*.px4board` configuration file manually, make sure you don't misspell a module name (or it won't be included in the build).
+Builds will silently ignore any missing or miss-spelled modules in the  `*.px4board` configuration file.
 :::
 
 ## PX4 Kconfig Label Inheritance

--- a/en/hardware/porting_guide_config.md
+++ b/en/hardware/porting_guide_config.md
@@ -30,6 +30,10 @@ if DRIVERS_UAVCAN_V1
 endif #DRIVERS_UAVCAN_V1
 ```
 
+:::note
+The `menuconfig` property in Kconfig file is the name used for configuration. If you edit the `*.px4board` configuration file manually, make sure you didn't misspell the module name! Otherwise, it won't include the module for the build.
+:::
+
 ## PX4 Kconfig Label Inheritance
 
 Each PX4 board must have a `default.px4board` configuration and can have an optional `bootloader.px4board configuration`.

--- a/en/hardware/porting_guide_nuttx.md
+++ b/en/hardware/porting_guide_nuttx.md
@@ -33,6 +33,7 @@ Run the following commands from any directory:
 ```sh
 git clone https://bitbucket.org/nuttx/tools.git
 cd tools/kconfig-frontends
+autoreconf --force --install
 sudo apt install gperf
 ./configure --enable-mconf --disable-nconf --disable-gconf --enable-qconf --prefix=/usr
 make

--- a/en/hardware/porting_guide_nuttx.md
+++ b/en/hardware/porting_guide_nuttx.md
@@ -33,7 +33,6 @@ Run the following commands from any directory:
 ```sh
 git clone https://bitbucket.org/nuttx/tools.git
 cd tools/kconfig-frontends
-autoreconf --force --install
 sudo apt install gperf
 ./configure --enable-mconf --disable-nconf --disable-gconf --enable-qconf --prefix=/usr
 make


### PR DESCRIPTION
I was adding a [custom module](https://nxp.gitbook.io/hovergames/developerguide/px4-tutorial-example-code/hg-px4-example-lab-5) and noticed that PX4 now uses Kconfig architecture for module configuration.

However, `autoreconf` command was missing from the doc. Without this, user can not build the menuconfig successfully. Original issue is referenced here : https://github.com/jerryscript-project/jerryscript/pull/2225

Also, while manually editing the `default.px4` board file, I noticed that when I mistype the module's `menuconfig` property (a.k.a, it's name), it doesn't show any error messages & just doesn't include it for the build. This can happen to any user who isn't so aware of Kconfig architecture. I added an helper description for that.