### PR TITLE
Ignition Gazebo Simulation: add instruction for advanced usages and multi vehicles simulations

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -345,6 +345,7 @@
       * [Gazebo Worlds](simulation/gazebo_worlds.md)
       * [Multi-Vehicle Sim with Gazebo](simulation/multi_vehicle_simulation_gazebo.md)
     * [Ignition Gazebo Simulation](simulation/ignition_gazebo.md)
+      * [Multi-Vehicle Sim with Ignition Gazebo](simulation/multi_vehicle_simulation_ignition_gazebo.md)
     * [FlightGear Simulation](simulation/flightgear.md)
       * [FlightGear Vehicles](simulation/flightgear_vehicles.md)
       * [Multi-Vehicle Sim with FlightGear](simulation/multi_vehicle_flightgear.md)

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -205,11 +205,9 @@ To disable lockstep in PX4, run `make px4_sitl_default boardconfig` and set the 
 To disable lockstep in Gazebo, edit [the model SDF file](https://github.com/PX4/PX4-SITL_gazebo/blob/3062d287c322fabf1b41b8e33518eb449d4ac6ed/models/plane/plane.sdf#L449) and set `<enable_lockstep>false</enable_lockstep>`.
 
 To disable lockstep in jMAVSim, remove `-l` in [sitl_run.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/jmavsim/sitl_run.sh#L40), or make sure otherwise that the java binary is started without the `-lockstep` flag.
-<!-- Relevant lines in sitl_run.sh are:
-# Start Java simulator
-"$src_path"/Tools/simulation/jmavsim/jmavsim_run.sh -r 250 -l &
-SIM_PID=$!
--->
+<!-- Relevant lines in sitl_run.sh are: -->
+<!-- # Start Java simulator -->
+<!-- "$src_path"/Tools/simulation/jmavsim/jmavsim_run.sh -r 250 -l & SIM_PID=$! -->
 
 
 ### Startup Scripts

--- a/en/simulation/ignition_gazebo.md
+++ b/en/simulation/ignition_gazebo.md
@@ -56,17 +56,19 @@ In order to run the simulation without running the ignition gazebo gui, one can 
 HEADLESS=1 make px4_sitl gz_x500
 ```
 
-## Advanced Usages
+## Usage/Configuration Options
 
-Even if at the time of writing only one frame is supported, the startup pipeline allows for highly flexible configurations.
-In particular, it is possible to
+The startup pipeline allows for highly flexible configuration.
+In particular, it is possible to:
 
-1. Start a new Ignition simulation with an arbitrary world or attach to an already running simulation.
-
-1. Add a new vehicle to Ignition or link a new PX4 instance to an existing one.
+- Start a new Ignition simulation with an arbitrary world or attach to an already running simulation.
+- Add a new vehicle to Ignition or link a new PX4 instance to an existing one.
 
 These scenarios are managed by setting the appropriate environment variables.
-The startup syntax takes the form
+
+### Syntax
+
+The startup syntax takes the form:
 
 ```bash
 ARGS ./build/px4_sitl_default/bin/px4
@@ -74,55 +76,35 @@ ARGS ./build/px4_sitl_default/bin/px4
 
 where `ARGS` is a list of environment variables including:
 
-- `PX4_SYS_AUTOSTART` (_mandatory_): Sets the airframe for PX4.
-Only `4001` (x500 quadcopter) is currently supported.
+- `PX4_SYS_AUTOSTART` (_mandatory_):
+  Sets the [airframe autostart id](../dev_airframes/adding_a_new_frame.md) of the PX4 airframe to start.
+  Only `4001` (x500 quadcopter) is currently supported.
 
-- `PX4_GZ_WORLD` (_optional_): Sets the Ignition world file for a new simulation. If it is not given, then [default](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/gz/worlds/default.sdf) is used.
-This variable is ignored if an existing simulation is already running.
+- `PX4_GZ_WORLD` (_optional_):
+  Sets the Ignition world file for a new simulation.
+  If it is not given, then [default](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/gz/worlds/default.sdf) is used.
+  This variable is ignored if an existing simulation is already running.
 
-- `PX4_GZ_MODEL_NAME`: Sets the name of an **existing** model in the gazebo simulation.
-When provided, the startup script tries to bind a new PX4 instance to the Ignition resource matching exactly that name.
-It is mutually exclusive with `PX4_GZ_MODEL`.
+- `PX4_GZ_MODEL_NAME`:
+  Sets the name of an **existing** model in the gazebo simulation.
+  When provided, the startup script tries to bind a new PX4 instance to the Ignition resource matching exactly that name.
+  It is mutually exclusive with `PX4_GZ_MODEL`.
 
-- `PX4_GZ_MODEL`: Sets the name of a new Ignition model that has to be spawned in the simulator.
-When provided, the startup script looks for a model in the Ignition resource path that matches the given variable, spawns it and binds a new PX4 instance to it.
-It is mutually exclusive with `PX4_GZ_MODEL_NAME`.
+- `PX4_GZ_MODEL`:
+  Sets the name of a new Ignition model to be spawned in the simulator.
+  When provided, the startup script looks for a model in the Ignition resource path that matches the given variable, spawns it and binds a new PX4 instance to it.
+  It is mutually exclusive with `PX4_GZ_MODEL_NAME`.
 
-- `PX4_GZ_MODEL_POSE` (_optional_): Sets the spawning position of the model when `PX4_GZ_MODEL` is adopted.
-When provided, then startup script spawns the model at the given position.
-If omitted, the origin `[0,0,0]` is used.
+- `PX4_GZ_MODEL_POSE` (_optional_):
+  Sets the spawning position of the model when `PX4_GZ_MODEL` is adopted.
+  When provided, then startup script spawns the model at the given position.
+  If omitted, the origin `[0,0,0]` is used.
 
-The PX4 Ignition worlds and and models databases are available [here](https://github.com/PX4/PX4-Autopilot/tree/main/Tools/simulation/gz) and they are added to the Ignition search PATH by [gazebo_env.sh.in](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/gz_bridge/gazebo_env.sh.in) during the simulation startup phase.
+The PX4 Ignition worlds and and models databases [can be found on Github here](https://github.com/PX4/PX4-Autopilot/tree/main/Tools/simulation/gz).
+They are added to the Ignition search `PATH` by [gazebo_env.sh.in](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/gz_bridge/gazebo_env.sh.in) during the simulation startup phase.
 
 :::note
 `gazebo_env.sh.in` is compiled and made available in `$PX4_DIR/build/px4_sitl/rootfs/gazebo_env.sh`
-:::
-
-### Adding new worlds and models
-
-New worlds files can be added in the PX4 Ignition [world directory](https://github.com/PX4/PX4-Autopilot/tree/main/Tools/simulation/gz/worlds).
-
-New models require to:
-
-1. Add their **sdf** file in the PX4 Ignition [model directory](https://github.com/PX4/PX4-Autopilot/tree/main/Tools/simulation/gz/models).
-
-1. Define their [airframes](../dev_airframes/adding_a_new_frame.md).
-
-1. Define the Ignition default parameters
-
-```
-PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
-PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
-PX4_SIM_MODEL=${PX4_SIM_MODEL:=<your model name>}
-```
-as in [x500 quadcopter](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/airframes/4001_x500). This last step is not mandatory, but if it not performed then `PX4_SIMULATOR=gz` and a valid world must be provided when launching the simulation. 
-`PX4_SIM_MODEL:=<your model name>` is only needed when the simulation is launched by the make command
-
-```sh
-make px4_sitl gz_<your model name>
-```
-:::note
-As long as the world file and the model file are in the Ignition search path `IGN_GAZEBO_RESOURCE_PATH` it is not necessary to add them to the PX4 world and model directories.
 :::
 
 ### Examples
@@ -131,23 +113,57 @@ Here are some examples of the different scenarios covered above.
 
 1. **Start simulator + default world + spawn vehicle at default location**
 
-```sh
-PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4
-```
+   ```sh
+   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4
+   ```
 
 2. **Start simulator + default world + spawn vehicle at custom location**
 
-```sh
-PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,0" PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4
-```
+   ```sh
+   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,0" PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4
+   ```
 
 3. **Start simulator + default world + link to existing vehicle**
 
-```sh
-PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_NAME=x500 ./build/px4_sitl_default/bin/px4
-```
+   ```sh
+   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_NAME=x500 ./build/px4_sitl_default/bin/px4
+   ```
+
+## Adding New worlds and Models
+
+New worlds files can simply be copied into the PX4 Ignition [world directory](https://github.com/PX4/PX4-Autopilot/tree/main/Tools/simulation/gz/worlds).
+
+To add a new model:
+
+1. Add an **sdf** file in the PX4 Ignition [model directory](https://github.com/PX4/PX4-Autopilot/tree/main/Tools/simulation/gz/models).
+1. Define an [airframe configuration file](../dev_airframes/adding_a_new_frame.md).
+1. Define the Ignition default parameters in the airframe configuration file (this example is from [x500 quadcopter](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/airframes/4001_x500)):
+
+   ```
+   PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
+   PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
+   PX4_SIM_MODEL=${PX4_SIM_MODEL:=<your model name>}
+   ```
+
+   - `PX4_SIM_MODEL` is not mandatory, but:
+     - it is needed to allow the simulation to be launched using the `make` command:
+
+       ```sh
+       make px4_sitl gz_<your model name>
+       ```
+     - if it is not set then `PX4_SIMULATOR=gz` and a valid world must be provided when launching the simulation.
+
+:::note
+As long as the world file and the model file are in the Ignition search path `IGN_GAZEBO_RESOURCE_PATH` it is not necessary to add them to the PX4 world and model directories.
+:::
+
+## Multi-Vehicle Simulation
+
+Multi-Vehicle simulation is supported on Linux hosts.
+
+For more information see: [Multi-Vehicle Sim with Ignition Gazebo](../simulation/multi_vehicle_simulation_ignition_gazebo.md)
 
 
 ## Further Information
 
-* [px4-simulation-ignition](https://github.com/Auterion/px4-simulation-ignition)
+- [px4-simulation-ignition](https://github.com/Auterion/px4-simulation-ignition)

--- a/en/simulation/ignition_gazebo.md
+++ b/en/simulation/ignition_gazebo.md
@@ -76,14 +76,14 @@ ARGS ./build/px4_sitl_default/bin/px4
 
 where `ARGS` is a list of environment variables including:
 
-- `PX4_SYS_AUTOSTART` (_mandatory_):
+- `PX4_SYS_AUTOSTART` (**Mandatory**):
   Sets the [airframe autostart id](../dev_airframes/adding_a_new_frame.md) of the PX4 airframe to start.
   - Only `4001` (x500 quadcopter) is currently supported.
 
 - `PX4_GZ_MODEL_NAME`:
-  Sets the name of an **existing** model in the gazebo simulation.
+  Sets the name of an _existing_ model in the gazebo simulation.
   If provided, the startup script tries to bind a new PX4 instance to the Ignition resource matching exactly that name.
-  - It is mutually exclusive with `PX4_GZ_MODEL`.
+  - The setting is mutually exclusive with `PX4_GZ_MODEL`.
 
 - `PX4_GZ_MODEL`:
   Sets the name of a new Ignition model to be spawned in the simulator.
@@ -100,6 +100,7 @@ where `ARGS` is a list of environment variables including:
   If provided, the startup script spawns the model at a pose following the syntax `"x,y,z,roll,pitch,yaw"`, where the positions are given in metres and the angles are in radians.
   - If omitted, the zero pose `[0,0,0,0,0,0]` is used.
   - If less then 6 values are provided, the missing ones are fixed to zero.
+  - The pose requires a model; this can only be set if either of `PX4_GZ_MODEL_NAME` or `PX4_GZ_MODEL` is set.
 
 - `PX4_GZ_WORLD`:
   Sets the Ignition world file for a new simulation.

--- a/en/simulation/ignition_gazebo.md
+++ b/en/simulation/ignition_gazebo.md
@@ -4,7 +4,7 @@
 Ignition Gazebo supports a single frame (X500 quadcopter) and world (October 2022).
 :::
 
-[Ignition Gazebo](https://gazebosim.org/libs/gazebo) is an open source robotics simulator from the _Ignition Robotics Project_.
+[Ignition Gazebo](https://gazebosim.org/home) is an open source robotics simulator from the _Ignition Robotics Project_.
 It is derived from the popular robotics simulator [Gazebo](./gazebo.md), featuring more advanced rendering, physics and sensor models.
 
 **Supported Vehicles:** Quadrotor
@@ -56,11 +56,97 @@ In order to run the simulation without running the ignition gazebo gui, one can 
 HEADLESS=1 make px4_sitl gz_x500
 ```
 
-In order to increase the verbose output, `VERBOSE_SIM=1` can be used:
+## Advanced Usages
+
+Even if at the time of writing only one frame is supported, the startup pipeline allows for highly flexible configurations.
+In particular, it is possible to
+
+1. Start a new Ignition simulation with an arbitrary world or attach to an already running simulation.
+
+1. Add a new vehicle to Ignition or link a new PX4 instance to an existing one.
+
+These scenarios are managed by setting the appropriate environment variables.
+The startup syntax takes the form
 
 ```bash
-VERBOSE_SIM=1 make px4_sitl gz_x500
+ARGS ./build/px4_sitl_default/bin/px4
 ```
+
+where `ARGS` is a list of environment variables including:
+
+- `PX4_SYS_AUTOSTART` (_mandatory_): Sets the airframe for PX4.
+Only `4001` (x500 quadcopter) is currently supported.
+
+- `PX4_GZ_WORLD` (_optional_): Sets the Ignition world file for a new simulation. If it is not given, then [default](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/gz/worlds/default.sdf) is used.
+This variable is ignored if an existing simulation is already running.
+
+- `PX4_GZ_MODEL_NAME`: Sets the name of an **existing** model in the gazebo simulation.
+When provided, the startup script tries to bind a new PX4 instance to the Ignition resource matching exactly that name.
+It is mutually exclusive with `PX4_GZ_MODEL`.
+
+- `PX4_GZ_MODEL`: Sets the name of a new Ignition model that has to be spawned in the simulator.
+When provided, the startup script looks for a model in the Ignition resource path that matches the given variable, spawns it and binds a new PX4 instance to it.
+It is mutually exclusive with `PX4_GZ_MODEL_NAME`.
+
+- `PX4_GZ_MODEL_POSE` (_optional_): Sets the spawning position of the model when `PX4_GZ_MODEL` is adopted.
+When provided, then startup script spawns the model at the given position.
+If omitted, the origin `[0,0,0]` is used.
+
+The PX4 Ignition worlds and and models databases are available [here](https://github.com/PX4/PX4-Autopilot/tree/main/Tools/simulation/gz) and they are added to the Ignition search PATH by [gazebo_env.sh.in](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/gz_bridge/gazebo_env.sh.in) during the simulation startup phase.
+
+:::note
+`gazebo_env.sh.in` is compiled and made available in `$PX4_DIR/build/px4_sitl/rootfs/gazebo_env.sh`
+:::
+
+### Adding new worlds and models
+
+New worlds files can be added in the PX4 Ignition [world directory](https://github.com/PX4/PX4-Autopilot/tree/main/Tools/simulation/gz/worlds).
+
+New models require to:
+
+1. Add their **sdf** file in the PX4 Ignition [model directory](https://github.com/PX4/PX4-Autopilot/tree/main/Tools/simulation/gz/models).
+
+1. Define their [airframes](../dev_airframes/adding_a_new_frame.md).
+
+1. Define the Ignition default parameters
+
+```
+PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
+PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=<your model name>}
+```
+as in [x500 quadcopter](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/airframes/4001_x500). This last step is not mandatory, but if it not performed then `PX4_SIMULATOR=gz` and a valid world must be provided when launching the simulation. 
+`PX4_SIM_MODEL:=<your model name>` is only needed when the simulation is launched by the make command
+
+```sh
+make px4_sitl gz_<your model name>
+```
+:::note
+As long as the world file and the model file are in the Ignition search path `IGN_GAZEBO_RESOURCE_PATH` it is not necessary to add them to the PX4 world and model directories.
+:::
+
+### Examples
+
+Here are some examples of the different scenarios covered above.
+
+1. **Start simulator + default world + spawn vehicle at default location**
+
+```sh
+PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4
+```
+
+2. **Start simulator + default world + spawn vehicle at custom location**
+
+```sh
+PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,0" PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4
+```
+
+3. **Start simulator + default world + link to existing vehicle**
+
+```sh
+PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_NAME=x500 ./build/px4_sitl_default/bin/px4
+```
+
 
 ## Further Information
 

--- a/en/simulation/ignition_gazebo.md
+++ b/en/simulation/ignition_gazebo.md
@@ -78,36 +78,38 @@ where `ARGS` is a list of environment variables including:
 
 - `PX4_SYS_AUTOSTART` (_mandatory_):
   Sets the [airframe autostart id](../dev_airframes/adding_a_new_frame.md) of the PX4 airframe to start.
-  Only `4001` (x500 quadcopter) is currently supported.
-
-- `PX4_SIMULATOR=GZ` (_optional_ as long as the selected airframe [defines the default variables](#adding-new-worlds-and-models)):
-  Sets the simulator, which for Ignition Gazebo must be `gz`.
-
-- `PX4_GZ_WORLD` (_optional_ as long as the selected airframe [defines the default variables](#adding-new-worlds-and-models)):
-  Sets the Ignition world file for a new simulation.
-  If it is not given, then [default](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/gz/worlds/default.sdf) is used.
-  This variable is ignored if an existing simulation is already running.
+  - Only `4001` (x500 quadcopter) is currently supported.
 
 - `PX4_GZ_MODEL_NAME`:
   Sets the name of an **existing** model in the gazebo simulation.
-  When provided, the startup script tries to bind a new PX4 instance to the Ignition resource matching exactly that name.
-  It is mutually exclusive with `PX4_GZ_MODEL`.
+  If provided, the startup script tries to bind a new PX4 instance to the Ignition resource matching exactly that name.
+  - It is mutually exclusive with `PX4_GZ_MODEL`.
 
 - `PX4_GZ_MODEL`:
   Sets the name of a new Ignition model to be spawned in the simulator.
-  When provided, the startup script looks for a model in the Ignition resource path that matches the given variable, spawns it and binds a new PX4 instance to it.
-  It is mutually exclusive with `PX4_GZ_MODEL_NAME`.
+  If provided, the startup script looks for a model in the Ignition resource path that matches the given variable, spawns it and binds a new PX4 instance to it.
+  - The setting is mutually exclusive with `PX4_GZ_MODEL_NAME`.
 
   :::note
   If both `PX4_GZ_MODEL_NAME` and `PX4_GZ_MODEL` are not given, then PX4 looks for `PX4_SIM_MODEL` and uses it as an alias for `PX4_GZ_MODEL`.
   However, this prevents the use of `PX4_GZ_MODEL_POSE`.
   :::
 
-- `PX4_GZ_MODEL_POSE` (_optional_):
+- `PX4_GZ_MODEL_POSE`:
   Sets the spawning position and orientation of the model when `PX4_GZ_MODEL` is adopted.
-  When provided, then startup script spawns the model at a pose following the syntax `"x,y,z,roll,pitch,yaw"`, where the positions are given in metres and the angles are in radians.
-  If omitted, the zero pose `[0,0,0,0,0,0]` is used.
-  If less then 6 values are provided, the missing ones are fixed to zero.
+  If provided, the startup script spawns the model at a pose following the syntax `"x,y,z,roll,pitch,yaw"`, where the positions are given in metres and the angles are in radians.
+  - If omitted, the zero pose `[0,0,0,0,0,0]` is used.
+  - If less then 6 values are provided, the missing ones are fixed to zero.
+
+- `PX4_GZ_WORLD`:
+  Sets the Ignition world file for a new simulation.
+  If it is not given, then [default](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/gz/worlds/default.sdf) is used.
+  - This variable is ignored if an existing simulation is already running.
+  - This value should be [specified for the selected airframe](#adding-new-worlds-and-models) but may be overridden using this argument.
+
+- `PX4_SIMULATOR=GZ`:
+  Sets the simulator, which for Ignition Gazebo must be `gz`.
+  - This value should be [set for the selected airframe](#adding-new-worlds-and-models), in which case it does not need to be set as an argument.
 
 The PX4 Ignition worlds and and models databases [can be found on Github here](https://github.com/PX4/PX4-Autopilot/tree/main/Tools/simulation/gz).
 They are added to the Ignition search `PATH` by [gazebo_env.sh.in](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/gz_bridge/gazebo_env.sh.in) during the simulation startup phase.

--- a/en/simulation/multi-vehicle-simulation.md
+++ b/en/simulation/multi-vehicle-simulation.md
@@ -2,6 +2,7 @@
 
 PX4 supports multi-vehicle simulation using the following simulators:
 - [Multi-Vehicle Sim with Gazebo](../simulation/multi_vehicle_simulation_gazebo.md) (both with and without ROS)
+- [Multi-Vehicle Sim with Ignition Gazebo](../simulation/multi_vehicle_simulation_ignition_gazebo.md)
 - [Multi-Vehicle Sim with FlightGear](../simulation/multi_vehicle_flightgear.md)
 - [Multi-Vehicle Sim with JMAVSim](../simulation/multi_vehicle_jmavsim.md)
 
@@ -11,5 +12,6 @@ The choice of the simulator depends on the vehicle to be simulated, how "good" t
   It can also be used if different types of vehicles need to be simulated at the same time.
 - Gazebo is less accurate and less heavy-weight and supports many features and vehicles that aren't available for FlightGear.
   It can only simulate a single type of vehicle at a time, but it can simulate many more vehicles at a time than FlightGear.
+- Ignition Gazebo is the successor of Gazebo. Like its precursor, it supports multiple vehicles simultaneously but, at the time of writing, only one frame (X500 quadcopter) is implemented in PX4. 
 - JMAVSim is a very light-weight simulator that supports only quadcopters.
   It is recommended if you need to support a lot of quadcopters, and the simulation only needs to be approximate.

--- a/en/simulation/multi_vehicle_simulation_ignition_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_ignition_gazebo.md
@@ -1,0 +1,18 @@
+# Multi-Vehicle Simulation with Ignition Gazebo
+
+This topic explains how to simulate multiple UAV vehicles using Ignition Gazebo and SITL (Linux only).
+
+Ignition Gazebo allows an easier and more flexible connection with PX4 compared to other simulators which unfolds in a simpler procedure to setup multi-vehicle scenarios.
+Once that the SITL code has been build with
+```sh
+make px4_sitl
+```
+it can be run and linked to Ignition with the right combination of environment variables and arguments:
+
+```
+ARGS ./build/px4_sitl_default/bin/px4 [-i <instance>]
+```
+- `<instance>`: The instance number of the vehicle, each vehicle must have a unique instance number.
+If not given, it defaults to zero.
+When used with `PX4_GZ_MODEL` then Ignition Gazebo will automatically pick an unique model name in the form `${PX4_GZ_MODEL}_instance`. 
+- `ARGS`: The same environmental variables list described in [Ingnition Gazebo Simulation](ignition_gazebo.md#advanced-usages).

--- a/en/simulation/multi_vehicle_simulation_ignition_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_ignition_gazebo.md
@@ -27,3 +27,4 @@ ARGS ./build/px4_sitl_default/bin/px4 [-i <instance>]
   - When used with `PX4_GZ_MODEL`, Ignition Gazebo will automatically pick a unique model name in the form `${PX4_GZ_MODEL}_instance`. 
 - `ARGS`:
    A list of environmental variables, as described in [Ingnition Gazebo Simulation > Usage/Configuration Options](../simulation/ignition_gazebo.md#usage-configuration-options).
+   

--- a/en/simulation/multi_vehicle_simulation_ignition_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_ignition_gazebo.md
@@ -1,6 +1,6 @@
 # Multi-Vehicle Simulation with Ignition Gazebo
 
-This topic explains how to simulate multiple UAV vehicles using [Ignition Gazebo](../simulation/multi_vehicle_simulation_ignition_gazebo.md) and SITL.
+This topic explains how to simulate multiple UAV vehicles using [Ignition Gazebo](../simulation/ignition_gazebo.md) and SITL.
 
 :::note
 Multi-Vehicle Simulation with Ignition Gazebo is only supported on Linux.
@@ -14,7 +14,7 @@ First build PX4 SITL code using:
 make px4_sitl
 ```
 
-Each instance of PX4 can then be run in its own terminal, specifying a unique instance number and its desired combination of [environment variables](../simulation/ignition_gazebo.md#usage-configuration-options):
+Each instance of PX4 can then be launched in its own terminal, specifying a unique instance number and its desired combination of [environment variables](../simulation/ignition_gazebo.md#usage-configuration-options):
 
 ```sh
 ARGS ./build/px4_sitl_default/bin/px4 [-i <instance>]

--- a/en/simulation/multi_vehicle_simulation_ignition_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_ignition_gazebo.md
@@ -1,18 +1,29 @@
 # Multi-Vehicle Simulation with Ignition Gazebo
 
-This topic explains how to simulate multiple UAV vehicles using Ignition Gazebo and SITL (Linux only).
+This topic explains how to simulate multiple UAV vehicles using [Ignition Gazebo](../simulation/multi_vehicle_simulation_ignition_gazebo.md) and SITL.
 
-Ignition Gazebo allows an easier and more flexible connection with PX4 compared to other simulators which unfolds in a simpler procedure to setup multi-vehicle scenarios.
-Once that the SITL code has been build with
+:::note
+Multi-Vehicle Simulation with Ignition Gazebo is only supported on Linux.
+:::
+
+Ignition Gazebo makes it very easy to setup multi-vehicle scenarios (compared to other simulators).
+
+First build PX4 SITL code using:
+
 ```sh
 make px4_sitl
 ```
-it can be run and linked to Ignition with the right combination of environment variables and arguments:
 
-```
+Each instance of PX4 can then be run in its own terminal, specifying a unique instance number and its desired combination of [environment variables](../simulation/ignition_gazebo.md#usage-configuration-options):
+
+```sh
 ARGS ./build/px4_sitl_default/bin/px4 [-i <instance>]
 ```
-- `<instance>`: The instance number of the vehicle, each vehicle must have a unique instance number.
-If not given, it defaults to zero.
-When used with `PX4_GZ_MODEL` then Ignition Gazebo will automatically pick an unique model name in the form `${PX4_GZ_MODEL}_instance`. 
-- `ARGS`: The same environmental variables list described in [Ingnition Gazebo Simulation](ignition_gazebo.md#advanced-usages).
+
+- `<instance>`:
+  The instance number of the vehicle.
+  - Each vehicle must have a unique instance number.
+    If not given, the instance number defaults to zero.
+  - When used with `PX4_GZ_MODEL`, Ignition Gazebo will automatically pick a unique model name in the form `${PX4_GZ_MODEL}_instance`. 
+- `ARGS`:
+   A list of environmental variables, as described in [Ingnition Gazebo Simulation > Usage/Configuration Options](../simulation/ignition_gazebo.md#usage-configuration-options).


### PR DESCRIPTION
This PR is based on https://github.com/PX4/PX4-Autopilot/pull/20319, https://github.com/PX4/PX4-Autopilot/pull/20221 and https://github.com/PX4/PX4-Autopilot/pull/20725.

- [x] Removed `VERBOSE_SIM` instructions as not used anymore.
- [x] Detailed instructions about command line arguments and environment variables managing the interaction between PX4 and Ignition Gazebo.
- [x] How to add new vehicles and worlds.
- [x] Examples about the most common scenarios. 
- [x] New page about multi vehicles simulation in Ignition Gazebo.
- [ ] Explanatory Videos.
- [ ] Microdds / ROS2 interaction.

The most relevant aspects of the `gz_bridge` and are highlighted
- Capability to start a new simulation or to link to an existing world.
- Capability to spawn a new vehicle or to link PX4 to an already existing object.
- Capability to set custom worlds and custom spawning poses.
- Capability to have multiple vehicles by simply setting a single parameter.