### PR TITLE
Minor fixes to look at airframe reference

### DIFF
--- a/en/advanced/parameters_and_configurations.md
+++ b/en/advanced/parameters_and_configurations.md
@@ -1,12 +1,12 @@
 # Parameters & Configurations
 
-PX4 uses the *param subsystem* (a flat table of `float` and `int32_t` values) and text files (for mixers and startup scripts) to store its configuration.
+PX4 uses the *param subsystem* (a flat table of `float` and `int32_t` values) and text files (for startup scripts) to store its configuration.
 
 This section discusses the *param* subsystem in detail.
 It covers how to list, save and load parameters, and how to define them and make them available to ground stations.
 
 :::tip
-[System startup](../concept/system_startup.md) and the way that [airframe configurations](../dev_airframes/adding_a_new_frame.md) work are detailed on other pages. 
+[System startup](../concept/system_startup.md) and the way that [frame configuration](../dev_airframes/adding_a_new_frame.md) startup scripts work are detailed on other pages.
 :::
 
 

--- a/en/config/airframe.md
+++ b/en/config/airframe.md
@@ -1,13 +1,13 @@
-# Airframe Setup
+# Frame Setup
 
-After installing firmware you need to select the [airframe configuration](../airframes/airframe_reference.md) that best matches your vehicle.
+After installing firmware you need to select the vehicle [frame configuration](../airframes/airframe_reference.md) that best matches your vehicle.
 
 :::note
-Select the airframe configuration for your vehicle brand and model, if one exists, as this should be tuned well enough to fly following standard configuration.
-Otherwise select the closest "Generic" frame option.
+Select the configuration for your vehicle brand and model, if one exists, as this should be tuned well enough to fly following standard configuration. 
+Otherwise select the closest "Generic" frame option. 
 :::
 
-## Set the Airframe
+## Set the Frame
 
 To set the airframe:
 

--- a/en/config/autotune.md
+++ b/en/config/autotune.md
@@ -159,7 +159,7 @@ PX4 uses [PID controllers](../flight_stack/controller_diagrams.md) (rate, attitu
 The controllers must be well tuned in order to get the best performance out of a vehicle.
 In particular, a poorly tuned rate controller results in less stable flight in all modes, and takes longer to recover from disturbances.
 
-Generally if you use an [airframe configuration](../config/airframe.md) that is similar to your vehicle then the vehicle will be able to fly.
+Generally if you use a [frame configuration](../config/airframe.md) that is similar to your vehicle then the vehicle will be able to fly.
 However unless the configuration precisely matches your hardware you should tune the rate and attitude controllers.
 Tuning the velocity and position controllers is less important because they are less affected by vehicle dynamics, and the default tuning configuration for a similar airframe is often sufficient.
 

--- a/en/config_mc/pid_tuning_guide_multicopter_basic.md
+++ b/en/config_mc/pid_tuning_guide_multicopter_basic.md
@@ -7,7 +7,7 @@ This tutorial explains how to _manually_ tune the PID loops on PX4 for all [mult
 Manual tuning is recommended for frames where autotuning does not work, or where fine-tuning is essential.
 :::
 
-Generally if you're using an appropriate [supported airframe configuration](../airframes/airframe_reference.md#copter), the default tuning should allow you to fly the vehicle safely.
+Generally if you're using an appropriate [supported frame configuration](../airframes/airframe_reference.md#copter), the default tuning should allow you to fly the vehicle safely.
 Tuning is recommended for all new vehicle setups to get the _very best_ performance, because relatively small hardware and assembly changes can affect the gains required tuning gains for optimal flight.
 For example, different ESCs or motors change the optimal tuning gains.
 
@@ -39,7 +39,7 @@ Then adjust the sliders (as discussed below) to improve the tracking of the resp
 
 ## Preconditions
 
-- You have selected the closest matching [default airframe configuration](../config/airframe.md) for your vehicle.
+- You have selected the closest matching [default frame configuration](../config/airframe.md) for your vehicle.
   This should give you a vehicle that already flies.
 - You should have done an [ESC calibration](../advanced_config/esc_calibration.md).
 - If using PWM output: [PWM_MAIN_MIN](../advanced_config/parameter_reference.md#PWM_MAIN_MIN) is set correctly.

--- a/en/dev_airframes/adding_a_new_frame.md
+++ b/en/dev_airframes/adding_a_new_frame.md
@@ -320,7 +320,7 @@ The following topics explain how to tune the parameters that will be specified i
 
 ## Add Frame to QGroundControl
 
-To make a new airframe available for section in the *QGroundControl* [airframe configuration](../config/airframe.md):
+To make a new airframe available for section in the *QGroundControl* [frame configuration](../config/airframe.md):
 
 1. Make a clean build (e.g. by running `make clean` and then `make px4_fmu-v5_default`)
 1. Open QGC and select **Custom firmware file...** as shown below:

--- a/en/frames_plane/wing_wing_z84.md
+++ b/en/frames_plane/wing_wing_z84.md
@@ -73,6 +73,6 @@ The images below give a rough idea about the assembly process, which is simple a
 
 ## Airframe Configuration
 
-Select the Z-84 in the flying wing section of the QGC airframe config:
+Select the Z-84 in the flying wing section of the QGC airframe config: 
 
-![QGC - select firmware for West Wing](../../assets/airframes/fw/wing_wing/qgc_firmware_flying_wing_west_wing.png)
+![QGC - select firmware for West Wing](../../assets/airframes/fw/wing_wing/qgc_firmware_flying_wing_west_wing.png) 

--- a/en/peripherals/dshot.md
+++ b/en/peripherals/dshot.md
@@ -25,6 +25,7 @@ A Pixhawk flight controller that has both FMU and IO will label these ports as A
 DShot can only be used on the FMU ports (labeled AUX), which is a problem because ESC/motor outputs are typically assigned to the MAIN port in the [airframe reference](../airframes/airframe_reference.md).
 
 To use DShot you therefore normally set `SYS_USE_IO=0` (which makes the ports labeled AUX behave *as though* they were the ports labeled MAIN), and connect your ESCs to the corresponding AUX-labeled outputs.
+
 Any outputs that would normally be assigned to AUX ports in the [airframe reference](../airframes/airframe_reference.md) are no longer available.
 
 Developers might alternatively modify the [airframe AUX mixer](../dev_airframes/adding_a_new_frame.md#mixer-file) so that the multirotor outputs are on the AUX port rather than MAIN.


### PR DESCRIPTION
I'm trying to move away from refering to airframe unless I actually mean "air" frame. This fixes up some cases.