### PR TITLE
Add note about QGC manual communication link for ethernet

### DIFF
--- a/en/advanced_config/ethernet_setup.md
+++ b/en/advanced_config/ethernet_setup.md
@@ -158,6 +158,10 @@ To connect a GCS to PX4 over Ethernet:
 1. QGroundControl should connect automatically.
 
 :::note
+In case if QGC doesn't connect automatically try to add communication link manually. in QGC go to Application Settings → Comm Links and create UDP connection with port `14550` and server address 192.168.0.4 (Pixhawk IP address). 
+:::
+
+:::note
 [PX4 Ethernet Port Configuration](#px4-ethernet-port-configuration) is not required because it is setup by default for connecting to a GCS.
 :::
 


### PR DESCRIPTION
I was confused by the phrase `QGroundControl should connect automatically.` while configuring an ethernet connection.
In my case, I had to manually add a communication link.

<img width="441" alt="Screenshot 2022-04-28 at 15 33 51" src="https://user-images.githubusercontent.com/1369783/167246447-ff00c812-3c6f-4c35-bf18-757495683f6f.png">

<img width="526" alt="Screenshot 2022-04-28 at 15 32 32" src="https://user-images.githubusercontent.com/1369783/167246446-a6936395-ee41-4730-804d-521abf36abf2.png">

Slack thread: https://px4.slack.com/archives/C581ST17V/p1648008264584879