### PR TITLE
Remove MOT_ORDERING param

### DIFF
--- a/en/config_mc/racer_setup.md
+++ b/en/config_mc/racer_setup.md
@@ -66,11 +66,6 @@ The integral term can account for an imbalanced setup, and a custom mixer can do
 However it is best to fix any imbalance as part of the vehicle setup.
 :::
 
-### Motor Ordering
-If you plan to use a 4-in-1 ESC, such as the [Hobbywing XRotor Micro 40A 4in1](http://www.hobbywing.com/goods.php?id=588), you will notice that it uses a motor ordering that is different from the one that PX4 uses.
-PX4 allows you to change the motor ordering in software via [MOT_ORDERING](../advanced_config/parameter_reference.md#MOT_ORDERING) parameter.
-You can select the Betaflight/Cleanflight motor ordering that is typically used on these 4-in-1 ESCs.
-
 ## Software Setup
 
 After having built the racer, you will need to configure the software.
@@ -79,6 +74,7 @@ Go through the [Basic Configuration Guide](../config/README.md).
 In particular, set the [Airframe](../config/airframe.md) that most closely matches your frame (typically you will choose the [Generic 250 Racer](../airframes/airframe_reference.md#copter_quadrotor_x_generic_250_racer) airframe, which sets some racer-specific parameters by default).
 
 These parameters are important:
+
 - Enable One-Shot (set [PWM_MAIN_RATE](../advanced_config/parameter_reference.md#PWM_MAIN_RATE) to 0) or DShot ([DSHOT_CONFIG](../advanced_config/parameter_reference.md#DSHOT_CONFIG)).
 - Set the maximum roll-, pitch- and yaw rates for Manual/Stabilized mode as
   desired: [MC_ROLLRATE_MAX](../advanced_config/parameter_reference.md#MC_ROLLRATE_MAX), [MC_PITCHRATE_MAX](../advanced_config/parameter_reference.md#MC_PITCHRATE_MAX) and [MC_YAWRATE_MAX](../advanced_config/parameter_reference.md#MC_YAWRATE_MAX).

--- a/en/flight_controller/kakuteh7.md
+++ b/en/flight_controller/kakuteh7.md
@@ -109,7 +109,6 @@ In addition to the [basic configuration](../config/README.md), the following par
 Parameter | Setting
 --- | ---
 [SYS_HAS_MAG](../advanced_config/parameter_reference.md#SYS_HAS_MAG) | This should be disabled since the board does not have an internal mag. You can enable it if you attach an external mag.
-[MOT_ORDERING](../advanced_config/parameter_reference.md#MOT_ORDERING) | If you use a 4-in-1 ESC with Betaflight motor assignment, this parameter can be set accordingly.
 
 
 ## Serial Port Mapping

--- a/en/flight_controller/omnibus_f4_sd.md
+++ b/en/flight_controller/omnibus_f4_sd.md
@@ -223,7 +223,8 @@ make omnibus_f4sd_default
 
 ## Installing PX4 Firmware
 
-The firmware can be installed in any of the normal ways: 
+The firmware can be installed in any of the normal ways:
+
 - Build and upload the source
   ```
   make omnibus_f4sd_default upload
@@ -240,7 +241,6 @@ Parameter | Setting
 --- | ---
 [SYS_HAS_MAG](../advanced_config/parameter_reference.md#SYS_HAS_MAG) | This should be disabled since the board does not have an internal mag. You can enable it if you attach an external mag.
 [SYS_HAS_BARO](../advanced_config/parameter_reference.md#SYS_HAS_BARO) | Disable this if your board does not have a barometer.
-[MOT_ORDERING](../advanced_config/parameter_reference.md#MOT_ORDERING) | If you use a 4-in-1 ESC with Betaflight/Cleanflight motor assignment, this parameter can be set accordingly.
 
 
 ## Further Info


### PR DESCRIPTION
`MOT_ORDERING` no longer exists - motors are ordered using the actuators setup.

I've just deleted the mentions where they occur - in most cases the associated docs refer to basic config, which contains actuator setup info.

FYI only @bkueng 