### PR TITLE
Add barometers page in peripherals.

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -226,6 +226,7 @@
       * [Snapdragon Flight](flight_controller/snapdragon_flight.md)
       * [Intel® Aero RTF Drone (Discontinued)](complete_vehicles/intel_aero.md)
   * [Flight Controller Peripherals](peripherals/README.md)
+    * [Barometers](sensor/barometers.md)
     * [GPS/Compass](gps_compass/README.md)
       * [ARK GPS](dronecan/ark_gps.md)
       * [LOCOSYS Hawk A1 GNSS](gps_compass/gps_locosys_hawk_a1.md)

--- a/en/dronecan/README.md
+++ b/en/dronecan/README.md
@@ -41,7 +41,7 @@ Supported hardware includes (this is not an exhaustive list):
   - [CubePilot Here3](https://www.cubepilot.org/#/here/here3)
   - [Zubax GNSS](https://zubax.com/products/gnss_2)
   - [CUAV NEO v2 Pro GNSS](https://doc.cuav.net/gps/neo-series-gnss/en/neo-v2-pro.html)
-  - [CUAV NEO 3 Pro GNSS](https://doc.cuav.net/gps/neo-series-gnss/en/neo-v2-pro.html)
+  - [CUAV NEO 3 Pro GNSS](https://doc.cuav.net/gps/neo-series-gnss/en/neo-3.html)
   - [CUAV C-RTK2 PPK/RTK GNSS](../gps_compass/rtk_gps_cuav_c-rtk2.md)
 - Power monitors
   - [Pomegranate Systems Power Module](../dronecan/pomegranate_systems_pm.md)

--- a/en/sensor/barometers.md
+++ b/en/sensor/barometers.md
@@ -1,0 +1,40 @@
+# Barometers
+
+Barometers measure atmospheric pressure, and are used in drones as altitude sensors.
+
+Most flight controller hardware on which PX4 incudes a barometer.
+By default PX4 will select the barometer with the highest priority (if any are present), and configure it as a data source for [Height estimation](../advanced_config/tuning_the_ecl_ekf.md#height).
+If a sensor fault is detected, PX4 will fall back to the next highest priority sensor.
+
+Generally barometers require no user configuration (or thought)!
+
+## Hardware Options
+
+[Pixhawk standard](../flight_controller/autopilot_pixhawk_standard.html) flight controllers include a barometer, as do [many others](../flight_controller/README.md).
+
+They are also present in other hardware:
+
+- [CUAV NEO 3 Pro GNSS module](https://doc.cuav.net/gps/neo-series-gnss/en/neo-3-pro.html#key-data) ([MS5611](../modules/modules_driver_baro.md#ms5611))
+
+The supported baro part numbers can be inferred from the driver names, which are listed in [PX4-Autopilot/src/drivers/barometer](https://github.com/PX4/PX4-Autopilot/tree/main/src/drivers/barometer) and from the [Modules Reference: Baro (Driver)](../modules/modules_driver_baro.md) documentation.
+At time of writing, drivers/parts include: bmp280, bmp388 (and BMP380), dps310, goertek (spl06), invensense (icp10100, icp10111, icp101xx, icp201xx), lps22hb, lps25h, lps33hw, maiertek (mpc2520), mpl3115a2, ms5611, ms5837, tcbp001ta
+
+
+## PX4 Configuration
+
+Generally barometers require no user configuration.
+If needed, you can:
+
+- Enable/Disable barometers as data source for [Height estimation](../advanced_config/tuning_the_ecl_ekf.md#height) using the [EKF2_BARO_CTRL](../advanced_config/parameter_reference.md#EKF2_BARO_CTRL) parameter.
+- Change the selection order of barometers using the [CAL_BAROx_PRIO](../advanced_config/parameter_reference.md#CAL_BARO0_PRIO) parameters for each baro.
+- Disable a baro by setting its [CAL_BAROx_PRIO](../advanced_config/parameter_reference.md#CAL_BARO0_PRIO) value to `0`.
+
+## Calibration
+
+Barometer parts are generally pre-calibrated.
+
+
+## Developer Information
+
+- [Baro driver source code](https://github.com/PX4/PX4-Autopilot/tree/main/src/drivers/barometer)
+- [Modules Reference: Baro (Driver)](../modules/modules_driver_baro.md) documentation.

--- a/en/sensor/barometers.md
+++ b/en/sensor/barometers.md
@@ -31,7 +31,13 @@ If needed, you can:
 
 ## Calibration
 
-Barometer parts are generally pre-calibrated.
+Barometers don't require calibration.
+
+<!-- Notes:
+- Absolute value isn't important since we just use the difference in altitude between "now" and the value when initializing EKF2
+- There is usually a scale factor error but it's compensated by the GNSS altitude using a bias estimator in EKF2 (we don't provide a way to calibrate that). This method is fine as long as the height change of the drone isn't too fast (below 200-300km/h probably; don't have real data on that).
+- The baro readings can be corrected using a [QNH](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#SENS_BARO_QNH) (https://en.wikipedia.org/wiki/Altimeter_setting) parameter, but again, it is only necessary to adjust it if the absolute barometric altitude is required by the pilot.
+-->
 
 
 ## Developer Information


### PR DESCRIPTION
This adds a page on barometers to the Peripherals/hardware section. This is complementary to the #2206 update because it wasn't clear to me what you can and cannot do with barometers, or that people would find this information easily.

I hope this makes the following things clear
- Generally you don't need to think about barometers - they are in the FC and pre-calibrated
- What parts are supported (pointers to drivers)
- That calibration is not needed (right?)
- But if you do want to disable them, how you do it.