### PR TITLE
Fixing the reference for mavlink start changes

### DIFF
--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -309,7 +309,7 @@ Do not use this approach if there are multiple simulations running on the networ
 :::
 
 This should be done in an appropriate configuration file where `mavlink start` is called.
-For example: [/ROMFS/px4fmu_common/init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/rcS).
+For example: [/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink).
 
 
 ### Enable Streaming to Specific Address
@@ -318,7 +318,7 @@ The [mavlink module](../modules/modules_communication.md#mavlink_usage) routes t
 The specified remote computer can then connect to the simulator by listening to the appropriate port (i.e. 14550 for *QGroundControl*).
 
 This should be done in various configuration files where `mavlink start` is called.
-For example: [/ROMFS/px4fmu_common/init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/rcS).
+For example: [/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink).
 
 
 ### SSH Tunneling


### PR DESCRIPTION
The file that must be changed to enable broadcasting and specific address streaming is the one that call `mavlink start`. This file is the `px4-rc.mavlink` instead of the `rcS`.