### PR TITLE
Remove unnecessary anchor links

### DIFF
--- a/en/assembly/quick_start_cuav_v5_nano.md
+++ b/en/assembly/quick_start_cuav_v5_nano.md
@@ -120,7 +120,7 @@ The other radio is connected to your ground station computer or mobile device (u
 <span id="sd_card"></span>
 ## SD Card (Optional)
 
-An [SD card](../getting_started/px4_basic_concepts.md#sd_cards) is inserted in the factory (you do not need to do anything).
+An [SD card](../getting_started/px4_basic_concepts.md#sd-cards-removable-memory) is inserted in the factory (you do not need to do anything).
 
 
 ## Motors

--- a/en/assembly/quick_start_cuav_v5_plus.md
+++ b/en/assembly/quick_start_cuav_v5_plus.md
@@ -116,7 +116,7 @@ The other radio is connected to your ground station computer or mobile device (u
 <span id="sd_card"></span>
 ## SD Card (Optional)
 
-An [SD card](../getting_started/px4_basic_concepts.md#sd_cards) is inserted in the factory (you do not need to do anything).
+An [SD card](../getting_started/px4_basic_concepts.md#sd-cards-removable-memory) is inserted in the factory (you do not need to do anything).
 
 ## Motors
 

--- a/en/assembly/quick_start_cube.md
+++ b/en/assembly/quick_start_cube.md
@@ -172,7 +172,7 @@ Insert the Micro-SD card into Cube as shown (if not already present).
 ![Cube - Mount SDCard](../../assets/flight_controller/cube/cube_sdcard.jpg)
 
 :::tip
-For more information see [Basic Concepts > SD Cards (Removable Memory)](../getting_started/px4_basic_concepts.md#sd_cards).
+For more information see [Basic Concepts > SD Cards (Removable Memory)](../getting_started/px4_basic_concepts.md#sd-cards-removable-memory).
 :::
 
 ## Motors

--- a/en/assembly/quick_start_durandal.md
+++ b/en/assembly/quick_start_durandal.md
@@ -171,7 +171,7 @@ Insert an SD card into the *Durandal* where indicated below.
 ![Durandal SD Card](../../assets/flight_controller/durandal/durandal_sd_slot.jpg)
 
 :::tip
-For more information see [Basic Concepts > SD Cards (Removable Memory)](../getting_started/px4_basic_concepts.md#sd_cards).
+For more information see [Basic Concepts > SD Cards (Removable Memory)](../getting_started/px4_basic_concepts.md#sd-cards-removable-memory).
 :::
 
 ## Motors

--- a/en/assembly/quick_start_pixhawk4.md
+++ b/en/assembly/quick_start_pixhawk4.md
@@ -161,7 +161,7 @@ Insert the card (included in Pixhawk 4 kit) into *Pixhawk 4* as shown below.
 ![Pixhawk 4/SD Card](../../assets/flight_controller/pixhawk4/pixhawk4_sd_card.png)
 
 :::tip
-For more information see [Basic Concepts > SD Cards (Removable Memory)](../getting_started/px4_basic_concepts.md#sd_cards).
+For more information see [Basic Concepts > SD Cards (Removable Memory)](../getting_started/px4_basic_concepts.md#sd-cards-removable-memory).
 :::
 
 ## Motors

--- a/en/assembly/quick_start_pixhawk4_mini.md
+++ b/en/assembly/quick_start_pixhawk4_mini.md
@@ -130,7 +130,7 @@ Insert the card (included in the kit) into *Pixhawk 4 Mini* as shown below.
 ![Pixhawk 4 Mini SD Card](../../assets/flight_controller/pixhawk4mini/pixhawk4mini_sdcard.png)
 
 :::tip
-For more information see [Basic Concepts > SD Cards (Removable Memory)](../getting_started/px4_basic_concepts.md#sd_cards).
+For more information see [Basic Concepts > SD Cards (Removable Memory)](../getting_started/px4_basic_concepts.md#sd-cards-removable-memory).
 :::
 
 ## Motors

--- a/en/assembly/quick_start_pixhawk5x.md
+++ b/en/assembly/quick_start_pixhawk5x.md
@@ -120,7 +120,7 @@ Insert the card (included in Pixhawk 5X kit) into *Pixhawk 5X* as shown below.
 <img src="../../assets/flight_controller/pixhawk5x/pixhawk5x_sd_slot.jpg" width="420px" title="Pixhawk5x standard set" />
 
 :::tip
-For more information see [Basic Concepts > SD Cards (Removable Memory)](../getting_started/px4_basic_concepts.md#sd_cards).
+For more information see [Basic Concepts > SD Cards (Removable Memory)](../getting_started/px4_basic_concepts.md#sd-cards-removable-memory).
 :::
 
 ## Motors

--- a/en/flying/basic_flying.md
+++ b/en/flying/basic_flying.md
@@ -9,7 +9,7 @@ Before you fly for the first time you should read our [First Flight Guidelines](
 <span id="arm"></span>
 ## Arm the Vehicle
 
-Before you can fly the vehicle it must first be [armed](../getting_started/px4_basic_concepts.md#arming).
+Before you can fly the vehicle it must first be [armed](../getting_started/px4_basic_concepts.md#arming-and-disarming).
 This will power all motors and actuators; on a multicopter it will start propellers turning.
 
 To arm the drone:

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -21,20 +21,19 @@ The "brain" of the drone is called an autopilot.
 It consists of *flight stack* software running on *vehicle controller* ("flight controller") hardware.
 
 
-<a id="autopilot"></a>
 ## PX4 Autopilot
 
-[PX4](https://px4.io/) is powerful open source autopilot *flight stack*. 
+[PX4](https://px4.io/) is powerful open source autopilot *flight stack*.
 
 Some of PX4's key features are:
 - Controls [many different vehicle frames/types](../airframes/airframe_reference.md), including: aircraft (multicopters, fixed wing aircraft and VTOLs), ground vehicles and underwater vehicles. 
-- Great choice of hardware for [vehicle controller](#vehicle_controller), sensors and other peripherals.
+- Great choice of hardware for [vehicle controller](#vehicle-flight-controller-board), sensors and other peripherals.
 - Flexible and powerful [flight modes](#flight_modes) and [safety features](#safety).
 
-PX4 is a core part of a broader drone platform that includes the [QGroundControl](#qgc) ground station, [Pixhawk hardware](https://pixhawk.org/), and [MAVSDK](http://mavsdk.mavlink.io) for integration with companion computers, cameras and other hardware using the MAVLink protocol.
+PX4 is a core part of a broader drone platform that includes the [QGroundControl](#qgroundcontrol) ground station, [Pixhawk hardware](https://pixhawk.org/), and [MAVSDK](http://mavsdk.mavlink.io) for integration with companion computers, cameras and other hardware using the MAVLink protocol.
 PX4 is supported by the [Dronecode Project](https://www.dronecode.org/).
 
-<a id="qgc"></a>
+
 ## QGroundControl
 
 The Dronecode ground control station is called [QGroundControl](http://qgroundcontrol.com/).
@@ -44,7 +43,7 @@ You can use *QGroundControl* to load (flash) PX4 onto the [vehicle control hardw
 
 ![QGC Main Screen](../../assets/concepts/qgc_main_screen.jpg)
 
-<span id="vehicle_controller"></span>
+
 ## Vehicle/Flight Controller Board
 
 PX4 was initially designed to run on [Pixhawk Series](../flight_controller/pixhawk_series.md) controllers, but can now run on Linux computers and other hardware.


### PR DESCRIPTION
Vuepress doesn't link to anchors "as well" as using the heading text. Replace them with heading text unless there is a good reason not to.