### PR TITLE
Uorb-graph: add new style for bidirectional links

### DIFF
--- a/.vuepress/public/en/middleware/uorb_graph.js
+++ b/.vuepress/public/en/middleware/uorb_graph.js
@@ -115,6 +115,20 @@ function loadSimulation(json_file_name) {
         }
         */
 
+        // change style for bidirectional edges
+        const edgeMap = new Map();
+        var i = 0;
+        while(i<graph.links.length) {
+            var curr_source = graph.links[i].source;
+            var curr_target = graph.links[i].target;
+            if (edgeMap.has(curr_target + curr_source) == true) {
+                graph.links.splice(i,1);
+                graph.links[edgeMap.get(curr_target + curr_source)].style = "dot-dashed";
+            }
+            else
+                edgeMap.set(curr_source + curr_target, i++);
+        }
+
         // explanation for the following syntax: https://bost.ocks.org/mike/join/
         link = svg.append("g")
             .attr("class", "links")
@@ -125,6 +139,7 @@ function loadSimulation(json_file_name) {
             .attr("stroke", function(d) { return d.color; })
             .style("stroke-dasharray", function(d) {
                 if (d.style == "dashed") return "3, 3";
+                if (d.style == "dot-dashed") return "3, 3, 9, 3";
                 return "1, 0";
             });
 

--- a/en/middleware/uorb_graph.md
+++ b/en/middleware/uorb_graph.md
@@ -26,7 +26,7 @@ The graph has the following properties:
 
 - Modules are shown in gray with rounded corners while topics are displayed as coloured rectangular boxes.
 - Associated modules and topics are connected by lines.
-  Dashed lines indicate that the module publishes the topic, while solid lines indicate that the module subscribes to the topic.
+  Dashed lines indicate that the module publishes the topic, solid lines indicate that the module subscribes to the topic, while dot-dashed lines indicate that the module both publishes and subscribes to the topic.
 - Some modules and topics are excluded:
   - Topics that are subscribed/published by many modules: `parameter_update`, `mavlink_log` and `log_message`.
   - The set of logged topics.


### PR DESCRIPTION
## Describe problem solved by this pull request
Fixes #2010
In the uorb graph, if a module publishes and subscribe to the same topic, then only the solid line of the subscriber link is visible.

## Describe your solution
Before the links are drawn, the link array is inspected and if a pair of links with swapped source and target nodes is found, then one of the two links is deleted while the style of the other is changed to _dot-dashed_.

I hope that with this third style the graph is still clear.
