### PR TITLE
More clear about gimbal support

### DIFF
--- a/en/advanced/gimbal_control.md
+++ b/en/advanced/gimbal_control.md
@@ -57,8 +57,6 @@ You can support additional gimbals provided that they:
 - Each gimbal must have a unique component id.
   For a PWM connected gimbal this will be the component ID of the autopilot
 
-Note that MAVLink does not support control of individual cameras in missions.
-Therefore any command sent in a mission will be broadcast to all connected cameras.
 
 ## Gimbal on FC PWM Output (MNT_MODE_OUT=AUX)
 

--- a/en/advanced/gimbal_control.md
+++ b/en/advanced/gimbal_control.md
@@ -27,26 +27,24 @@ The output is set using the [MNT_MODE_OUT](../advanced_config/parameter_referenc
 By default the output is set to a PXM port (`AUX (0)`).
 If the [MAVLink Gimbal Protocol v2](https://mavlink.io/en/services/gimbal_v2.html) is supported by your gimbal, you should instead select `MAVLink gimbal protocol v2 (2)`.
 
-
 The full list of parameters for setting up the mount driver can be found in [Parameter Reference > Mount](../advanced_config/parameter_reference.md#mount).
 The relevant settings for a number of common gimbal configurations are described below.
 
 ## MAVLink Gimbal (MNT_MODE_OUT=MAVLINK)
 
-To enable a MAVLink gimbal, first set parameter [MNT_MODE_IN](../advanced_config/parameter_reference.md#MNT_MODE_IN) to `MAVlink gimbal protocol v2` and [MNT_MODE_OUT](../advanced_config/parameter_reference.md#MNT_MODE_OUT) to `MAVLink gimbal protocol v2`. 
+Each physical gimbal device on the system must have its own high level gimbal manager, which is discoverable by a ground station using the MAVLink gimbal protocol.
+The ground station sends high level [MAVLink Gimbal Manager](https://mavlink.io/en/services/gimbal_v2.html#gimbal-manager-messages) commands to the manager, and it will in turn send appropriate lower level "gimbal device" commands to control the gimbal.
+
+PX4 can be configured as the gimbal manager to control a single gimbal device (which can either be physically connected or be a MAVLink gimbal).
+Additional MAVLink gimbals may be controlled by their own gimbal manager components (PX4 will forward the MAVLink traffic).
+
+To enable a MAVLink gimbal, first set parameter [MNT_MODE_IN](../advanced_config/parameter_reference.md#MNT_MODE_IN) to `MAVlink gimbal protocol v2` and [MNT_MODE_OUT](../advanced_config/parameter_reference.md#MNT_MODE_OUT) to `MAVLink gimbal protocol v2`.
 
 The gimbal can be connected to *any free serial port* using the instructions in [MAVLink Peripherals (GCS/OSD/Companion)](../peripherals/mavlink_peripherals.md) (also see [Serial Port Configuration](../peripherals/serial_configuration.md#serial-port-configuration)).
 For example, if the `TELEM2` port on the flight controller is unused you can connect it to the gimbal and set the following PX4 parameters:
 - [MAV_1_CONFIG](../advanced_config/parameter_reference.md#MAV_1_CONFIG) to **TELEM2** (if `MAV_1_CONFIG` is already used for a companion computer (say), use `MAV_2_CONFIG`).
 - [MAV_1_MODE](../advanced_config/parameter_reference.md#MAV_1_MODE) to **NORMAL**
 - [SER_TEL2_BAUD](../advanced_config/parameter_reference.md#SER_TEL2_BAUD) to manufacturer recommended baud rate.
-
-With this setup, ground stations can send [MAVLink Gimbal Commands](https://mavlink.io/en/services/gimbal_v2.html#gimbal-manager-messages) to PX4, such as `MAV_CMD_DO_SET_ROI_LOCATION` to track region of interest and `MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW` to control the gimbal attitude, and so on.
-
-:::note
-In Gimbal Protocol v2 terms, this setup configures PX4 as a _Gimbal Manager_.
-The flight stack handles high level "gimbal manager" commands and mission items, sending appropriate lower level "gimbal device" commands to control the gimbal.
-:::
 
 ## Gimbal on FC PWM Output (MNT_MODE_OUT=AUX)
 

--- a/en/advanced/gimbal_control.md
+++ b/en/advanced/gimbal_control.md
@@ -33,10 +33,9 @@ The relevant settings for a number of common gimbal configurations are described
 ## MAVLink Gimbal (MNT_MODE_OUT=MAVLINK)
 
 Each physical gimbal device on the system must have its own high level gimbal manager, which is discoverable by a ground station using the MAVLink gimbal protocol.
-The ground station sends high level [MAVLink Gimbal Manager](https://mavlink.io/en/services/gimbal_v2.html#gimbal-manager-messages) commands to the manager, and it will in turn send appropriate lower level "gimbal device" commands to control the gimbal.
+The ground station sends high level [MAVLink Gimbal Manager](https://mavlink.io/en/services/gimbal_v2.html#gimbal-manager-messages) commands to the manager of the gimbal it wants to control, and the manager will in turn send appropriate lower level "gimbal device" commands to control the gimbal.
 
-PX4 can be configured as the gimbal manager to control a single gimbal device (which can either be physically connected or be a MAVLink gimbal).
-Additional MAVLink gimbals may be controlled by their own gimbal manager components (PX4 will forward the MAVLink traffic).
+PX4 can be configured as the gimbal manager to control a single gimbal device (which can either be physically connected or be a MAVLink gimbal that implements the [gimbal device interface](https://mavlink.io/en/services/gimbal_v2.html#gimbal-device-messages)).
 
 To enable a MAVLink gimbal, first set parameter [MNT_MODE_IN](../advanced_config/parameter_reference.md#MNT_MODE_IN) to `MAVlink gimbal protocol v2` and [MNT_MODE_OUT](../advanced_config/parameter_reference.md#MNT_MODE_OUT) to `MAVLink gimbal protocol v2`.
 
@@ -45,6 +44,21 @@ For example, if the `TELEM2` port on the flight controller is unused you can con
 - [MAV_1_CONFIG](../advanced_config/parameter_reference.md#MAV_1_CONFIG) to **TELEM2** (if `MAV_1_CONFIG` is already used for a companion computer (say), use `MAV_2_CONFIG`).
 - [MAV_1_MODE](../advanced_config/parameter_reference.md#MAV_1_MODE) to **NORMAL**
 - [SER_TEL2_BAUD](../advanced_config/parameter_reference.md#SER_TEL2_BAUD) to manufacturer recommended baud rate.
+
+### Multiple Gimbal Support
+
+PX4 does not automatically create gimbal managers for other gimbal devices on the system.
+
+You can support additional gimbals provided that they:
+
+- implement the gimbal _manager_ protocol
+- Are visible to the ground station and PX4 on the MAVLink network.
+  This may require that traffic forwarding be configured between PX4, the GCS, and the gimbal.
+- Each gimbal must have a unique component id.
+  For a PWM connected gimbal this will be the component ID of the autopilot
+
+Note that MAVLink does not support control of individual cameras in missions.
+Therefore any command sent in a mission will be broadcast to all connected cameras.
 
 ## Gimbal on FC PWM Output (MNT_MODE_OUT=AUX)
 

--- a/en/advanced/gimbal_control.md
+++ b/en/advanced/gimbal_control.md
@@ -47,7 +47,8 @@ For example, if the `TELEM2` port on the flight controller is unused you can con
 
 ### Multiple Gimbal Support
 
-PX4 does not automatically create gimbal managers for other gimbal devices on the system.
+PX4 can automatically create a gimbal manager for a connected PWM gimbal or the first MAVLink gimbal device with the same system id it detects on any interface.
+It does not automatically create gimbal manager for any other MAVLink gimbal devices that it detects. 
 
 You can support additional gimbals provided that they:
 


### PR DESCRIPTION
This is a follow up to #2085 to better explain gimbal support on PX4. Still draft, as I'm after confirmations.

The update is to better capture the story for multiple gimbals and PX4. It is draft because I don't know the answers yet.

So the way that the gimbal protocol works, 
- High level gimbal manager API and low level device API.
- there is a 1:1 relationship between gimbals manager and gimbal device.
- Ground station talks to gimbal manager, which then sends commands to the connected low level device.
- a gimbal might implement either or both sets of messages. 
  - If it implemented just the high level API you would have to connect to the gimbal using that API.
  - If it implements the low level API then you could control it with "some" gimbal manager - i.e. PX4 could be the thing that sends it messages.
- The ground station can discover any gimbal manager on the connected system using provided messages.

The gimbal docs on MAVLink assume that a mavlink node like PX4 will autodiscover all gimbal devices and roll out gimbal manager instances to manage them. Is that what it does?

What I think has been done (minimally) is to implement the gimbal manager protocol in PX4. This allows PX4 to publish itself as a gimbal manager and control either a PWM gimbal or a gimbal that implements the gimbal device API connected via mavlink.
I **think** then that the assumption is that if you have other gimbal devices on the device they will have to have their own managers and that you will have to configure PX4 to forward any traffic from GCS to them.

Is that right? Or does PX4 also creates a manager for every other device on the system?

Is the first gimbal component ID "reserved" for a hardware connected PWM gimbal? i.e. how is the ID allocated in this case? My assumption, since the manager uses the gimbal id to connect to, is that these must be individually made to be different.