### PR TITLE
Prearming and actuator movement discoverability

### DIFF
--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -66,7 +66,10 @@ For more information see:
 
 PX4 uses *outputs* to control: motor speed (e.g. via [ESC](#escs-motors)), flight surfaces like ailerons and flaps, camera triggers, parachutes, grippers, and many other types of payloads.
 
-For example, the images below show the PWM output ports for [Pixhawk 4](../flight_controller/pixhawk4.md) and [Pixhawk 4 mini](../flight_controller/pixhawk4_mini.md).
+The outputs may be PWM ports or be mapped to UAVCAN nodes (e.g. UAVCAN [motor controllers](../peripherals/uavcan_escs.md)).
+The same airframe mapping of outputs to nodes is used in both cases case.
+
+The images below show the PWM output ports for [Pixhawk 4](../flight_controller/pixhawk4.md) and [Pixhawk 4 mini](../flight_controller/pixhawk4_mini.md).
 
 ![Pixhawk 4 output ports](../../assets/flight_controller/pixhawk4/pixhawk4_main_aux_ports.jpg) ![Pixhawk4 mini MAIN ports](../../assets/flight_controller/pixhawk4mini/pixhawk4mini_pwm.png)
 
@@ -78,7 +81,7 @@ The output mapping for all airframes is given in the [Airframe Reference](../air
 :::
 
 :::warning
-A flight controller may only have `MAIN` outputs (like the *Pixhawk 4 Mini*), or may have only 6 outputs on either `MAIN` or `AUX`.
+A flight controller may only have `MAIN` PWM outputs (like the *Pixhawk 4 Mini*), or may have only 6 outputs on either `MAIN` or `AUX`.
 Ensure that you select a controller that has enough of the right types of ports/outputs for your [airframe](../airframes/airframe_reference.md).
 :::
 
@@ -88,16 +91,12 @@ For example, in a [Generic Quadcopter](../airframes/airframe_reference.md#copter
 The actual ports/bus used for the outputs on the [flight controller](#vehicle_controller) depends on the hardware and PX4 configuration.
 *Usually* the ports are mapped to PWM outputs as shown above, which are commonly screen printed `MAIN OUT` and `AUX OUT`.
 
-They might also be marked as `FMU PWM OUT` or `IO PWM Out` (or similar). 
+They might also be marked as `FMU PWM OUT` or `IO PWM Out` (or similar).
 Pixhawk controllers have a "main" FMU board and *may* have a separate IO board.
 If there is an IO board, the `AUX` ports are connected directly to the FMU and the `MAIN` ports are connected to the IO board.
 Otherwise the `MAIN` ports are connected to the FMU, and there are no `AUX` ports.
 The FMU output ports can use [D-shot](../peripherals/dshot.md) or *One-shot* protocols (as well as PWM), which provide much lower-latency behaviour.
 This can be useful for racers and other airframes that require better performance.
-  
-The output ports may also be mapped to UAVCAN nodes (e.g. UAVCAN [motor controllers](../peripherals/uavcan_escs.md)). 
-The (same) airframe mapping of outputs to nodes is used in this case. 
-
 
 **Notes:**
 - There are only 6-8 outputs in `MAIN` and `AUX` because most flight controllers only have this many PWM/Dshot/Oneshot outputs.
@@ -154,7 +153,7 @@ Joysticks are also commonly used to fly the vehicle in simulation.
 
 ## Safety Switch
 
-It is common for vehicles to have a *safety switch* that must be engaged before the vehicle can be [armed](#arming) (when armed, motors are powered and propellers can turn).
+It is common for vehicles to have a *safety switch* that must be engaged before the vehicle can be [armed](#arming-and-disarming) (when armed, motors are powered and propellers can turn).
 Commonly the safety switch is integrated into a GPS unit, but it may also be a separate physical component.
 
 :::warning
@@ -199,14 +198,23 @@ Flight controllers that do not include an SD Card slot may:
 
 ## Arming and Disarming
 
-Vehicles may have moving parts, some of which are potentially dangerous when powered (in particular motors and propellers)!
+Vehicles may have moving parts, some of which are dangerous when powered (in particular motors and propellers)!
 
-To reduce the chance of accidents:
-- PX4 vehicles are *disarmed* (unpowered) when not in use, and must be explicitly *armed* before taking off.
-- A vehicle will automatically disarm if a pilot does not take off quickly enough, and after landing (the disarm time is configurable).
-- Some vehicles also have a [safety switch](#safety-switch) that must be disengaged before arming can succeed (often this switch is part of the GPS).
+To reduce accidents, PX4 defines three power states:
+- **Disarmed:** All motors and actuators are unpowered.
+- **Prearmed:** Motors are unpowered, but actuators are not (allowing non-dangerous actuators to be bench-tested).
+- **Armed:** Motors and other actuators are powered, and propellers may be spinning. 
+
+Vehicles are _armed_ only when necessary.
+Some vehicles may even have a [safety switch](#safety-switch) that must be disengaged before arming can succeed (often this switch is part of the GPS).
+
+By default:
+- Vehicles are *disarmed* (unpowered) when not in use, and must be explicitly *armed* before taking off.
+- Vehicles automatically disarm if a pilot does not take off quickly enough (the disarm time is configurable).
+- Vehicles automatically disarm after landing (the disarm time is configurable).
 - Arming is prevented if the vehicle is not in a "healthy" state.
 - Arming is prevented if a VTOL vehicle is in fixed-wing mode ([by default](../advanced_config/parameter_reference.md#CBRK_VTOLARMING)).
+- Prearming may be used safely bench-test actuators, while still keeping motors unpowered.
 
 Arming is triggered by default (Mode 2 transmitters) by holding the RC throttle/yaw stick on the *bottom right* for one second (to disarm, hold stick on bottom left).
 It is alternatively possible to configure PX4 to arm using an RC switch or button (and arming MAVLink commands can also be sent from a ground station).

--- a/en/payloads/README.md
+++ b/en/payloads/README.md
@@ -2,6 +2,14 @@
 
 PX4 supports a wide range of payloads and cameras.
 
+Payloads are connected to [Fight Controller outputs](../getting_started/px4_basic_concepts.md#outputs-motors-servos-actuators), and can generally be triggered automatically in missions, or manually using RC passthrough or MAVLink/MAVSDK commands.
+
+:::note
+Payloads (actuators) can be tested in the [pre-arm state](../getting_started/px4_basic_concepts.html#arming-and-disarming), which allows movement of actuators while disabling motors.
+This may be safer than testing when the vehicle is armed.
+:::
+
+
 ## Mapping Drones
 
 Mapping drones use cameras to capture images at time or distance intervals during surveys.


### PR DESCRIPTION
There was a comment on slack that it was hard to work out the right approach for bench testing actuators - testing them when not armed. The right way to do this is to use the prearm state, but it wasn't clear in the early docs that the state allowed this kind of thing.

This PR increases the chance that someone will discover the prearming state, and understand that it meets this use case. 
- Updates the basic concepts arming/disarming to explicitly mention the prearming state and what it is used for.
- Updates the payload/cameras doc to note that you can test safely in prearm mode.
- Did some unrelated fixes to basic  concepts > outputs to move UAVCAN mention up the top - i.e. more clearly note that outputs can be of any type not just PWM.

Note, will need to do more work on that when actuator config comes in, because it states that the config is fixed by airframe.