### PR TITLE
Version 1.13: Update PX4-ROS2 and ROS(1) over ROS2 bridge instructions

### DIFF
--- a/en/ros/ros1_via_ros2.md
+++ b/en/ros/ros1_via_ros2.md
@@ -79,14 +79,16 @@ To use ROS (1) **and** ROS 2 (you need both for this!):
 
 1. [Setup your PX4 Ubuntu Linux development environment](../dev_setup/dev_env_linux_ubuntu.md) - the default instructions get the latest version of PX4 source and install all the needed tools.
 
-:::warning Note
-The above instructions must be adjusted to get version v1.13 of PX4 source.
-```sh
-git clone -b <tag> https://github.com/PX4/PX4-Autopilot.git --recursive
-```
-where `<tag>` can be `release/1.13` or any of the `v.13.*` tags depending on the user specific scenarios.
-Otherwise, please refer to the [latest](https://docs.px4.io/main/en/contribute/) documentation.
-:::
+   :::warning Note
+   The above instructions must be adjusted to get version v1.13 of PX4 source.
+   
+   ```sh
+   git clone -b <tag> https://github.com/PX4/PX4-Autopilot.git --recursive
+   ```
+   
+   where `<tag>` can be `release/1.13` or any of the `v.13.*` tags depending on the user specific scenarios.
+   Otherwise, please refer to the [latest](https://docs.px4.io/main/en/contribute/) documentation.
+   :::
 
 1. Open a new terminal in the root of the **PX4 Autopilot** project, and then start a PX4 Gazebo simulation using:
    ```sh

--- a/en/ros/ros1_via_ros2.md
+++ b/en/ros/ros1_via_ros2.md
@@ -51,6 +51,12 @@ To create and build the workspace:
    $ git clone https://github.com/PX4/px4_ros_com.git ~/px4_ros_com_ros1/src/px4_ros_com -b ros1 # clones the 'ros1' branch
    $ git clone https://github.com/PX4/px4_msgs.git ~/px4_ros_com_ros1/src/px4_msgs -b ros1
    ```
+1. Update the message definitions of the `ros1` branch
+   <!-- px4_msgs/ros1 is not synchronized with release/1.13 -->
+   ```sh
+   $ rm -f ~/px4_ros_com_ros1/src/px4_msgs/msg/*.msg
+   $ cp ~/px4_ros_com_ros2/src/px4_msgs/msg/*.msg ~/px4_ros_com_ros1/src/px4_msgs/msg/
+   ```
 1. Use the `build_ros1_bridge.bash` script to build the ROS workspace (including `px4_ros_com`, `px4_msgs`, and `ros1_bridge`).
    <!-- we didn't clone `ros1_bridge` ? -->
    ```sh
@@ -72,6 +78,16 @@ As discussed in [ROS 2 User Guide > Sanity Check the Installation](../ros/ros2_c
 To use ROS (1) **and** ROS 2 (you need both for this!):
 
 1. [Setup your PX4 Ubuntu Linux development environment](../dev_setup/dev_env_linux_ubuntu.md) - the default instructions get the latest version of PX4 source and install all the needed tools.
+
+:::warning Note
+The above instructions must be adjusted to get version v1.13 of PX4 source.
+```sh
+git clone -b <tag> https://github.com/PX4/PX4-Autopilot.git --recursive
+```
+where `<tag>` can be `release/1.13` or any of the `v.13.*` tags depending on the user specific scenarios.
+Otherwise, please refer to the [latest](https://docs.px4.io/main/en/contribute/) documentation.
+:::
+
 1. Open a new terminal in the root of the **PX4 Autopilot** project, and then start a PX4 Gazebo simulation using:
    ```sh
    make px4_sitl_rtps gazebo

--- a/en/ros/ros1_via_ros2.md
+++ b/en/ros/ros1_via_ros2.md
@@ -79,7 +79,7 @@ To use ROS (1) **and** ROS 2 (you need both for this!):
 
 1. [Setup your PX4 Ubuntu Linux development environment](../dev_setup/dev_env_linux_ubuntu.md) - the default instructions get the latest version of PX4 source and install all the needed tools.
 
-   :::warning Note
+   :::note
    The above instructions must be adjusted to get version v1.13 of PX4 source.
    
    ```sh

--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -151,14 +151,16 @@ We can do this by running the bridge against PX4 running in the simulator.
 
 1. [Setup your PX4 Ubuntu Linux development environment](../dev_setup/dev_env_linux_ubuntu.md) - the default instructions get the **latest** version of PX4 source and install all the needed tools.
 
-:::warning Note
-The above instructions must be adjusted to get version v1.13 of PX4 source.
-```sh
-git clone -b <tag> https://github.com/PX4/PX4-Autopilot.git --recursive
-```
-where `<tag>` can be `release/1.13` or any of the `v.13.*` tags depending on the user specific scenarios.
-Otherwise, please refer to the [latest](https://docs.px4.io/main/en/contribute/) documentation.
-:::
+   :::note
+   The above instructions must be adjusted to get version v1.13 of PX4 source.
+   
+   ```sh
+   git clone -b <tag> https://github.com/PX4/PX4-Autopilot.git --recursive
+   ```
+   
+   where `<tag>` can be `release/1.13` or any of the `v.13.*` tags depending on the user specific scenarios.
+   Otherwise, please refer to the [latest](https://docs.px4.io/main/en/contribute/) documentation.
+   :::
 
 1. Open a new terminal in the root of the **PX4 Autopilot** project, and then start a PX4 Gazebo simulation using:
    ```sh

--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -149,7 +149,17 @@ The `px4_ros_com/scripts` directory contains multiple scripts for building diffe
 One way to check that the installation/setup succeeded is to test that the bridge can communicate with PX4.
 We can do this by running the bridge against PX4 running in the simulator.
 
-1. [Setup your PX4 Ubuntu Linux development environment](../dev_setup/dev_env_linux_ubuntu.md) - the default instructions get the latest version of PX4 source and install all the needed tools.
+1. [Setup your PX4 Ubuntu Linux development environment](../dev_setup/dev_env_linux_ubuntu.md) - the default instructions get the **latest** version of PX4 source and install all the needed tools.
+
+:::warning Note
+The above instructions must be adjusted to get version v1.13 of PX4 source.
+```sh
+git clone -b <tag> https://github.com/PX4/PX4-Autopilot.git --recursive
+```
+where `<tag>` can be `release/1.13` or any of the `v.13.*` tags depending on the user specific scenarios.
+Otherwise, please refer to the [latest](https://docs.px4.io/main/en/contribute/) documentation.
+:::
+
 1. Open a new terminal in the root of the **PX4 Autopilot** project, and then start a PX4 Gazebo simulation using:
    ```sh
    make px4_sitl_rtps gazebo

--- a/en/ros/ros2_offboard_control.md
+++ b/en/ros/ros2_offboard_control.md
@@ -76,7 +76,7 @@ Besides that:
 
 ## Implementation
 
-The source code of the offboard control example can be found in [offboard_control.cpp](https://github.com/PX4/px4_ros_com/blob/master/src/examples/offboard/offboard_control.cpp).
+The source code of the offboard control example can be found in [offboard_control.cpp](https://github.com/PX4/px4_ros_com/blob/release/1.13/src/examples/offboard/offboard_control.cpp).
 
 Here are some details about the implementation:
 
@@ -159,7 +159,7 @@ Also, in this case, the `x`, `y`, `z` and `yaw` fields are hardcoded to certain 
 
 :::tip
 The position is published in the NED coordinate frame for simplicity.
-If a user wants to subscribe to data coming from nodes that publish in a different frame (for example the ENU, which is the standard frame of reference in ROS/ROS 2), they can use the helper functions in the [frame_transforms](https://github.com/PX4/px4_ros_com/blob/master/src/lib/frame_transforms.cpp) library.
+If a user wants to subscribe to data coming from nodes that publish in a different frame (for example the ENU, which is the standard frame of reference in ROS/ROS 2), they can use the helper functions in the [frame_transforms](https://github.com/PX4/px4_ros_com/blob/release/1.13/src/lib/frame_transforms.cpp) library.
 :::
 
 ```cpp


### PR DESCRIPTION
- Instructions and links updated from `main` to `release/1.13` branches.
- Instructions for working on ROS (1) over the ROS2 bridge updated with message definitions synchronization step.