### PR TITLE
Remove MOT_ORDERING from Kakute

### DIFF
--- a/en/flight_controller/kakutef7.md
+++ b/en/flight_controller/kakutef7.md
@@ -9,7 +9,6 @@ The *Kakute F7* from Holybro is a flight controller board designed for racers.
 
 <img src="../../assets/flight_controller/kakutef7/board.jpg" width="400px" title="Kakute F7" />
 
-
 :::note
 This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
@@ -96,6 +95,8 @@ The firmware can be installed in any of the normal ways:
 
 
 ## Configuration
+
+If you use a 4-in-1 ESC with Betaflight/Cleanflight motor assignment you can use the [Actuator](../config/actuators.md) configuration UI to set the motor ordering appropriately.
 
 In addition to the [basic configuration](../config/README.md), the following parameters are important:
 

--- a/en/flight_controller/kakutef7.md
+++ b/en/flight_controller/kakutef7.md
@@ -1,4 +1,4 @@
-# Holybro  Kakute F7
+# Holybro Kakute F7
 
 :::warning
 PX4 does not manufacture this (or any) autopilot.
@@ -102,7 +102,6 @@ In addition to the [basic configuration](../config/README.md), the following par
 Parameter | Setting
 --- | ---
 [SYS_HAS_MAG](../advanced_config/parameter_reference.md#SYS_HAS_MAG) | This should be disabled since the board does not have an internal mag. You can enable it if you attach an external mag.
-[MOT_ORDERING](../advanced_config/parameter_reference.md#MOT_ORDERING) | If you use a 4-in-1 ESC with Betaflight/Cleanflight motor assignment, this parameter can be set accordingly.
 
 
 ## Serial Port Mapping
@@ -135,4 +134,3 @@ The  [SWD interface](../debug/swd_debug.md) (JTAG) pins are:
 These are shown below.
 
 ![SWD Pins on Kakute F7 - CLK SWO](../../assets/flight_controller/kakutef7/debug_swd_port.jpg) ![SWD Pins on Kakute F7:  GND and VDD_3V3](../../assets/flight_controller/kakutef7/debug_swd_port_gnd_vcc3_3.jpg)
-


### PR DESCRIPTION
The `MOT_ORDERING` is no longer in PX4 but was marked as an important setting.
I have deleted it, but is there something else we should be saying here?

@bkueng No urgency, but I'm sure you'll know.