### PR TITLE
Pr fix custom message key receiver

### DIFF
--- a/en/ros/mavros_custom_messages.md
+++ b/en/ros/mavros_custom_messages.md
@@ -4,7 +4,7 @@
 This article has been tested against:
 - **Ubuntu:** 20.04
 - **ROS:** Noetic
-- **PX4 Firmware:** v1.12.3
+- **PX4 Firmware:** v1.13
 
 However these steps are fairly general and so it should work with other distros/versions with little to no modifications.
 :::

--- a/en/ros/mavros_custom_messages.md
+++ b/en/ros/mavros_custom_messages.md
@@ -199,7 +199,6 @@ Follow *Source Installation* instructions from [mavlink/mavros](https://github.c
    #include <px4_platform_common/px4_config.h>
    #include <px4_platform_common/tasks.h>
    #include <px4_platform_common/posix.h>
-   #include <px4_platform_common/log.h>
    #include <unistd.h>
    #include <stdio.h>
    #include <poll.h>

--- a/en/ros/mavros_custom_messages.md
+++ b/en/ros/mavros_custom_messages.md
@@ -199,6 +199,7 @@ Follow *Source Installation* instructions from [mavlink/mavros](https://github.c
    #include <px4_platform_common/px4_config.h>
    #include <px4_platform_common/tasks.h>
    #include <px4_platform_common/posix.h>
+   #include <px4_platform_common/log.h>
    #include <unistd.h>
    #include <stdio.h>
    #include <poll.h>
@@ -216,7 +217,7 @@ Follow *Source Installation* instructions from [mavlink/mavros](https://github.c
        orb_set_interval(key_sub_fd, 200); // limit the update rate to 200ms
 
        px4_pollfd_struct_t fds[] = {
-           { .fd = keyboard_sub_fd,   .events = POLLIN },
+           { .fd = key_sub_fd,   .events = POLLIN },
        };
 
        int error_counter = 0;


### PR DESCRIPTION
PR for issue 2116 : https://github.com/PX4/PX4-user_guide/issues/2116
Added library for PX4_ERROR message and fixed variable name
Tested on 1.13, Ubuntu 20.04 and Ros Noetic

Fixes #2116