### PR TITLE
dev env mac: note that macos.sh is in the PX4 source

### DIFF
--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -13,7 +13,7 @@ If you have an Apple M1 Macbook, make sure to run the terminal as x86 by setting
 3. Rename the duplicated Terminal app, e.g. to *x86 Terminal*
 4. Now select the renamed *x86 Terminal* app and right-click and choose **Get Info*
 5. Check the box for **Open using Rosetta**, then close the window
-6. Run the *x86 Terminal*` as usual, which will fully support the current PX4 toolchain
+6. Run the *x86 Terminal* as usual, which will fully support the current PX4 toolchain
 :::
 
 :::tip
@@ -84,8 +84,8 @@ brew install --cask xquartz
 brew install px4-sim-gazebo
 ```
 
-Run the `macos.sh` setup script.
-The easiest way to do this is to clone the PX4 source, navigate into the **PX4-Autopilot/Tools/setup** directory, and then run the script:
+Run this macOS setup script: `PX4-Autopilot/Tools/setup/macos.sh`
+The easiest way to do this is to clone the PX4 source, and then run the script from the directory, as shown:
 
 ```sh
 git clone https://github.com/PX4/PX4-Autopilot.git --recursive

--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -84,9 +84,12 @@ brew install --cask xquartz
 brew install px4-sim-gazebo
 ```
 
-Navigate into the **PX4-Autopilot/Tools/setup** directory (using the `cd` command) and enter:
+Run the `macos.sh` setup script.
+The easiest way to do this is to clone the PX4 source, navigate into the **PX4-Autopilot/Tools/setup** directory, and then run the script:
 
 ```sh
+git clone https://github.com/PX4/PX4-Autopilot.git --recursive
+cd PX4-Autopilot/Tools/setup
 sh macos.sh
 ```
 


### PR DESCRIPTION
This fixes a user comment that it wasn't obvious where the script is.
I've chosen to use the source cloning approach rather than curl or wget because I don't have a mac computer to test what is present by default.