### PR TITLE
Update collision_prevention.md

### DIFF
--- a/en/computer_vision/collision_prevention.md
+++ b/en/computer_vision/collision_prevention.md
@@ -47,6 +47,7 @@ Parameter | Description
 <span id="CP_DELAY"></span>[CP_DELAY](../advanced_config/parameter_reference.md#CP_DELAY) | Set the sensor and velocity setpoint tracking delay. See [Delay Tuning](#delay_tuning) below.
 <span id="CP_GUIDE_ANG"></span>[CP_GUIDE_ANG](../advanced_config/parameter_reference.md#CP_GUIDE_ANG) | Set the angle (to both sides of the commanded direction) within which the vehicle may deviate if it finds fewer obstacles in that direction. See [Guidance Tuning](#angle_change_tuning) below.
 <span id="CP_GO_NO_DATA"></span>[CP_GO_NO_DATA](../advanced_config/parameter_reference.md#CP_GO_NO_DATA) | Set to 1 to allow the vehicle to move in directions where there is no sensor coverage (default is 0/`False`).
+<span id="MPC_POS_MODE"></span>[MPC_POS_MODE](../advanced_config/parameter_reference.md#MPC_POS_MODE) | Set to 0 or 3 to enable Collision Prevention in Position Mode (default is 4).
 
 
 <span id="algorithm"></span>


### PR DESCRIPTION
By default MPC.POS_MODE is set to 4, which disables Collision Prevention. Current documentation does not make evident that this parameter needs to be set correctly. I propose to include the paramater in the documentation to avoid further confusion.