### PR TITLE
Purge mixer from Adding an Airframe

### DIFF
--- a/en/dev_airframes/adding_a_new_frame.md
+++ b/en/dev_airframes/adding_a_new_frame.md
@@ -1,11 +1,30 @@
-# Adding a New Airframe Configuration
+# Adding a Frame Configuration
 
-PX4 uses canned airframe configurations as starting point for airframes.
-The configurations are defined in [config files](#config-file) that are stored in the [ROMFS/px4fmu_common/init.d](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d) folder.
+PX4 [frame configuration files](#configuration-file-overview) are shell scripts that set up some (or all) of the parameters, controllers and apps needed for a particular vehicle frame, such as a quadcopter, ground vehicle, or boat.
+These scripts are executed when the corresponding airframe is is selected and applied in QGroundControl during [AirFrame](../config/airframe.md) configuration.
 
-Adding a configuration is straightforward: create a new config file in the [init.d/airframes folder](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d/airframes) (prepend the filename with an unused autostart ID), add the name of your new airframe config file to the [CMakeLists.txt](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt) in the relevant section, then [build and upload](../dev_setup/building_px4.md) the software.
+The configuration files for NuttX targets are stored in the [ROMFS/px4fmu_common/init.d](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d) folder (configuration files for POSIX simulators are stored in [ROMFS/px4fmu_common/init.d-posix](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d-posix/airframes)).
+The folder contains both complete and full configurations for specific vehicles, and partial "generic configurations" for different vehicle types.
+The generic configurations are often used as the starting point for creating new configuration files.
 
-Developers who do not want to create their own configuration can instead customize existing configurations using text files on the microSD card, as detailed on the [custom system startup](../concept/system_startup.md) page.
+In addition, a frame configuration file can also be loaded from an SD card, or you can _customize_ the current existing firmware configuration using text files on the SD card
+Both cases are detailed on the [System Startup](../concept/system_startup.md) page.
+
+## How to add a Frame Configuration
+
+When developing a new frame it is usual to select an appropriate "generic configuration" in QGC, such as _Generic Quadcopter_, configure the geometry/outputs, tune the vehicle.
+Once the vehicle is ready you can create a new configuration file that appends the additional parameters to the information in the original generic configuration.
+
+:::note
+The [`param show-for-airframe`](../modules/modules_command.md#param) console command can be used to list the parameter difference compared to the original generic airfame.
+:::
+
+To create a new frame configuration:
+
+1. Create a new config file in the [init.d/airframes](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d/airframes) folder.
+   Give it a short descriptive filename and prepend the filename with an unused autostart ID.
+
+1. Add the name of the new frame config file to the [CMakeLists.txt](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt) in the relevant section for the type of vehicle, then [build and upload](../dev_setup/building_px4.md) the software.
 
 :::note
 To determine which parameters/values need to be set in the configuration file, you can first assign a generic airframe and tune the vehicle, and then use [`param show-for-airframe`](../modules/modules_command.md#param) to list the parameters that changed.
@@ -15,76 +34,208 @@ To determine which parameters/values need to be set in the configuration file, y
 
 The configuration file consists of several main blocks:
 
-* Airframe documentation (used in the [Airframes Reference](../airframes/airframe_reference.md) and *QGroundControl*).
+* Documentation (used in the [Airframes Reference](../airframes/airframe_reference.md) and *QGroundControl*).
 * Airframe-specific parameter settings, including [tuning gains](#tuning-gains)
 * The controllers and apps it should start, e.g. multicopter or fixed wing controllers, land detectors etc.
-* The physical configuration of the system (e.g. a plane, wing or multicopter) and geometry.
-  Geometry may be specified using a [mixer file](#mixer-file) or using [control allocation](../concept/control_allocation.md) parameters (from PX4 v1.13).
+* The physical configuration of the system (e.g. a plane, wing or multicopter) and geometry using [control allocation](../concept/control_allocation.md) parameters.
 
 These aspects are mostly independent, which means that many configurations share the same physical layout of the airframe, start the same applications and differ most in their tuning gains.
 
 :::note
-New airframe files are only automatically added to the build system after a clean build (run `make clean`).
+New frame configuration files are only automatically added to the build system after a clean build (run `make clean`).
 :::
 
-<a id="config-file"></a>
-### Config File
+### Example - Generic Quadcopter Frame Config
 
-A typical configuration file is shown below ([original file here](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/airframes/3033_wingwing)).
-
-The first section is the airframe documentation.
-This is used in the [Airframes Reference](../airframes/airframe_reference.md) and *QGroundControl*.
-```bash
+```
 #!/bin/sh
 #
-# @name Wing Wing (aka Z-84) Flying Wing
+# @name Generic Quadcopter
 #
-# @url https://docs.px4.io/master/en/frames_plane/wing_wing_z84.html
-#
-# @type Flying Wing
-# @class Plane
-#
-# @output MAIN1 left aileron
-# @output MAIN2 right aileron
-# @output MAIN4 throttle
-#
-# @output AUX1 feed-through of RC AUX1 channel
-# @output AUX2 feed-through of RC AUX2 channel
-# @output AUX3 feed-through of RC AUX3 channel
+# @type Quadrotor x
+# @class Copter
 #
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
+
+. ${R}etc/init.d/rc.mc_defaults
+
+param set-default CA_ROTOR_COUNT 4
+param set-default CA_ROTOR0_PX 0.15
+param set-default CA_ROTOR0_PY 0.15
+param set-default CA_ROTOR1_PX -0.15
+param set-default CA_ROTOR1_PY -0.15
+param set-default CA_ROTOR2_PX 0.15
+param set-default CA_ROTOR2_PY -0.15
+param set-default CA_ROTOR2_KM -0.05
+param set-default CA_ROTOR3_PX -0.15
+param set-default CA_ROTOR3_PY 0.15
+param set-default CA_ROTOR3_KM -0.05
+```
+
+### Example - Babyshark VTOL Complete Vehicle
+
+A typical configuration file is shown below.
+This is the configuration for the Baby Shark [Standard VTOL](../frames_vtol/standardvtol.md) ([original file here](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark)).
+
+The first line is a shebang, which tells the NuttX operating system (on which PX4 runs) that the configuration file is an executable shell script.
+This is followed by the frame documentation.
+
+The shebang is followed by the frame documentation, which is used in the [Airframes Reference](../airframes/airframe_reference.md) and *QGroundControl*.
+
+The name and 
+
+`@name` is the name of the frame, `@class` are used to 
+This is used in 
+
+
+
+
+This is used in the [Airframes Reference](../airframes/airframe_reference.md) and *QGroundControl*.
+
+
+```bash
+#!/bin/sh
+#
+# @name BabyShark VTOL
+#
+# @type Standard VTOL
+# @class VTOL
+#
+# @maintainer Silvan Fuhrer <silvan@auterion.com>
+#
+# @output Motor1 motor 1
+# @output Motor2 motor 2
+# @output Motor3 motor 3
+# @output Motor4 motor 4
+# @output Motor5 Pusher motor
+# @output Servo1 Ailerons
+# @output Servo2 A-tail left
+# @output Servo3 A-tail right
+#
 # @board px4_fmu-v2 exclude
 # @board bitcraze_crazyflie exclude
+# @board holybro_kakutef7 exclude
 #
 ```
 
 The next section specifies vehicle-specific parameters, including [tuning gains](#tuning-gains):
+
 ```bash
-. ${R}etc/init.d/rc.fw_defaults
+. ${R}etc/init.d/rc.vtol_defaults
 
-param set-default BAT_N_CELLS 2
-param set-default FW_AIRSPD_MAX 15
-param set-default FW_AIRSPD_MIN 10
-param set-default FW_AIRSPD_TRIM 13
-param set-default FW_R_TC 0.3
-param set-default FW_P_TC 0.3
-param set-default FW_L1_DAMPING 0.74
-param set-default FW_L1_PERIOD 16
-param set-default FW_LND_ANG 15
-param set-default FW_LND_FLALT 5
-param set-default FW_LND_HHDIST 15
-param set-default FW_LND_HVIRT 13
-param set-default FW_LND_TLALT 5
-param set-default FW_THR_LND_MAX 0
-param set-default FW_PR_FF 0.35
-param set-default FW_RR_FF 0.6
-param set-default FW_RR_P 0.04
+param set-default MAV_TYPE 22
 
-param set-default PWM_MAIN_DISARM 1000
+param set-default BAT1_N_CELLS 6
+
+param set-default FW_AIRSPD_MAX 30
+param set-default FW_AIRSPD_MIN 19
+param set-default FW_AIRSPD_TRIM 23
+param set-default FW_L1_R_SLEW_MAX 40
+param set-default FW_PSP_OFF 3
+param set-default FW_P_LIM_MAX 18
+param set-default FW_P_LIM_MIN -25
+param set-default FW_RLL_TO_YAW_FF 0.1
+param set-default FW_RR_P 0.08
+param set-default FW_R_LIM 45
+param set-default FW_R_RMAX 50
+param set-default FW_THR_TRIM 0.65
+param set-default FW_THR_MIN 0.3
+param set-default FW_THR_SLEW_MAX 0.6
+param set-default FW_T_HRATE_FF 0
+param set-default FW_T_SINK_MAX 15
+param set-default FW_T_SINK_MIN 3
+param set-default FW_YR_P 0.15
+
+param set-default IMU_DGYRO_CUTOFF 15
+param set-default MC_PITCHRATE_MAX 60
+param set-default MC_ROLLRATE_MAX 60
+param set-default MC_YAWRATE_I 0.15
+param set-default MC_YAWRATE_MAX 40
+param set-default MC_YAWRATE_P 0.3
+
+param set-default MPC_ACC_DOWN_MAX 2
+param set-default MPC_ACC_HOR_MAX 2
+param set-default MPC_ACC_UP_MAX 3
+param set-default MC_AIRMODE 1
+param set-default MPC_JERK_AUTO 4
+param set-default MPC_LAND_SPEED 1
+param set-default MPC_MAN_TILT_MAX 25
+param set-default MPC_MAN_Y_MAX 40
+param set-default COM_SPOOLUP_TIME 1.5
+param set-default MPC_THR_HOVER 0.45
+param set-default MPC_TILTMAX_AIR 25
+param set-default MPC_TKO_RAMP_T 1.8
+param set-default MPC_TKO_SPEED 1
+param set-default MPC_VEL_MANUAL 3
+param set-default MPC_XY_CRUISE 3
+param set-default MPC_XY_VEL_MAX 3.5
+param set-default MPC_YAWRAUTO_MAX 40
+param set-default MPC_Z_VEL_MAX_UP 2
+
+param set-default NAV_ACC_RAD 3
+
+param set-default PWM_MAIN_DIS3 1000
+param set-default PWM_MAIN_MIN3 1120
+
+param set-default SENS_BOARD_ROT 4
+
+param set-default VT_ARSP_BLEND 10
+param set-default VT_ARSP_TRANS 21
+param set-default VT_B_DEC_MSS 1.5
+param set-default VT_B_TRANS_DUR 12
+param set-default VT_ELEV_MC_LOCK 0
+param set-default VT_FWD_THRUST_SC 1.2
+param set-default VT_F_TR_OL_TM 8
+param set-default VT_PSHER_RMP_DT 2
+param set-default VT_TRANS_MIN_TM 4
+param set-default VT_TYPE 2
+```
+
+```bash
+param set-default CA_AIRFRAME 2
+param set-default CA_ROTOR_COUNT 5
+param set-default CA_ROTOR0_PX 1
+param set-default CA_ROTOR0_PY 1
+param set-default CA_ROTOR1_PX -1
+param set-default CA_ROTOR1_PY -1
+param set-default CA_ROTOR2_PX 1
+param set-default CA_ROTOR2_PY -1
+param set-default CA_ROTOR2_KM -0.05
+param set-default CA_ROTOR3_PX -1
+param set-default CA_ROTOR3_PY 1
+param set-default CA_ROTOR3_KM -0.05
+param set-default CA_ROTOR4_AX 1.0
+param set-default CA_ROTOR4_AZ 0.0
+
+param set-default CA_SV_CS_COUNT 3
+param set-default CA_SV_CS0_TYPE 15
+param set-default CA_SV_CS0_TRQ_R 1.0
+param set-default CA_SV_CS1_TRQ_P 0.5000
+param set-default CA_SV_CS1_TRQ_R 0.0000
+param set-default CA_SV_CS1_TRQ_Y -0.5000
+param set-default CA_SV_CS1_TYPE 13
+param set-default CA_SV_CS2_TRQ_P 0.5000
+param set-default CA_SV_CS2_TRQ_Y 0.5000
+param set-default CA_SV_CS2_TYPE 14
+
+param set-default PWM_MAIN_FUNC1 201
+param set-default PWM_MAIN_FUNC2 202
+param set-default PWM_MAIN_FUNC3 105
+param set-default PWM_MAIN_FUNC4 203
+param set-default PWM_MAIN_FUNC5 101
+param set-default PWM_MAIN_FUNC6 102
+param set-default PWM_MAIN_FUNC7 103
+param set-default PWM_MAIN_FUNC8 104
+
+param set-default PWM_MAIN_TIM0 50
+param set-default PWM_MAIN_DIS1 1500
+param set-default PWM_MAIN_DIS2 1500
+param set-default PWM_MAIN_DIS4 1500
 ```
 
 Set frame type ([MAV_TYPE](https://mavlink.io/en/messages/common.html#MAV_TYPE)):
+
 ```bash
 # Configure this as plane
 set MAV_TYPE 1
@@ -107,131 +258,10 @@ The channels are only reversed when flying in manual mode, when you switch in an
 Thus for a correct channel assignment change either your PWM signals with `PWM_MAIN_REV1` (e.g. for channel one) or change the signs of the output scaling in the corresponding mixer (see below).
 :::
 
-<a id="mixer-file"></a>
+
 ### Mixer File
 
-:::note
-Mixer files will be replaced by [Control Allocation](../concept/control_allocation.md) parameters in the next version (after PX4 v1.13).
 
-You can enable control allocation in PX4 v1.13 by setting [SYS_CTRL_ALLOC=1](../advanced_config/parameter_reference.md#SYS_CTRL_ALLOC).
-If enabled, the geometry may then be defined using `CA_*` parameters in the airframe configuration file, as shown in [13200_generic_vtol_tailsitter](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter#L28).
-:::
-
-:::note
-First read [Concepts > Mixing](../concept/mixing.md).
-This provides background information required to interpret this mixer file.
-:::
-
-[mixer files](#mixer-file) describe the physical configuration of the system, and are stored in the [ROMFS/px4fmu_common/mixers](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/mixers) folder.
-
-A typical mixer file is shown below ([original file here](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/mixers/wingwing.main.mix)).
-A mixer filename, in this case `wingwing.main.mix`, gives important information about the type of airframe (`wingwing`), the type of output (`.main` or `.aux`) and lastly that it is a mixer file (`.mix`).
-
-The mixer file contains several blocks of code, each of which refers to one actuator or ESC.
-So if you have e.g. two servos and one ESC, the mixer file will contain three blocks of code.
-
-:::note
-The plugs of the servos / motors go in the order of the mixers in this file.
-:::
-
-So MAIN1 would be the left aileron, MAIN2 the right aileron, MAIN3 is empty (note the Z: zero mixer) and MAIN4 is throttle (to keep throttle on output 4 for common fixed wing configurations).
-
-A mixer is encoded in normalized units from -10000 to 10000, corresponding to -1..+1.
-
-```
-M: 2
-O:      10000  10000      0 -10000  10000
-S: 0 0  -6000  -6000      0 -10000  10000
-S: 0 1   6500   6500      0 -10000  10000
-```
-
-Where each number from left to right means:
-
-* M: Indicates two scalers for two control inputs.
-  It indicates the number of control inputs the mixer will receive.
-* O: Indicates the output scaling (\*1 in negative, \*1 in positive), offset (zero here), and output range (-1..+1 here).  
-  * If you want to invert your PWM signal, the signs of the output scalings have to be changed:
-    ```
-    O:      -10000  -10000      0 -10000  10000
-    ```
-  * This line can (and should) be omitted completely if it specifies the default scaling:
-    ```
-    O:      10000  10000   0 -10000  10000
-    ```
-* S: Indicates the first input scaler: It takes input from control group #0 (Flight Control) and the first input (roll).
-  It scales the roll control input * 0.6 and reverts the sign (-0.6 becomes -6000 in scaled units).
-  It applies no offset (0) and outputs to the full range (-1..+1)
-* S: Indicates the second input scaler: It takes input from control group #0 (Flight Control) and the second input (pitch). \
-  It scales the pitch control input * 0.65.
-  It applies no offset (0) and outputs to the full range (-1..+1)
-
-:::note
-In short, the output of this mixer would be SERVO = ( (roll input \* -0.6 + 0)  \* 1 + (pitch input \* 0.65 + 0)  \* 1 ) \* 1 + 0
-:::
-
-Behind the scenes, both scalers are added, which for a flying wing means the control surface takes maximum 60% deflection from roll and 65% deflection from pitch.
-
-The complete mixer looks like this:
-
-
-```bash
-Delta-wing mixer for PX4FMU
-===========================
-
-Designed for Wing Wing Z-84
-
-This file defines mixers suitable for controlling a delta wing aircraft using
-PX4FMU. The configuration assumes the elevon servos are connected to PX4FMU
-servo outputs 0 and 1 and the motor speed control to output 3. Output 2 is
-assumed to be unused.
-
-Inputs to the mixer come from channel group 0 (vehicle attitude), channels 0
-(roll), 1 (pitch) and 3 (thrust).
-
-See the README for more information on the scaler format.
-
-Elevon mixers
--------------
-Three scalers total (output, roll, pitch).
-
-The scaling factor for roll inputs is adjusted to implement differential travel
-for the elevons.
-
-This first block of code is for Servo 0...
-
-M: 2
-O:      10000  10000      0 -10000  10000
-S: 0 0  -6000  -6000      0 -10000  10000
-S: 0 1   6500   6500      0 -10000  10000
-
-And this is for Servo 1...
-
-M: 2
-O:      10000  10000      0 -10000  10000
-S: 0 0  -6000  -6000      0 -10000  10000
-S: 0 1  -6500  -6500      0 -10000  10000
-
-Note that in principle, you could implement left/right wing asymmetric mixing, but in general the two blocks of code will be numerically equal, and just differ by the sign of the third line (S: 0 1), since to roll the plane, the two ailerons must move in OPPOSITE directions.
-The signs of the second lines (S: 0 0) are identical, since to pitch the plane, both servos need to move in the SAME direction.
-
-Output 2
---------
-This mixer is empty.
-
-Z:
-
-Motor speed mixer
------------------
-Two scalers total (output, thrust).
-
-This mixer generates a full-range output (-1 to 1) from an input in the (0 - 1)
-range.  Inputs below zero are treated as zero.
-
-M: 1
-O:      10000  10000      0 -10000  10000
-S: 0 3      0  20000 -10000 -10000  10000
-
-```
 
 ## Adding a New Airframe Group
 
@@ -240,13 +270,13 @@ Every group has a name, and an associated svg image which shows the common geome
 
 The airframe metadata files used by *QGroundControl* and the documentation source code are generated from the airframe description, via a script, using the build command: `make airframe_metadata`
 
-For a new airframe belonging to an existing group, you don't need to do anything more than provide documentation in the airframe description located at
+For a new frame belonging to an existing group, you don't need to do anything more than provide documentation in the airframe description located at
 [ROMFS/px4fmu_common/init.d](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d).
 
 If the airframe is for a **new group** you additionally need to:
 1. Add the svg image for the group into user guide documentation (if no image is provided a placeholder image is displayed): [assets/airframes/types](https://github.com/PX4/PX4-user_guide/tree/master/assets/airframes/types)
 1. Add a mapping between the new group name and image filename in the [srcparser.py](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/px4airframes/srcparser.py) method `GetImageName()` (follow the pattern below): 
-   ```
+   ```python
    def GetImageName(self):
        """
        Get parameter group image base name (w/o extension)
@@ -256,7 +286,7 @@ If the airframe is for a **new group** you additionally need to:
        elif (self.name == "Flying Wing"):
            return "FlyingWing"
         ...
-	...
+    ...
        return "AirframeUnknown"
    ```
 1. Update *QGroundControl*:
@@ -280,12 +310,13 @@ If the airframe is for a **new group** you additionally need to:
 
 The following topics explain how to tune the parameters that will be specified in the config file:
 
+* [Autotuning](../config/autotune.md)
 * [Multicopter PID Tuning Guide](../config_mc/pid_tuning_guide_multicopter.md)
 * [Fixed Wing PID Tuning Guide](../config_fw/pid_tuning_guide_fixedwing.md)
 * [VTOL Configuration](../config_vtol/README.md)
 
 
-## Add New Airframe to QGroundControl
+## Add Frame to QGroundControl
 
 To make a new airframe available for section in the *QGroundControl* [airframe configuration](../config/airframe.md):
 
@@ -299,4 +330,4 @@ To make a new airframe available for section in the *QGroundControl* [airframe c
 1. Press **OK** to start flashing the firmware.
 1. Restart *QGroundControl*.
 
-The new airframe will then be available for selection in *QGroundControl*.
+The new frame will then be available for selection in *QGroundControl*.


### PR DESCRIPTION
@bkueng This purges mixers from Adding an airframe.
I've tried to make it a little more contextual and explain the process for working out what params you need. 

Also remove "air" from the frame. This configures all kinds of frames.