### PR TITLE
ULog File Format Document Improvement

### DIFF
--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-The logger is able to log any ORB topic with all included fields.
+The [system logger](../modules/modules_system.md#logger) is able to log any ORB topic with all included fields.
 Everything necessary is generated from the `.msg` file, so that only the topic name needs to be specified.
 An optional interval parameter specifies the maximum logging rate of a certain topic.
 All existing instances of a topic are logged.

--- a/en/dev_log/ulog_file_format.md
+++ b/en/dev_log/ulog_file_format.md
@@ -5,7 +5,7 @@ The format is self-describing, i.e. it contains the format and [uORB](../middlew
 
 ::: note
 The [system logger](../modules/modules_system.md#logger) allows the default set of logged topics to be replaced with a custom set that is defined on an SD Card.
-See [Logging > SD Card Configuration](../dev_log/logging.html#sd-card-configuration) for more information.
+See [Logging > SD Card Configuration](../dev_log/logging#sd-card-configuration) for more information.
 :::
 
 ULog commonly logs uORB topics related to (but not limited to) the following sources:
@@ -32,7 +32,10 @@ The following binary types are used for logging. They all correspond to the type
 Additionally the types can be used as an array: e.g. `float[5]`.
 
 Strings (`char[length]`) do not usually contain the termination NULL character `'\0'` at the end.
-String comparisons are case sensitive.
+
+:::note
+String comparisons are case sensitive, which should be taken into account when comparing the uORB topic names when [adding subscriptions](#a-subscription-message).
+:::
 
 ## ULog File Structure
 
@@ -80,10 +83,10 @@ struct message_header_s {
 - `msg_size` is the size of the message in bytes without the header.
 - `msg_type` defines the content, and is a single alphabet character.
 
-In practice, we include the `msg_size` and `msg_type` in each message definitions as the first 2 members, so the header `message_header_s` never gets used directly in most cases.
+In practice, we include the `msg_size` and `msg_type` in each message definitions as the first 2 members of different message definitions.
 
 :::note
-Messages described below are prefixed with the single alphabet that corresponds to it's `msg_type` in the beginning.
+Messages below are prefixed with the single alphabet that corresponds to it's `msg_type`.
 :::
 
 
@@ -100,7 +103,7 @@ The message types in this section are:
 6. [Default Parameter](#q-default-parameter-message)
 
 
-#### 'B': Flag Bits Message
+#### 'B': Flag Bits Message (`msg_type = 'B'`)
 
 :::note
 This message must be the **first message** right after the header section, so that it has a fixed constant offset from the start of the file!
@@ -168,7 +171,8 @@ Some field names are special:
 - `timestamp`: every [Subscription Message](#a-subscription-message) must include a timestamp field
   - Its type can be: `uint64_t` (currently the only one used), `uint32_t`, `uint16_t` or `uint8_t`.
   - The unit is always microseconds, except for in `uint8_t` where the unit is in milliseconds.
-  - A log writer must make sure to log messages often enough to be able to detect wrap-arounds and a log reader must handle wrap-arounds (and take into account dropouts).
+  - A log writer must make sure to log messages often enough to be able to detect **wrap-arounds** (when the timestamp overflows the data type and goes back to 0)
+  - Also, the log reader must handle wrap-arounds (and take into account dropouts).
   - The timestamp must always be monotonic increasing for a message series with the same `msg_id`.
 - `_padding{}`: field names that start with `_padding` (e.g. `_padding[3]`) should not be displayed and their data must be ignored by a reader.
   - These fields can be inserted by a writer to ensure correct alignment.

--- a/en/dev_log/ulog_file_format.md
+++ b/en/dev_log/ulog_file_format.md
@@ -1,6 +1,6 @@
 # ULog File Format
 
-ULog (Universal-Log) is the file format used for logging messages. The format is self-describing, i.e. it contains the format and [uORB](../middleware/uorb.md) message types that are logged.
+ULog is the file format used for logging messages. The format is self-describing, i.e. it contains the format and [uORB](../middleware/uorb.md) message types that are logged.
 This document is meant to be the ULog File Format Spec Documentation.
 It is intended especially for anyone who is interested in writing a ULog parser / serializer and needs to decode / encode files.
 
@@ -126,9 +126,9 @@ struct ulog_message_flag_bits_s {
   - `incompat_flags[0]`: *DATA_APPENDED* (Bit 0): if set, the log contains appended data and at least one of the `appended_offsets` is non-zero.
   
   The rest of the bits are currently not defined and must be set to 0.
-  This can be used to introduce breaking changes that existing parsers cannot handle. For example, when an old ULog Parser that didn't have the concept of *DATA_APPENDED* reads the newer ULog, it would stop parsing the log as the log will contain out-of-spec messages / concepts.
+  This can be used to introduce breaking changes that existing parsers cannot handle. For example, when an old ULog parser that didn't have the concept of *DATA_APPENDED* reads the newer ULog, it would stop parsing the log as the log will contain out-of-spec messages / concepts.
   If a parser finds any of these bits set that isn't specified, it must refuse to parse the log.
-- `appended_offsets`: File offset for appended data.
+- `appended_offsets`: File offset (0-based) for appended data.
   If no data is appended, all offsets must be zero.
   This can be used to reliably append data for logs that may stop in the middle of a message.
   For example, crash dumps.
@@ -233,7 +233,7 @@ This message can also be used in the Data section (this is however the preferred
 
 #### 'M': Multi Information Message
 
-Multi information message serves the same purpose as the information message, but for cases where the `value` length exceeds  (parsers store them as a list).
+Multi information message serves the same purpose as the information message, but for long messages or multiple messages with the same key.
 
 ```c
 struct ulog_message_info_multiple_header_s {
@@ -441,7 +441,7 @@ struct message_sync_s {
 
 #### 'O': Dropout message
 
-Mark a dropout (lost logging messages) of a given duration in ms
+Mark a dropout (lost logging messages) of a given duration in ms.
 
 Dropouts can occur e.g. if the device is not fast enough.
 

--- a/en/dev_log/ulog_file_format.md
+++ b/en/dev_log/ulog_file_format.md
@@ -143,7 +143,7 @@ struct ulog_message_flag_bits_s {
 
 It is possible that there are more fields appended at the end of this message in future ULog specifications.
 This means a parser must not assume a fixed length of this message.
-If the message is longer than expected (currently 40 bytes), the exceeding bytes must just be ignored.
+If the message is longer than expected (currently 40 bytes), any additional bytes must be ignored/discarded.
 
 #### 'F': Format Message
 


### PR DESCRIPTION
## Background
While writing the Part 4 of the PX4 uORB Explained Series, I found that ULog File Format document is quite hard to read. Therefore here's the improvement PR!

## Changes from this PR
1. Change Message Type sections from lists into concrete header sections
2. Add Table of 'Messages' section for Definitions / Data section, to
give an overview of the types of messages logged
3. Rephrased and organized doc sentences to make it more easily
understandable

## Note
In case interested, here's the published Part 3 of the uORB Explained Series : https://px4.io/px4-uorb-explained-part-3-the-deep-stuff/