### PR TITLE
WSL - improve instructions for getting IP address

### DIFF
--- a/en/dev_setup/dev_env_windows_wsl.md
+++ b/en/dev_setup/dev_env_windows_wsl.md
@@ -217,26 +217,17 @@ Install [QGroundControl on Windows](https://docs.qgroundcontrol.com/master/en/ge
 These steps describe how you can connect to the simulation running in the WSL:
 
 1. [Open a WSL shell](#opening-a-wsl-shell)
-2. Check the IP address of the WSL virtual machine by running the command `ip address`:
+2. Check the IP address of the WSL virtual machine by running the command `ip addr | grep eth0`:   
    ```bash
-   $ ip address
-   1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
-       link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
-       inet 127.0.0.1/8 scope host lo
-          valid_lft forever preferred_lft forever
-       inet6 ::1/128 scope host
-          valid_lft forever preferred_lft forever
-   ...
+   $ ip addr | grep eth0
+   
    6: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
-       link/ether 00:15:5d:fb:f5:10 brd ff:ff:ff:ff:ff:ff
-       inet 172.28.202.135/20 brd 172.28.207.255 scope global eth0
-          valid_lft forever preferred_lft forever
-       inet6 fe80::215:5dff:fefb:f510/64 scope link
-          valid_lft forever preferred_lft forever
+       inet 172.18.46.131/20 brd 172.18.47.255 scope global eth0
    ```
-   Copy the address of the `eth` interface to the clipboard. In this case: `172.28.202.135`.
+   Copy the first part of the `eth0` interface `inet` address to the clipboard.
+   In this case: `172.18.46.131`.
 3. In QGC go to **Q > Application Settings > Comm Links**
-4. Add a UDP Link called "WSL" to port 18570 of the IP address copied before.
+4. Add a UDP Link called "WSL" to port `18570` of the IP address copied above.
 5. Save it and connect to it.
 
 :::note


### PR DESCRIPTION
WSL instructions suggest command `ip addr | grep eth0`:    to get interface address. Output much easier for readers.

FYI only @MaEtUgR 