### PR TITLE
airspeed - set the primary source

### DIFF
--- a/en/sensor/airspeed.md
+++ b/en/sensor/airspeed.md
@@ -26,7 +26,6 @@ All the above sensors are connected via the I2C bus/port.
 Additionally, the [Avionics Anonymous Air Data Computer](https://www.tindie.com/products/avionicsanonymous/uavcan-air-data-computer-airspeed-sensor/) can be connected to the UAVCAN bus to determine not only high-accuracy airspeed, but also true static pressure and air temperature via onboard barometer and an OAT probe.
 :::
 
-
 ## Configuration
 
 ### Enable Airspeed Sensors
@@ -39,7 +38,11 @@ Enable each type using its [corresponding parameter](../advanced_config/paramete
 - **TE MS5525:** [SENS_EN_MS5525DS](../advanced_config/parameter_reference.md#SENS_EN_MS5525DS)
 - **Eagle Tree airspeed sensor:** [SENS_EN_ETSASPD](../advanced_config/parameter_reference.md#SENS_EN_ETSASPD)
 
-### Sensor-specific configuration
+### Set Primary Source
+
+If you have enabled multiple airspeed sensors enabled, you can select which one is the primary source for measurements using [ASPD_PRIMARY](../advanced_config/parameter_reference.md#ASPD_PRIMARY).
+
+### Sensor-specific Configuration
 
 Other than enabling the sensor, sensor-specific configuration is often not required.
 If it is needed, it should be covered in the appropriate sensor page (for example [TFSLOT > Configuration](./airspeed_tfslot.md\#configuration)).

--- a/en/sensor/airspeed.md
+++ b/en/sensor/airspeed.md
@@ -38,7 +38,7 @@ Enable each type using its [corresponding parameter](../advanced_config/paramete
 - **TE MS5525:** [SENS_EN_MS5525DS](../advanced_config/parameter_reference.md#SENS_EN_MS5525DS)
 - **Eagle Tree airspeed sensor:** [SENS_EN_ETSASPD](../advanced_config/parameter_reference.md#SENS_EN_ETSASPD)
 
-You should also check [ASPD_PRIMARY](../advanced_config/parameter_reference.md#ASPD_PRIMARY) is `1` (the default).
+You should also check [ASPD_PRIMARY](../advanced_config/parameter_reference.md#ASPD_PRIMARY) is `1` (see next section - this is the default).
 
 ### Multiple Airspeed Sensors
 

--- a/en/sensor/airspeed.md
+++ b/en/sensor/airspeed.md
@@ -38,9 +38,19 @@ Enable each type using its [corresponding parameter](../advanced_config/paramete
 - **TE MS5525:** [SENS_EN_MS5525DS](../advanced_config/parameter_reference.md#SENS_EN_MS5525DS)
 - **Eagle Tree airspeed sensor:** [SENS_EN_ETSASPD](../advanced_config/parameter_reference.md#SENS_EN_ETSASPD)
 
-### Set Primary Source
+You should also check [ASPD_PRIMARY](../advanced_config/parameter_reference.md#ASPD_PRIMARY) is `1` (the default).
 
-If you have enabled multiple airspeed sensors enabled, you can select which one is the primary source for measurements using [ASPD_PRIMARY](../advanced_config/parameter_reference.md#ASPD_PRIMARY).
+### Multiple Airspeed Sensors
+
+If you have multiple airspeed sensors then you can select which sensor is _preferred_ as the primary source using [ASPD_PRIMARY](../advanced_config/parameter_reference.md#ASPD_PRIMARY), where `1`, `2` and `3` reflect the order in which the airspeed sensors were started:
+- `-1`: Disabled (no airspeed information used). 
+- `0`: Synthetic airspeed estimation (groundspeed minus windspeed)
+- `1`: First airspeed sensor started (default)
+- `2`: Second airspeed sensor started
+- `3`: Third airspeed sensor started
+
+The airspeed selector validates the indicated sensor _first_ and only falls back to other sensors if the indicated sensor fails the checks.
+The selected sensor is then used to supply data to the estimator (EKF2).
 
 ### Sensor-specific Configuration
 


### PR DESCRIPTION
@sfuhrer @avcuenes This PR replaces https://github.com/PX4/PX4-user_guide/pull/2005 because I can't easily remove the changes to translations.

@sfuhrer It is worth mentioning [ASPD_PRIMARY](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#ASPD_PRIMARY) here.

Two questions:

1. ASPD_PRIMARY sets an index. How can I tell/find out which index matches to which sensor I have enabled?
2. What does it mean to be the primary? Is this just weighted in some way in EKF2 or is it the ONLY thing used by EKF2 and then dropped if EKF2 somehow decides the first value is invalid. Are there docs I can point to?
