### PR TITLE
Improve Rover Documentation

### DIFF
--- a/en/frames_rover/README.md
+++ b/en/frames_rover/README.md
@@ -1,24 +1,49 @@
-# Rover (UGVs)
+# Rovers (UGVs)
 
-![Traxxas Rover Picture](../../assets/airframes/rover/traxxas_stampede_vxl/final_side.jpg)
-
-PX4 provides support for Unmanned Ground Vehicles (UGVs). The set of configurations can be seen in [Airframes Reference > Rover](../airframes/airframe_reference.md#rover).
+PX4 supports rovers (Unmanned Ground Vehicles - UGVs) with [ackermann and differential](#rover-types) steering.
 
 This section contains build logs/instructions for assembling as well as configuring a number of UGV frames.
 
-## How to configure a Rover
+![Traxxas Rover Picture](../../assets/airframes/rover/traxxas_stampede_vxl/final_side.jpg)
 
-Using the [control allocation](../config/actuators.md), it is straight forward to setup the rover.
+## Rover Types
 
-First, determine your rover type as there are two types of Rover:
-1. Rover (Differential) : Rover that steers itself using different speeds of the wheels left and right. For example, the [r1 rover](../simulation/gazebo.md#ugv_differential) is differential type.
-2. Rover (Ackermann) : Rover with a steering mechanism equivalent to a regular car using the [ackermann geometry](https://en.wikipedia.org/wiki/Ackermann_steering_geometry). For example, the [gazebo rover](../simulation/gazebo.md#ugv_ackermann) is ackermann type.
+PX4 supports rovers with:
 
-Then, set the appropriate airframe by modifying the [CA_AIRFRAME](../advanced_config/parameter_reference.md#CA_AIRFRAME) parameter.
+- **Differential steering**: direction is controlled by moving the left- and right-side wheels at different speeds.
+   This kind of steering commonly used on a military tank of the wheels left and right. 
+- **Ackermann steering**: direction is controlled by pointing wheels in the direction of travel ([ackermann geometry](https://en.wikipedia.org/wiki/Ackermann_steering_geometry) compensates for the fact that wheels on the inside and outside of the turn move at different rates).
+  This kind of steering is used on most commercial vehicles, including cars, trucks etc.
 
-Next, follow the [Actuators document](../config/actuators.md) to finish actuator function mapping and output configuration. Have fun driving!
+The supported frames can be seen in [Airframes Reference > Rover](../airframes/airframe_reference.md#rover).
+
+
+## How to Configure a Rover
+
+Using [control allocation](../config/actuators.md), it is straightforward to setup a rover.
+
+For vehicles with Ackermann steering:
+
+1. In the [Airframe](../config/airframe.md) configuration, select the *Generic Ground Vehicle*.
+1. Set the [CA_AIRFRAME](../advanced_config/parameter_reference.md#CA_AIRFRAME) parameter to **Rover (Ackermann)** (5).
+1. Follow the [Actuators document](../config/actuators.md) to map the steering and throttle outputs as displayed.
+
+For vehicles with Differential steering:
+
+1. In the [Airframe](../config/airframe.md) configuration, select either the _Aion Robotics R1 UGV_ or _NXP Cup car: DF Robot GPX_
+1. Set the [CA_AIRFRAME](../advanced_config/parameter_reference.md#CA_AIRFRAME) parameter to **Rover (Differential)** (6).
+1. Follow the [Actuators document](../config/actuators.md) to map the left and right motor and throttle outputs.
+
+
+## Simulation
+
+Gazebo provides simulations for both types of steering:
+
+- Ackermann: [gazebo rover](../simulation/gazebo.md#ackermann-ugv)
+- Differential: [r1 rover](../simulation/gazebo.md#differential-ugv)
 
 ## Videos
-@[youtube](https://youtu.be/N3HvSKS3nCw)
 
-This video is with the [Traxxas Stampede Rover](../frames_rover/traxxas_stampede.md) 
+This video shows the [Traxxas Stampede Rover](../frames_rover/traxxas_stampede.md) (an Ackermann vehicle).
+
+@[youtube](https://youtu.be/N3HvSKS3nCw)

--- a/en/frames_rover/README.md
+++ b/en/frames_rover/README.md
@@ -32,7 +32,7 @@ For vehicles with Differential steering:
 
 1. In the [Airframe](../config/airframe.md) configuration, select either the _Aion Robotics R1 UGV_ or _NXP Cup car: DF Robot GPX_
 1. Set the [CA_AIRFRAME](../advanced_config/parameter_reference.md#CA_AIRFRAME) parameter to **Rover (Differential)** (6).
-1. Follow the [Actuators document](../config/actuators.md) to map the left and right motor and throttle outputs.
+1. Follow the [Actuators document](../config/actuators.md) to map the left and right motors and throttle outputs.
 
 
 ## Simulation

--- a/en/frames_rover/README.md
+++ b/en/frames_rover/README.md
@@ -1,11 +1,24 @@
-# Rover Frames (UGVs)
+# Rover (UGVs)
 
-PX4 provides basic support for Unmanned Ground Vehicles (UGVs). The set of validated configurations can be seen in [Airframes Reference > Rover](../airframes/airframe_reference.md#rover).
+![Traxxas Rover Picture](../../assets/airframes/rover/traxxas_stampede_vxl/final_side.jpg)
 
-This section contains build logs/instructions for assembling and configuring a number of UGV frames.
+PX4 provides support for Unmanned Ground Vehicles (UGVs). The set of configurations can be seen in [Airframes Reference > Rover](../airframes/airframe_reference.md#rover).
+
+This section contains build logs/instructions for assembling as well as configuring a number of UGV frames.
+
+## How to configure a Rover
+
+Using the [control allocation](../config/actuators.md), it is straight forward to setup the rover.
+
+First, determine your rover type as there are two types of Rover:
+1. Rover (Differential) : Rover that steers itself using different speeds of the wheels left and right. For example, the [r1 rover](../simulation/gazebo.md#ugv_differential) is differential type.
+2. Rover (Ackermann) : Rover with a steering mechanism equivalent to a regular car using the [ackermann geometry](https://en.wikipedia.org/wiki/Ackermann_steering_geometry). For example, the [gazebo rover](../simulation/gazebo.md#ugv_ackermann) is ackermann type.
+
+Then, set the appropriate airframe by modifying the [CA_AIRFRAME](../advanced_config/parameter_reference.md#CA_AIRFRAME) parameter.
+
+Next, follow the [Actuators document](../config/actuators.md) to finish actuator function mapping and output configuration. Have fun driving!
 
 ## Videos
-
-[Traxxas Stampede](../frames_rover/traxxas_stampede.md) 
-
 @[youtube](https://youtu.be/N3HvSKS3nCw)
+
+This video is with the [Traxxas Stampede Rover](../frames_rover/traxxas_stampede.md) 

--- a/en/simulation/gazebo.md
+++ b/en/simulation/gazebo.md
@@ -63,7 +63,8 @@ Vehicle | Command
 [Standard Plane (with catapult launch)](../simulation/gazebo_vehicles.md#standard_plane_catapult) | `make px4_sitl gazebo_plane_catapult`
 [Standard VTOL](../simulation/gazebo_vehicles.md#standard_vtol) | `make px4_sitl gazebo_standard_vtol`
 [Tailsitter VTOL](../simulation/gazebo_vehicles.md#tailsitter_vtol) | `make px4_sitl gazebo_tailsitter`
-[Ackerman vehicle (UGV/Rover)](../simulation/gazebo_vehicles.md#ugv) | `make px4_sitl gazebo_rover`
+[Ackerman UGV (Rover)](../simulation/gazebo_vehicles.md#ackermann-ugv) | `make px4_sitl gazebo_rover`
+[Differential UGV (Rover)](../simulation/gazebo_vehicles.md#differential-ugv) | `make px4_sitl gazebo_r1_rover`
 [HippoCampus TUHH (UUV: Unmanned Underwater Vehicle)](../simulation/gazebo_vehicles.md#uuv) | `make px4_sitl gazebo_uuv_hippocampus`
 [Boat (USV: Unmanned Surface Vehicle)](../simulation/gazebo_vehicles.md#usv) | `make px4_sitl gazebo_boat`
 [Cloudship (Airship)](../simulation/gazebo_vehicles.md#airship) | `make px4_sitl gazebo_cloudship`

--- a/en/simulation/gazebo_vehicles.md
+++ b/en/simulation/gazebo_vehicles.md
@@ -99,8 +99,8 @@ make px4_sitl gazebo_tailsitter
 <a id="ugv"></a>
 ## Unmmanned Ground Vehicle (UGV/Rover/Car)
 
-<a id="ugv_ackerman"></a>
-### Ackerman UGV
+<a id="ugv_ackermann"></a>
+### Ackermann UGV
 
 ```sh
 make px4_sitl gazebo_rover

--- a/en/simulation/gazebo_vehicles.md
+++ b/en/simulation/gazebo_vehicles.md
@@ -99,7 +99,6 @@ make px4_sitl gazebo_tailsitter
 <a id="ugv"></a>
 ## Unmmanned Ground Vehicle (UGV/Rover/Car)
 
-<a id="ugv_ackermann"></a>
 ### Ackermann UGV
 
 ```sh
@@ -108,7 +107,6 @@ make px4_sitl gazebo_rover
 
 ![Rover in Gazebo](../../assets/simulation/gazebo/vehicles/rover.png)
 
-<a id="ugv_differential"></a>
 ### Differential UGV
 
 ```sh


### PR DESCRIPTION
## Motivation
A recent [post in the Discuss forum](https://discuss.px4.io/t/diy-rover-some-suggest-and-problem/28346#h-1the-px4-document-has-very-little-introduction-to-rover-5) about the poor documentation of using Rovers in PX4 has sparked my interest in improving the general documentation on Rovers.

Currently there are a lot of problems in terms of making a simple Rover work in PX4 since it is mostly focused on flight control and multicopter / fixed-wing vehicles. However, I think having a better documentation will at least attract more users to try out rover and lead to contributions / improvements in the end.

## Content
This is a first cut at improving the documentation and I would like to add the build documentation for a racing boat I am currently configuring as a follow up in a separate PR.

Let's make Rovers work well with PX4 :mechanical_arm: !