### PR TITLE
Compass mounting/orientation doc

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -16,6 +16,7 @@
   * [Flight Reporting](getting_started/flight_reporting.md)
 * [Basic Assembly](assembly/README.md)
   * [Mounting the Flight Controller](assembly/mount_and_orient_controller.md)
+  * [Mounting the GPS/Compass](assembly/mount_gps_compass.md)
   * [Vibration Isolation](assembly/vibration_isolation.md)
   * [Cable Wiring](assembly/cable_wiring.md)
   * [CUAV V5+ Wiring Quickstart](assembly/quick_start_cuav_v5_plus.md)

--- a/en/assembly/mount_gps_compass.md
+++ b/en/assembly/mount_gps_compass.md
@@ -1,0 +1,20 @@
+# Mounting the GPS/Compass
+
+The GPS/Compass (or just the Compass) should be mounted on the frame as far away from other electronics as possible, with the direction marker towards the front of the vehicle (separating the compass from other electronics will reduce interference).
+
+The diagram below shows the heading marker on the Pixhawk 4 and compass.
+
+![Connect compass/GPS to Pixhawk 4](../../assets/flight_controller/pixhawk4/pixhawk4_compass_gps.jpg)
+
+## Compass Orientation
+
+The compass can also be mounted in any other _supported_ orientation, where the supported orientations can be seen in [CAL_MAGn_ROT](../advanced_config/parameter_reference.md#CAL_MAG1_ROT), and have the same meaning as used for [orienting the flight controller](../config/flight_controller_orientation.md#calculating-orientation).
+
+:::warning
+You must mount the compass in a supported orientation!
+
+If you mount the compass at an orientation that isn't supported, for example `Yaw 30`, the PX4 will detect the closest matching value.
+This will result error and warnings, even if the calibration appeared to succeed.
+:::
+
+If you're using the normal [Compass Calibration](../config/compass.md) process the parameter [CAL_MAG_ROT_AUTO](../advanced_config/parameter_reference.md#CAL_MAG_ROT_AUTO) is enabled, and the orientation should be detected automatically.

--- a/en/assembly/mount_gps_compass.md
+++ b/en/assembly/mount_gps_compass.md
@@ -1,7 +1,6 @@
 # Mounting the GPS/Compass
 
-The GPS/Compass (or just the Compass) should be mounted on the frame as far away from other electronics as possible, with the direction marker towards the front of the vehicle (separating the compass from other electronics will reduce interference).
-
+The GPS/Compass should be mounted on the frame as far away from other electronics as possible, with the direction marker pointing towards the front of the vehicle.
 The diagram below shows the heading marker on the Pixhawk 4 and compass.
 
 ![Connect compass/GPS to Pixhawk 4](../../assets/flight_controller/pixhawk4/pixhawk4_compass_gps.jpg)

--- a/en/assembly/mount_gps_compass.md
+++ b/en/assembly/mount_gps_compass.md
@@ -10,11 +10,11 @@ The diagram below shows the heading marker on the Pixhawk 4 and compass.
 
 The compass can also be mounted in any other _supported_ orientation, where the supported orientations can be seen in [CAL_MAGn_ROT](../advanced_config/parameter_reference.md#CAL_MAG1_ROT), and have the same meaning as used for [orienting the flight controller](../config/flight_controller_orientation.md#calculating-orientation).
 
+If you're using the normal [Compass Calibration](../config/compass.md) process the parameter [CAL_MAG_ROT_AUTO](../advanced_config/parameter_reference.md#CAL_MAG_ROT_AUTO) is enabled, and the orientation should be detected automatically.
+
 :::warning
 You must mount the compass in a supported orientation!
 
 If you mount the compass at an orientation that isn't supported, for example `Yaw 30`, the PX4 will detect the closest matching value.
 This will result error and warnings, even if the calibration appeared to succeed.
 :::
-
-If you're using the normal [Compass Calibration](../config/compass.md) process the parameter [CAL_MAG_ROT_AUTO](../advanced_config/parameter_reference.md#CAL_MAG_ROT_AUTO) is enabled, and the orientation should be detected automatically.

--- a/en/assembly/mount_gps_compass.md
+++ b/en/assembly/mount_gps_compass.md
@@ -15,6 +15,6 @@ If you're using the normal [Compass Calibration](../config/compass.md) process t
 :::warning
 You must mount the compass in a supported orientation!
 
-If you mount the compass at an orientation that isn't supported, for example `Yaw 30`, the PX4 will detect the closest matching value.
-This will result error and warnings, even if the calibration appeared to succeed.
+If you mount the compass at an orientation that isn't supported, for example `Yaw 30`, PX4 will detect the closest supported value.
+This will result in errors/warnings, even if the calibration appeared to succeed.
 :::

--- a/en/assembly/quick_start_cuav_v5_nano.md
+++ b/en/assembly/quick_start_cuav_v5_nano.md
@@ -51,7 +51,7 @@ The recommended GPS module is the *Neo v2 GPS*, which contains GPS, compass, saf
 Other GPS modules may not work (see [this compatibility issue](../flight_controller/cuav_v5_nano.md#compatibility_gps)).
 :::
 
-The GPS/Compass module should be mounted on the frame as far away from other electronics as possible, with the direction marker towards the front of the vehicle (Neo GPS arrow is in the same direction as the flight control arrow).
+The GPS/Compass module should be [mounted on the frame](../assembly/mount_gps_compass.md) as far away from other electronics as possible, with the direction marker towards the front of the vehicle (Neo GPS arrow is in the same direction as the flight control arrow).
 Connect to the flight control GPS interface using a cable.
 
 :::note

--- a/en/assembly/quick_start_cuav_v5_plus.md
+++ b/en/assembly/quick_start_cuav_v5_plus.md
@@ -53,7 +53,7 @@ The recommended GPS module is the *Neo v2 GPS*, which contains GPS, compass, saf
 Other GPS modules may not work (see [this compatibility issue](../flight_controller/cuav_v5_nano.md#compatibility_gps)\)).
 :::
 
-The GPS/Compass module should be mounted on the frame as far away from other electronics as possible, with the direction marker towards the front of the vehicle (*Neo v2 GPS* arrow is in the same direction as the flight control arrow).
+The GPS/Compass module should be [mounted on the frame](../assembly/mount_gps_compass.md) as far away from other electronics as possible, with the direction marker towards the front of the vehicle (*Neo v2 GPS* arrow is in the same direction as the flight control arrow).
 Connect to the flight control GPS interface using a cable.
 
 :::note

--- a/en/assembly/quick_start_pixhawk4.md
+++ b/en/assembly/quick_start_pixhawk4.md
@@ -35,7 +35,7 @@ If the controller cannot be mounted in the recommended/default orientation (e.g
 
 Attach the provided GPS with integrated compass, safety switch, buzzer and LED to the **GPS MODULE** port.
 
-The GPS/Compass should be mounted on the frame as far away from other electronics as possible, with the direction marker towards the front of the vehicle (separating the compass from other electronics will reduce interference).
+The GPS/Compass should be [mounted on the frame](../assembly/mount_gps_compass.md) as far away from other electronics as possible, with the direction marker towards the front of the vehicle (separating the compass from other electronics will reduce interference).
 
 ![Connect compass/GPS to Pixhawk 4](../../assets/flight_controller/pixhawk4/pixhawk4_compass_gps.jpg) 
 

--- a/en/assembly/quick_start_pixhawk4_mini.md
+++ b/en/assembly/quick_start_pixhawk4_mini.md
@@ -20,6 +20,7 @@ More information about available ports can be found here: [*Pixhawk 4 Mini* > In
 :::
 
 ## Mount and Orient Controller
+
 *Pixhawk 4 Mini* should be mounted on your frame using vibration-damping foam pads (included in the kit).
 It should be positioned as close to your vehicle’s center of gravity as possible, oriented top-side up with the arrow pointing towards the front of the vehicle.
 
@@ -31,7 +32,7 @@ If the controller cannot be mounted in the recommended/default orientation (e.g
 
 ## GPS + Compass + Buzzer + Safety Switch + LED
 
-Attach the provided GPS with integrated compass, safety switch, buzzer, and LED to the **GPS MODULE** port. The GPS/Compass should be mounted on the frame as far away from other electronics as possible, with the direction marker towards the front of the vehicle (separating the compass from other electronics will reduce interference).
+Attach the provided GPS with integrated compass, safety switch, buzzer, and LED to the **GPS MODULE** port. The GPS/Compass should be [mounted on the frame](../assembly/mount_gps_compass.md) as far away from other electronics as possible, with the direction marker towards the front of the vehicle (separating the compass from other electronics will reduce interference).
 
 ![Connect compass/GPS to Pixhawk 4](../../assets/flight_controller/pixhawk4mini/pixhawk4mini_gps.png)
 

--- a/en/assembly/quick_start_pixhawk5x.md
+++ b/en/assembly/quick_start_pixhawk5x.md
@@ -41,7 +41,7 @@ These GNSS modules have an integrated compass, safety switch, buzzer and LED.
 
 A secondary [M8N or M9N GPS](https://shop.holybro.com/c/gps-systems_0428) (6-pin connector) can be purchased separately and connected to the **GPS2** port.
 
-The GPS/Compass should be mounted on the frame as far away from other electronics as possible, with the direction marker towards the front of the vehicle (separating the compass from other electronics will reduce interference).
+The GPS/Compass should be [mounted on the frame](../assembly/mount_gps_compass.md) as far away from other electronics as possible, with the direction marker towards the front of the vehicle (separating the compass from other electronics will reduce interference).
 
 <img src="../../assets/flight_controller/pixhawk5x/pixhawk5x_gps_front.jpg" width="200px" title="Pixhawk5x standard set" />
 

--- a/en/config/compass.md
+++ b/en/config/compass.md
@@ -6,7 +6,7 @@ The compass calibration process configures all connected internal and external [
 You will need to calibrate your compass on first use, and you may need to recalibrate it if the vehicles is ever exposed to a very strong magnetic field, or if it is used in an area with abnormal magnetic characteristics.
 
 :::note
-If you are using an external magnetometer/compass (or a compass integrated into a GPS module) make sure it is [mounted](../assembly/mount_gps_compass.md) as far as possible form other electronics and in a _supported orientation_.
+If you are using an external magnetometer/compass (or a compass integrated into a GPS module) make sure it is [mounted](../assembly/mount_gps_compass.md) as far as possible from other electronics and in a _supported orientation_.
 Instructions for _connecting_ your GPS+compass can be found in [Basic Assembly](../assembly/README.md) for your specific autopilot hardware.
 Once connected, *QGroundControl* will automatically detect the external magnetometer.
 :::

--- a/en/config/compass.md
+++ b/en/config/compass.md
@@ -45,7 +45,7 @@ Once you've calibrated the vehicle in all the positions *QGroundControl* will di
 
 ## Further Information
 
-* [Peripherals> GPS & Compass > GPS & Compass > Compass Configuration](../gps_compass/README.md#compass-configuration)
+* [Peripherals > GPS & Compass > Compass Configuration](../gps_compass/README.md#compass-configuration)
 * [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/en/SetupView/sensors_px4.html#compass)
 * [PX4 Setup Video - @2m38s](https://youtu.be/91VGmdSlbo4?t=2m38s) (Youtube)
 * [Compass Power Compensation](../advanced_config/compass_power_compensation.md) (Advanced Configuration)

--- a/en/config/compass.md
+++ b/en/config/compass.md
@@ -45,6 +45,7 @@ Once you've calibrated the vehicle in all the positions *QGroundControl* will di
 
 ## Further Information
 
+* [Peripherals> GPS & Compass > GPS & Compass > Compass Configuration](../gps_compass/README.md#compass-configuration)
 * [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/en/SetupView/sensors_px4.html#compass)
 * [PX4 Setup Video - @2m38s](https://youtu.be/91VGmdSlbo4?t=2m38s) (Youtube)
 * [Compass Power Compensation](../advanced_config/compass_power_compensation.md) (Advanced Configuration)

--- a/en/config/compass.md
+++ b/en/config/compass.md
@@ -3,14 +3,15 @@
 The compass calibration process configures all connected internal and external [magnetometers](../gps_compass/README.md).
 *QGroundControl* will guide you to position the vehicle in a number of set orientations and rotate the vehicle about the specified axis.
 
+You will need to calibrate your compass on first use, and you may need to recalibrate it if the vehicles is ever exposed to a very strong magnetic field, or if it is used in an area with abnormal magnetic characteristics.
+
 :::note
-If you are using an external magnetometer/compass (e.g. a compass integrated into a GPS module) make sure you mount the external compass on your vehicle properly and connect it to the autopilot hardware.
-Instructions for connecting your GPS+compass can be found in [Basic Assembly](../assembly/README.md) for your specific autopilot hardware.
+If you are using an external magnetometer/compass (or a compass integrated into a GPS module) make sure it is [mounted](../assembly/mount_gps_compass.md) as far as possible form other electronics and in a _supported orientation_.
+Instructions for _connecting_ your GPS+compass can be found in [Basic Assembly](../assembly/README.md) for your specific autopilot hardware.
 Once connected, *QGroundControl* will automatically detect the external magnetometer.
 :::
 
 :::tip
-You will need to calibrate your compass on first use, and you may need to recalibrate it if the vehicles is ever exposed to a very strong magnetic field, or if it is used in an area with abnormal magnetic characteristics.
 Indications of a poor compass calibration include multicopter circling during hover, toilet bowling (circling at increasing radius/spiraling-out, usually constant altitude, leading to fly-way), or veering off-path when attempting to fly straight.
 :::
 

--- a/en/gps_compass/README.md
+++ b/en/gps_compass/README.md
@@ -138,7 +138,7 @@ If using this feature, all other configuration should be setup up as normal (e.g
 ## Compass Configuration
 
 Compass calibration is covered in: [Compass Configuration](../config/compass.md).
-The process is straightforward and will autodetect, calibrate and prioritise all connected magnetometers.
+The process is straightforward and will autodetect, [set default rotations](../advanced_config/parameter_reference.md#CAL_MAG_ROT_AUTO), calibrate, and prioritise, all connected magnetometers.
 
 Further compass configuration should generally not be required.
 


### PR DESCRIPTION
Calibration can "silently fail" if the orientation is set incorrectly. To make this clear I have created a new doc on mounting the compass which talks about orientation, and linked it from the calibration page. A search should at least find this now.

Fixes #1833

Note, if this is OK might then link it from the assembly pages for the different flight controllers as a post process.