### PR TITLE
Add note to enable GPS Blending on ARK RTK GPS

### DIFF
--- a/en/uavcan/ark_rtk_gps.md
+++ b/en/uavcan/ark_rtk_gps.md
@@ -83,6 +83,7 @@ General instructions for UAVCAN PX4 configuration can also be found in [UAVCAN >
 
 You need to set necessary [UAVCAN](README.md) parameters and define offsets if the sensor is not centred within the vehicle.
 - Enable GPS yaw fusion by setting bit 7 of [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) to true.
+- Enable GPS blending to ensure the heading is always published by setting [SENS_GPS_MASK](../advanced_config/parameter_reference.md#SENS_GPS_MASK) to 7 (all three bits checked).
 - Enable [UAVCAN_SUB_GPS](../advanced_config/parameter_reference.md#UAVCAN_SUB_GPS), [UAVCAN_SUB_MAG](../advanced_config/parameter_reference.md#UAVCAN_SUB_MAG), and [UAVCAN_SUB_BARO](../advanced_config/parameter_reference.md#UAVCAN_SUB_BARO).
 - Set [CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM) to `1` if this is that last node on the CAN bus.
 - The parameters [EKF2_GPS_POS_X](../advanced_config/parameter_reference.md#EKF2_GPS_POS_X), [EKF2_GPS_POS_Y](../advanced_config/parameter_reference.md#EKF2_GPS_POS_Y) and [EKF2_GPS_POS_Z](../advanced_config/parameter_reference.md#EKF2_GPS_POS_Z) can be set to account for the offset of the ARK RTK GPS from the vehicles centre of gravity.


### PR DESCRIPTION
With moving baseline on two cannodes, the flight controller can't ensure the rover is always GPS1 in uorb based on when they boot. If the rover comes up as instance 2, the heading is not used unless GPS Blending is enabled. With GPS blending enabled, the heading is always published, and the best receiver is used for gps position. The moving base produces a more accurate position, while the rover produces the heading.

Rover came up as GPS1
https://review.px4.io/plot_app?log=4bc33dda-df8c-4b4d-9814-d92eb397a384

Rover came up as GPS2
https://review.px4.io/plot_app?log=0a591982-8ee9-4386-9c9f-121bad7f4b1d