### PR TITLE
Update parameter_reference.md

### DIFF
--- a/en/advanced_config/parameter_reference.md
+++ b/en/advanced_config/parameter_reference.md
@@ -24998,7 +24998,7 @@ table {
 </tr>
 <tr>
  <td><strong id="SENS_ULAND_CFG">SENS_ULAND_CFG</strong> (INT32)</td>
- <td>Serial Configuration for uLanding Radar <p><strong>Comment:</strong> Configure on which serial port to run uLanding Radar.</p> <strong>Values:</strong><ul>
+ <td>Serial Configuration for US-D1 Radar <p><strong>Comment:</strong> Configure on which serial port to run US-D1 Radar.</p> <strong>Values:</strong><ul>
 <li><strong>0:</strong> Disabled</li> 
 
 <li><strong>6:</strong> UART 6</li> 


### PR DESCRIPTION
When Ainstein released the latest version of our standard altimeter we renamed it the US-D1 Radar Altimeter as https://docs.px4.io/master/en/sensor/ulanding_radar.html shows. I wanted to rename the uLanding radar sections to US-D1.
We can keep the ULAND_CFG parameter the same for the sake of simplicity.
Thanks!