### PR TITLE
Fix SDLOG_PROFILE in Mag Comp

### DIFF
--- a/en/advanced_config/compass_power_compensation.md
+++ b/en/advanced_config/compass_power_compensation.md
@@ -28,7 +28,7 @@ Performing this power compensation is advisable only if all the following statem
 1. Make sure your drone runs a Firmware version supporting power compensation (current master, or releases from v.1.11.0).
 1. Perform the [standard compass calibration](../config/compass.md#compass-calibration).
 1. Set the parameter [SDLOG_MODE](../advanced_config/parameter_reference.md#SDLOG_MODE) to 2 to enable logging of data from boot. 
-1. Set the parameter [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) checkbox for *high rate* (bit 2) to get more data points.
+1. Set the parameter [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) checkbox for *Sensor comparison* (bit 6) to get more data points.
 1. Secure the drone so that it cannot move, and attach the propellers (so the motors can draw the same current as in flight).
    This example secures the vehicle using straps.
    


### PR DESCRIPTION
This has always been wrong. High Rate does not log the mag at a high rate, but Sensor Comparison does.