### PR TITLE
Change to host networking in container example

### DIFF
--- a/en/test_and_ci/docker.md
+++ b/en/test_and_ci/docker.md
@@ -129,15 +129,19 @@ xhost +
 # Run docker and open bash shell
 docker run -it --privileged \
 --env=LOCAL_USER_ID="$(id -u)" \
--v ~/Projects/PX4-Autopilot:/src/PX4-Autopilot/:rw \
+-v ~/src/PX4-Autopilot:/src/PX4-Autopilot/:rw \
 -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
--e DISPLAY=$DISPLAY \
+-e DISPLAY=:0 \
 --network host \
 --name=px4-ros px4io/px4-dev-ros2-foxy:2022-07-31 bash
 ```
 
 :::note
 We use the host network mode to avoid conflicts between the UDP port access control when using QGroundControl on the same system as the docker container.
+:::
+
+:::note
+In some situations, `DISPLAY` may need to be set to a different value such as `:1`. It may be possible to determine what that value is by using `echo $DISPLAY` or simply by changing `-e DISPLAY=:0` to `-e DISPLAY=$DISPLAY`. Note that making that change assumes that the environment variable `DISPLAY` has been set.
 :::
 
 If everything went well you should be in a new bash shell now. Verify if everything works by running, for example, SITL:

--- a/en/test_and_ci/docker.md
+++ b/en/test_and_ci/docker.md
@@ -141,7 +141,9 @@ We use the host network mode to avoid conflicts between the UDP port access cont
 :::
 
 :::note
-In some situations, `DISPLAY` may need to be set to a different value such as `:1`. It may be possible to determine what that value is by using `echo $DISPLAY` or simply by changing `-e DISPLAY=:0` to `-e DISPLAY=$DISPLAY`. Note that making that change assumes that the environment variable `DISPLAY` has been set.
+If you encounter the error "Can't open display: :0", `DISPLAY` may need to be set to a different value.
+On Linux (XWindow) hosts you can change `-e DISPLAY=:0` to `-e DISPLAY=$DISPLAY`.
+On other hosts you might iterate the value of `0` in  `-e DISPLAY=:0` until the "Can't open display: :0" error goes away.
 :::
 
 If everything went well you should be in a new bash shell now. Verify if everything works by running, for example, SITL:

--- a/en/test_and_ci/docker.md
+++ b/en/test_and_ci/docker.md
@@ -126,12 +126,16 @@ xhost +
 # Run docker and open bash shell
 docker run -it --privileged \
 --env=LOCAL_USER_ID="$(id -u)" \
--v ~/src/PX4-Autopilot:/src/PX4-Autopilot/:rw \
+-v ~/Projects/PX4-Autopilot:/src/PX4-Autopilot/:rw \
 -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
--e DISPLAY=:0 \
--p 14570:14570/udp \
---name=mycontainer px4io/px4-dev-ros:2017-10-23 bash
+-e DISPLAY=$DISPLAY \
+--network host \
+--name=px4-ros px4io/px4-dev-ros2-foxy:2022-07-31 bash
 ```
+
+:::note
+We use the host network mode to avoid conflicts between the UDP port access control when using QGroundControl on the same system as the docker container.
+:::
 
 If everything went well you should be in a new bash shell now. Verify if everything works by running, for example, SITL:
 

--- a/en/test_and_ci/docker.md
+++ b/en/test_and_ci/docker.md
@@ -12,7 +12,8 @@ They are built automatically on [Docker Hub](https://hub.docker.com/u/px4io/).
 ## Prerequisites
 
 :::note
-PX4 containers are currently only supported on Linux (if you don't have Linux you can run the container [inside a virtual machine](#virtual_machine)). Do not use `boot2docker` with the default Linux image because it contains no X-Server.
+PX4 containers are currently only supported on Linux (if you don't have Linux you can run the container [inside a virtual machine](#virtual_machine)).
+Do not use `boot2docker` with the default Linux image because it contains no X-Server.
 :::
 
 [Install Docker](https://docs.docker.com/installation/) for your Linux computer, preferably using one of the Docker-maintained package repositories to get the latest stable version. You can use either the *Enterprise Edition* or (free) *Community Edition*.
@@ -48,7 +49,9 @@ For example, below you can see that the docker container with nuttx build tools 
   - px4io/px4-dev-nuttx-focal
   - px4io/px4-dev-simulation-focal
     - px4io/px4-dev-ros-noetic
-    - px4io/px4-dev-ros2-foxy
+      - px4io/px4-dev-ros2-foxy
+  - px4io/px4-dev-ros2-rolling
+  - px4io/px4-dev-ros2-galactic
 
 
 The most recent version can be accessed using the `latest` tag: `px4io/px4-dev-nuttx-bionic:latest`


### PR DESCRIPTION
When running the container example in bridged mode, QGroundControl reports that the UDP port is already in use when attempting to connect to the SITL simulation through the comms ports. This is rectified by including a note and making a slight modification to the example code.