### PR TITLE
PWM3901 - better point to mounting info in sub topics

### DIFF
--- a/en/sensor/pmw3901.md
+++ b/en/sensor/pmw3901.md
@@ -16,14 +16,13 @@ The board name links to board-specific sections that include wiring and purchase
 
 Manufacture | Board | Interface | Flow | Range Finder | Gyro | Voltage (V) | Size (mm) | Max Height (m)
 --- | --- | --- | --- | --- | --- | --- | --- | ---
-Bitcraze | [Flow breakout](#bitcraze_flow_breakout) | SPI | Y | Y | - | 3 - 5 | 21x20 | 1
-Tindie | [PMW3901 Optical Flow Sensor](#tindie_pmw3901_flow_sensor) | SPI | Y | - | - | 3 - 5 | AxB | -
-Hex | [HereFlow PMW3901 Optical Flow Sensor](#hex_hereflow_pwm3901) | CAN | Y | Y | Y | 3 - 5 | AxB | 4
-Thone | [ThoneFlow-3901U](#thone_thoneflow_3901U) | UART | Y | - | - | 3 - 5 | AxB | -
-Alientek | [ATK-PMW3901](#alientek_atk-pwm3901) | SPI | Y | - | - | 3.3 - 4.2 | 27.5x16.5 | 1
+Bitcraze | [Flow breakout](#bitcraze-flow-breakout) | SPI | Y | Y | - | 3 - 5 | 21x20 | 1
+Tindie | [PMW3901 Optical Flow Sensor](#tindie-pmw3901-optical-flow-sensor) | SPI | Y | - | - | 3 - 5 | AxB | -
+Hex | [HereFlow PMW3901 Optical Flow Sensor](#hex-hereflow-pmw3901-optical-flow-sensor) | CAN | Y | Y | Y | 3 - 5 | AxB | 4
+Thone | [ThoneFlow-3901U](#thone-thoneflow-3901u) | UART | Y | - | - | 3 - 5 | AxB | -
+Alientek | [ATK-PMW3901](#alientek-atk-pmw3901) | SPI | Y | - | - | 3.3 - 4.2 | 27.5x16.5 | 1
 
 
-<a id="external_rangefinder"></a>
 ## External Rangefinders
 
 An external rangefinder/distance sensor is *required* for the sensors that don't have a rangefinder (e.g. *Tindie* or *Thone*) and *recommended* for the other boards (as their range is quite limited).
@@ -39,7 +38,6 @@ The sensor can be mounted anywhere but must point down, and should be connected/
 The PX4 team mainly tested using the [Lidar Lite V3](../sensor/lidar_lite.md) on larger vehicles and the [Lanbao CM8JL65](../sensor/cm8jl65_ir_distance_sensor.md) on smaller vehicles.
 :::
 
-<a id="orientation"></a>
 ## Mounting/Orientation
 
 Flow modules are typically mounted near the centre of the vehicle.
@@ -63,7 +61,6 @@ Tindie<br>![PMW3901 Tindie Notch](../../assets/hardware/sensors/pmw3901/tindie_n
 Thone<br>![PMW3901 Thoneflow Notch](../../assets/hardware/sensors/pmw3901/thoneflow_3901u_notch.jpg) | Alientek (also has an arrow indicating the front!)<br>![PMW3901 Alientek Notch](../../assets/hardware/sensors/pmw3901/alientek_pmw3901_notch.jpg)
 
 
-<a id="configuration"></a>
 ## PX4 Configuration
 
 The PX4 configuration that is common to all PMW3901-based boards:
@@ -78,24 +75,24 @@ In addition for:
 
 Individual flow sensors are further setup/configured as described in the sections below.
 
-<a id="bitcraze_flow_breakout"></a>
-## Bitcraze Flow breakout
+## Bitcraze Flow Breakout
 
-The [Bitcraze Flow breakout](https://www.bitcraze.io/products/flow-breakout/) directly exposes the [SPI interface](#spi_wiring) from the PMW3901 module.
+The [Bitcraze Flow breakout](https://www.bitcraze.io/products/flow-breakout/) directly exposes the [SPI interface](#spi-wiring) from the PMW3901 module.
 
-The board also incorporates a distance sensor [wired to the Pixhawk I2C port](#i2c_wiring).
+The board also incorporates a distance sensor [wired to the Pixhawk I2C port](#i2c-wiring).
 This distance sensor is the VL53L0x ToF sensor from STMicroelectronics.
 The sensor range is minimal (2 metres) and will be reduced when flying in the sunlight.
-We therefore highly recommend that you use an [external distance sensor](#external_rangefinder).
+We therefore highly recommend that you use an [external distance sensor](#external-rangefinders).
 
 ![Bitcraze Flow Deck](../../assets/hardware/sensors/pmw3901/bitcraze-flow.jpg)
 
+[PX4 configuration](#px4-configuration) and [mounting/orientation](#mounting-orientation) instructions are provided above.
 
-<a id="spi_wiring"></a>
 ### SPI Wiring
 
-The PMW3901, if connected to the SPI port on a Pixhawk 4, will automatically detect the Bitcraze flow module. This device's driver was explicitly written to be plugged into the SPI port using the chip select 1.
-No parameters will have to be configured other than the [orientation and position of the sensor](#orientation).
+The PMW3901, if connected to the SPI port on a Pixhawk 4, will automatically detect the Bitcraze flow module.
+This device's driver was explicitly written to be plugged into the SPI port using the chip select 1.
+No parameters will have to be configured other than the [orientation and position of the sensor](#mounting-orientation).
 
 The pinout mapping for the Pixhawk SPI port to Bitcraze Flow Board is shown below (the port mapping is the same for all Pixhawk FMU versions).
 
@@ -117,37 +114,36 @@ The following diagram shows how to wire the sensor to a Pixhawk 4.
 ![Bitcraze PH4 Pinout](../../assets/hardware/sensors/pmw3901/ph4-bitcraze-flow-pinout.png)
 
 
-<a id="i2c_wiring"></a>
 ### I2C Wiring
 
 The I2C wiring is the same for any other distance sensor.
 Simply connect the SLA, SLC, GND, and VCC to the corresponding (same) pins on the Pixhawk and the sensor. 
 
-
-<a id="tindie_pmw3901_flow_sensor"></a>
 ## Tindie PMW3901 Optical Flow Sensor
 
-The Tindie [PMW3901 Optical Flow Sensor](https://www.tindie.com/products/onehorse/pmw3901-optical-flow-sensor/) exposes the SPI interface from the PMW3901 module exactly as on the Bitcraze module (see [SPI Wiring](#spi_wiring)).
+The Tindie [PMW3901 Optical Flow Sensor](https://www.tindie.com/products/onehorse/pmw3901-optical-flow-sensor/) exposes the SPI interface from the PMW3901 module exactly as on the Bitcraze module (see [SPI Wiring](#spi-wiring)).
 
 ![Tindie PH4 Pinout](../../assets/hardware/sensors/pmw3901/ph4-tindie-flow-pinout.png)
 
-The sensor doesn't have a distance sensor onboard, so you will need to use an [external distance sensor](#external_rangefinder).
+The sensor doesn't have a distance sensor onboard, so you will need to use an [external distance sensor](#external-rangefinders).
+
+[PX4 configuration](#px4-configuration) and [mounting/orientation](#mounting-orientation) instructions are provided above.
 
 
-<span id="alientek_atk-pwm3901"></span>
 ## AlienTek ATK-PMW3901
 
-The AlienTek [ATK-PMW3901](https://www.aliexpress.com/i/32979605707.html) exposes the SPI interface from the PMW3901 module in the same way as the Bitcraze module (see [SPI Wiring](#spi_wiring)).
+The AlienTek [ATK-PMW3901](https://www.aliexpress.com/i/32979605707.html) exposes the SPI interface from the PMW3901 module in the same way as the Bitcraze module (see [SPI Wiring](#spi-wiring)).
 
 ![Alientek Pixhawk4 Connections](../../assets/hardware/sensors/pmw3901/ph4-alientek-flow-pinout.png)
 
-The board also incorporates a distance sensor (we recommend that you use an [external distance sensor](#external_rangefinder)).
-You can wire the internal sensor to the Pixhawk I2C port [in the same way as any other I2C peripheral.](#i2c_wiring)
+The board also incorporates a distance sensor (we recommend that you use an [external distance sensor](#external-rangefinders)).
+You can wire the internal sensor to the Pixhawk I2C port [in the same way as any other I2C peripheral.](#i2c-wiring)
 A screenshot showing the I2C pins (SLA, SLC, GND, and VCC) is provided below.
 
 ![Alientek Pinout](../../assets/hardware/sensors/pmw3901/alientek.png)
 
-<a id="hex_hereflow_pwm3901"></a>
+[PX4 configuration](#px4-configuration) and [mounting/orientation](#mounting-orientation) instructions are provided above.
+
 ## Hex HereFlow PMW3901 Optical Flow Sensor
 
 The Hex [HereFlow PMW3901 Optical Flow Sensor](http://www.proficnc.com/all-products/185-pixhawk2-suite.html) is a tiny board containing the PMW3901 flow module, VL53L1X distance sensor, and an IMU (used to synchronize the flow data with the gyro data).
@@ -156,8 +152,9 @@ An onboard microcontroller samples the three sensors and publishes two UAVCAN me
 
 The board can be connected to any CAN port on any Pixhawk board (see [UAVCAN wiring](#uavcan_wiring)).
 
-As for the other optical flow boards, we recommend that you use an [external distance sensor](#external_rangefinder).
+As for the other optical flow boards, we recommend that you use an [external distance sensor](#external-rangefinders).
 
+[PX4 configuration](#px4-configuration) and [mounting/orientation](#mounting-orientation) instructions are provided above.
 
 <a id="uavcan_wiring"></a>
 ### UAVCAN Wiring/Setup
@@ -172,18 +169,20 @@ In addition to any other configuration, you will need to set the parameter [UAVC
 
 For general information about UAVCAN wiring and configuration see: [UAVCAN Peripherals](../uavcan/README.md).
 
-<a id="thone_thoneflow_3901U"></a>
 ## Thone ThoneFlow-3901U
 
 The Thone [ThoneFlow-3901U](https://www.seeedstudio.com/ThoneFlow-3901U-UART-Serial-Version-PMW3901-Optical-Flow-Sensor-p-4040.html) exposes a PMW3901 optical flow module via a UART interface.
 
-The board doesn't include a distance sensor onboard, so you will need to use an [external distance sensor](#external_rangefinder).
+The board doesn't include a distance sensor onboard, so you will need to use an [external distance sensor](#external-rangefinders).
 
 ![PMW3901 Thoneflow Hero](../../assets/hardware/sensors/pmw3901/thoneflow_3901u_hero.jpg)
 
 <!-- note, this will be set using SENS_TFLOW_CFG
 Wiring is also required.
 -->
-In addition to the general [PX4 configuration](#px4-configuration) you must also set the parameter [SENS_TFLOW_CFG](../advanced_config/parameter_reference.md#SENS_TFLOW_CFG) to the value of the UART port you connected (e.g. if the sensor is connected to `TELEM 2` then set `SENS_TFLOW_CFG=102`.
+
+[PX4 configuration](#px4-configuration) and [mounting/orientation](#mounting-orientation) instructions are provided above.
+
+In addition, you must also set the parameter [SENS_TFLOW_CFG](../advanced_config/parameter_reference.md#SENS_TFLOW_CFG) to the value of the UART port you connected (e.g. if the sensor is connected to `TELEM 2` then set `SENS_TFLOW_CFG=102`.
 For more information see [Serial Port Configuration](../peripherals/serial_configuration.md).
 


### PR DESCRIPTION
There was some confusion about orientation of the board w.r.t. autopilot. This was answered in the mounting instructions, but not clear to the reader. 

This updates all individual sections to point back up to the PX4 config and mounting instructions. 

I also removed some explicitly defined anchors to link to headings instead.