### PR TITLE
Ethernet setup - add to sidebar

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -153,6 +153,7 @@
   * [Prearm/Arm/Disarm Configuration](advanced_config/prearm_arm_disarm.md)
   * [Serial Port Configuration](peripherals/serial_configuration.md)
   * [MAVLink Telemetry (OSD/GCS)](peripherals/mavlink_peripherals.md)
+  * [PX4 Ethernet Setup](advanced_config/ethernet_setup.md)
   * [Full Parameter Reference](advanced_config/parameter_reference.md)
 * [Hardware (Drones&Parts)](hardware/drone_parts.md)
   * [Complete Vehicles](complete_vehicles/README.md)

--- a/en/peripherals/mavlink_peripherals.md
+++ b/en/peripherals/mavlink_peripherals.md
@@ -57,6 +57,8 @@ The value you use will depend on the type of connection and the capabilities of 
 <span id="default_ports"></span>
 ## Default MAVLink Ports
 
+### TELEM1
+
 The `TELEM 1` port is almost always used for the GCS telemetry stream.
 
 To support this there is a [default serial port mapping](../peripherals/serial_configuration.md#default_port_mapping) of MAVLink instance 0 as shown below:
@@ -66,6 +68,19 @@ To support this there is a [default serial port mapping](../peripherals/serial_c
 - [MAV_0_FORWARD](../advanced_config/parameter_reference.md#MAV_0_FORWARD) = `True`
 - [SER_TEL1_BAUD](../advanced_config/parameter_reference.md#SER_TEL1_BAUD) = `57600`
 
+### ETHERNET
+
+Pixhawk 5x and later devices that have an Ethernet port, configure it by default to connect to a GCS on the standard GCS UDP port:
+PX4 configures the Ethernet (serial) port to connect to a GCS by default via MAVLink.
+
+On this hardware, there is a [default serial port mapping](../peripherals/serial_configuration.md#default_port_mapping) of MAVLink instance 2 as shown below:
+- [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG) = `Ethernet`  (1000)
+- [MAV_2_BROADCAST](../advanced_config/parameter_reference.md#MAV_2_BROADCAST) = `1`
+- [MAV_2_MODE](../advanced_config/parameter_reference.md#MAV_2_MODE) = `0` (normal/GCS)
+- [MAV_2_RADIO_CTL](../advanced_config/parameter_reference.md#MAV_2_RADIO_CTL) = `0`
+- [MAV_2_RATE](../advanced_config/parameter_reference.md#MAV_2_RATE) = `100000`
+- [MAV_2_REMOTE_PRT](../advanced_config/parameter_reference.md#MAV_2_REMOTE_PRT)= `14550` (GCS)
+- [MAV_2_UDP_PRT](../advanced_config/parameter_reference.md#MAV_2_UDP_PRT) = `14550` (GCS)
 
 ## Example
 

--- a/en/peripherals/mavlink_peripherals.md
+++ b/en/peripherals/mavlink_peripherals.md
@@ -70,8 +70,7 @@ To support this there is a [default serial port mapping](../peripherals/serial_c
 
 ### ETHERNET
 
-Pixhawk 5x and later devices that have an Ethernet port, configure it by default to connect to a GCS on the standard GCS UDP port:
-PX4 configures the Ethernet (serial) port to connect to a GCS by default via MAVLink.
+Pixhawk 5x devices (and later) that have an Ethernet port, configure it by default to connect to a GCS:
 
 On this hardware, there is a [default serial port mapping](../peripherals/serial_configuration.md#default_port_mapping) of MAVLink instance 2 as shown below:
 - [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG) = `Ethernet`  (1000)
@@ -81,6 +80,8 @@ On this hardware, there is a [default serial port mapping](../peripherals/serial
 - [MAV_2_RATE](../advanced_config/parameter_reference.md#MAV_2_RATE) = `100000`
 - [MAV_2_REMOTE_PRT](../advanced_config/parameter_reference.md#MAV_2_REMOTE_PRT)= `14550` (GCS)
 - [MAV_2_UDP_PRT](../advanced_config/parameter_reference.md#MAV_2_UDP_PRT) = `14550` (GCS)
+
+For more information see: [PX4 Ethernet Setup](../advanced_config/ethernet_setup.md)
 
 ## Example
 

--- a/en/peripherals/serial_configuration.md
+++ b/en/peripherals/serial_configuration.md
@@ -19,11 +19,12 @@ The following functions are typically mapped to the same specific serial ports o
 
 - MAVLink is mapped to the `TELEM 1` port with baudrate 57600 (for a [telemetry module](../telemetry/README.md)).
 - GPS 1 ([gps driver](../modules/modules_driver.md#gps)) is mapped to the `GPS 1` port with a baudrate *Auto* (with this setting a GPS will automatically detect the baudrate - except for the Trimble MB-Two, which requires 115200 baudrate).
+- MAVLink is mapped to the Ethernet port using `MAV_2_CONFIG` on Pixhawk devices that have an Ethernet port.
 
 All other ports have no assigned functions by default (are disabled).
 
 :::tip
-The ports mappings above can be disabled by setting [MAV_0_CONFIG](../advanced_config/parameter_reference.md#MAV_0_CONFIG) and [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG) to *Disabled*, respectively.
+The port mappings above can be disabled by setting [MAV_0_CONFIG](../advanced_config/parameter_reference.md#MAV_0_CONFIG), [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG), and [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG) to *Disabled*, respectively.
 :::
 
 


### PR DESCRIPTION
This adds the ethernet setup doc from #1813 into the sidebar. It also updates the MAVLink doc to add default port info.

I'm merging. There may be more to say, but this is good enough for now.