### PR TITLE
Update micrortps.md

### DIFF
--- a/en/middleware/micrortps.md
+++ b/en/middleware/micrortps.md
@@ -145,7 +145,7 @@ The PX4 Autopilot firmware initialization code may in future automatically start
 For example, in order to run the *Client* daemon with SITL connecting to the Agent via UDP:
 
 ```sh
-micrortps_client start -t UDP
+micrortps_agent start -t UDP
 ```
 
 ## Agent in an Offboard Fast DDS interface (ROS-independent)


### PR DESCRIPTION
On Ubuntu 22.04 with px4_msgs@7f89976091235579633935b7ccaab68b2debbe19 and PX4_Autopilot@e780a583cd2f3c0c42978ff0e5c010f104443267, micrortps_client is not found. The micrortps_agent seems to be working though.