### PR TITLE
Installing Gazebo and ROS 2 and ROS 1

### DIFF
--- a/en/dev_setup/dev_env.md
+++ b/en/dev_setup/dev_env.md
@@ -18,6 +18,7 @@ Target | Linux (Ubuntu) | Mac | Windows
 **Simulation:** [Gazebo SITL](../sim_gazebo_gz/README.md) | &check; | &check; | &check;
 **Simulation:** [Gazebo Classic SITL](../sim_gazebo_classic/README.md) | &check; | &check; | &check;
 **Simulation:** [ROS with Gazebo Classic](../simulation/ros_interface.md) | &check; | | 
+**Simulation:** ROS2 with Gazebo | &check; | | 
 
 Experienced Docker users can also build with the containers used by our continuous integration system: [Docker Containers](../test_and_ci/docker.md)
 

--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -1,6 +1,7 @@
 # Ubuntu Development Environment
 
-The following instructions set up a PX4 development environment on Ubuntu Linux 18.04 and 20.04.
+The following instructions set up a PX4 development environment on Ubuntu Linux 18.04, 20.04 and 22.04 (not fully supported).
+
 This environment can be used to build PX4 for [most PX4 targets](../dev_setup/dev_env.md#supported-targets):
 
 - Pixhawk and other NuttX-based hardware
@@ -36,7 +37,7 @@ They are intended to be run on *clean* Ubuntu LTS installations.
 
 Script | Description
 --- | ---
-**[ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh)** | Installs [Gazebo Classic](../sim_gazebo_classic/README.md) (version 9 on Ubuntu 18.04 - otherwise version 11) and [jMAVSim](../simulation/jmavsim.md) simulators and/or [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) tools.
+**[ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh)** | Installs [Gazebo Classic](../sim_gazebo_classic/README.md) (version 9 on Ubuntu 18.04, version 11 on Ubuntu 20.04) and [jMAVSim](../simulation/jmavsim.md) simulators and/or [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) tools.
 **[ubuntu_sim_ros_melodic.sh](https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_ros_melodic.sh)** | Installs [ROS "Melodic"](#rosgazebo) and PX4 on Ubuntu 18.04 LTS **only**.<br>Do not use on Ubuntu 20.04 or later!
 
 :::note
@@ -48,7 +49,7 @@ The scripts *may* not work if installed "on top" of an existing system, or on a 
 Use the [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) script to set up a development environment that includes [Gazebo Classic](../sim_gazebo_classic/README.md) and [jMAVSim](../simulation/jmavsim.md) simulators, and/or the [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) toolchain.
 
 :::warning
-ROS Melodic users should jump to [ROS Melodic /Gazebo](#rosgazebo) (skip this section).
+ROS(1) users should jump to [ROS Melodic /Gazebo](#rosgazebo) (skip this section).
 :::
 
 To install the toolchain:
@@ -97,7 +98,7 @@ These notes are provided "for information only":
 
 ## Gazebo
 
-[Gazebo](../sim_gazebo_gz/README.md) is supported on Ubuntu 18.04, Ubuntu 20.04, and Ubuntu 22.04, and recommended for working with PX4 on Ubuntu 22.04 and later.
+[Gazebo](../sim_gazebo_gz/README.md) "Garden" is supported on Ubuntu 18.04, Ubuntu 20.04, and Ubuntu 22.04, and recommended for working with PX4 on Ubuntu 22.04 and later.
 It is not installed by the [bash scripts](#bash-scripts) above (see [PX4-Autopilot/#21090](https://github.com/PX4/PX4-Autopilot/issues/21090)), but can be installed manually.
 
 To install Gazebo:
@@ -113,7 +114,9 @@ To install Gazebo:
     sudo apt-get install gz-garden
    ```
    
-   Note that installing `gz-garden` will uninstall Gazebo-Classic!
+   :::note
+   Installing `gz-garden` will uninstall Gazebo-Classic!
+   """
 
 <!-- reproduced from the official [Gazebo "Garden"](https://gazebosim.org/docs/garden/install_ubuntu) installation instructions. -->
 
@@ -211,14 +214,6 @@ For installation instructions for the respective simulators see:
 
 - [Gazebo Classic, JMAVSim and NuttX (Pixhawk) Targets](#gazebo-classic-jmavsim-and-nuttx-pixhawk-targets)
 - [Gazebo](#gazebo)
-
-:::note
-ROS desktop builds (i.e. installed with say, `ros-humble-desktop`) include specific versions of Gazebo and Gazebo Classic by default.
-For example, ROS2 "Humble" and "Rolling" come with Ignition Fortress, ROS2 "Foxy" comes with Gazebo Classic 11, and ROS1 "Melodic" comes with Gazebo 9. 
-
-PX4 supports specific versions of Gazebo, so you should follow the instructions above to install [Gazebo](#gazebo).
-:::
-
 
 <a id="rosgazebo"></a>
 ## ROS Melodic/Gazebo Classic

--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -48,7 +48,7 @@ The scripts *may* not work if installed "on top" of an existing system, or on a 
 Use the [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) script to set up a development environment that includes [Gazebo Classic](../sim_gazebo_classic/README.md) and [jMAVSim](../simulation/jmavsim.md) simulators, and/or the [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) toolchain.
 
 :::warning
-ROS Melodic users should skip these instructions and follow the instructions at [ROS Melodic /Gazebo](#rosgazebo) (Gazebo Classic is installed by default, and there may be some conflicts).
+ROS Melodic users should jump to [ROS Melodic /Gazebo](#rosgazebo) (skip this section).
 :::
 
 To install the toolchain:
@@ -71,9 +71,8 @@ To install the toolchain:
    - You can use the `--no-nuttx` and `--no-sim-tools` options to omit the NuttX and/or simulation tools.
 1. Restart the computer on completion.
 
-:::note
-These are additional "for your information" notes:
-
+:::details Additional notes
+These notes are provided "for information only":
 - The script installs Gazebo Classic 9 on Ubuntu 18.04 and otherwise Gazebo Classic 11.
 - You can verify the NuttX installation by confirming the gcc version as shown:
   ```bash
@@ -103,6 +102,7 @@ It is not installed by the [bash scripts](#bash-scripts) above (see [PX4-Autopil
 To install Gazebo:
 
 1. Follow the instructions above for installing [Gazebo Classic, JMAVSim and NuttX (Pixhawk) Targets](#gazebo-classic-jmavsim-and-nuttx-pixhawk-targets).
+   The NuttX components are optional, but you will need the simulator dependencies.
 2. Install Gazebo:
 
    ```sh
@@ -112,16 +112,9 @@ To install Gazebo:
     sudo apt-get install gz-garden
    ```
    
-   This will uninstall Gazebo-Classic on Ubuntu 22.02.
+   Note that installing `gz-garden` will uninstall Gazebo-Classic on Ubuntu 22.02.
 
 <!-- reproduced from the official [Gazebo "Garden"](https://gazebosim.org/docs/garden/install_ubuntu) installation instructions. -->
-
-
-:::note
-If you're working with ROS2 "Humble" or later (Ubuntu 22.04), Gazebo can alternatively be installed as part of the desktop builds, such as `ros-humble-desktop`.
-Note that ROS2 "Foxy" installs Gazebo Classic 11.
-:::
-
 
 <a id="raspberry-pi-hardware"></a>
 ## Raspberry Pi
@@ -206,6 +199,26 @@ Additional developer information for using PX4 on Raspberry Pi (including buildi
 - [Raspberry Pi 2/3/4 PilotPi Shield](../flight_controller/raspberry_pi_pilotpi.md).
 
 
+## ROS 2
+
+Information about ROS 2 setup and development with PX4 can be found in the [ROS 2 User Guide](../ros/ros2_comm.md).
+
+Generally speaking if you're working with hardware and don't need to modify PX4 itself, then you do not need a PX4 development environment (dependencies for working with ROS 2 are included and built into PX4 firmware by default).
+
+You will need to install the normal development simulator environment in order to work with the PX4 simulator.
+For installation instructions for the respective simulators see:
+
+- [Gazebo Classic, JMAVSim and NuttX (Pixhawk) Targets](#gazebo-classic-jmavsim-and-nuttx-pixhawk-targets)
+- [Gazebo](#gazebo)
+
+:::note
+ROS desktop builds (i.e. installed with say, `ros-humble-desktop`) include specific versions of Gazebo and Gazebo classic by default.
+For example, ROS2 "Humble" and "Rolling" come with Ignition Fortress, ROS2 "Foxy" comes with Gazebo Classic 11, and ROS1 "Melodic" comes with Gazebo 9. 
+
+PX4 supports specific versions of Gazebo, so you should follow the instructions above to install [Gazebo](#gazebo).
+:::
+
+
 <a id="rosgazebo"></a>
 ## ROS Melodic/Gazebo Classic
 
@@ -217,7 +230,8 @@ ROS Melodic can *only* install on Ubuntu 18.04.
 
 To install the development toolchain:
 
-1. Download the script in a bash shell:
+1. Download the [ubuntu_sim_ros_melodic.sh](https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_ros_melodic.sh) script in a bash shell:
+
    ```bash
    wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_ros_melodic.sh
    ```
@@ -233,12 +247,6 @@ To install the development toolchain:
 * Your catkin (ROS build system) workspace is created at **~/catkin_ws/**.
 * The script uses instructions from the ROS Wiki "Melodic" [Ubuntu page](http://wiki.ros.org/melodic/Installation/Ubuntu).
 :::
-
-## ROS 2
-
-PX4 dependencies for working with ROS 2 are included and built into firmware by default.
-
-Information about ROS 2 development with PX4 can be found in the [ROS 2 User Guide](../ros/ros2_comm.md).
 
 
 ## Next Steps

--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -75,13 +75,14 @@ To install the toolchain:
 These notes are provided "for information only":
 - The script installs Gazebo Classic 9 on Ubuntu 18.04 and otherwise Gazebo Classic 11.
 - You can verify the NuttX installation by confirming the gcc version as shown:
-  ```bash
-   $arm-none-eabi-gcc --version
 
-   arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 7-2017-q4-major) 7.2.1 20170904 (release) [ARM/embedded-7-branch revision 255204]
-   Copyright (C) 2017 Free Software Foundation, Inc.
-   This is free software; see the source for copying conditions.  There is NO
-   warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ```bash
+  $arm-none-eabi-gcc --version
+
+  arm-none-eabi-gcc (GNU Arm Embedded Toolchain 9-2020-q2-update) 9.3.1 20200408 (release)
+  Copyright (C) 2019 Free Software Foundation, Inc.
+  This is free software; see the source for copying conditions.  There is NO
+  warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
   ```
 - You're going to need the PX4 source code anyway.
   But if you just wanted to set up the development environment without getting all the source code you could instead just download [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) and [requirements.txt](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/requirements.txt) and then run **ubuntu.sh**:
@@ -212,7 +213,7 @@ For installation instructions for the respective simulators see:
 - [Gazebo](#gazebo)
 
 :::note
-ROS desktop builds (i.e. installed with say, `ros-humble-desktop`) include specific versions of Gazebo and Gazebo classic by default.
+ROS desktop builds (i.e. installed with say, `ros-humble-desktop`) include specific versions of Gazebo and Gazebo Classic by default.
 For example, ROS2 "Humble" and "Rolling" come with Ignition Fortress, ROS2 "Foxy" comes with Gazebo Classic 11, and ROS1 "Melodic" comes with Gazebo 9. 
 
 PX4 supports specific versions of Gazebo, so you should follow the instructions above to install [Gazebo](#gazebo).

--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -116,7 +116,7 @@ To install Gazebo:
    
    :::note
    Installing `gz-garden` will uninstall Gazebo-Classic!
-   """
+   :::
 
 <!-- reproduced from the official [Gazebo "Garden"](https://gazebosim.org/docs/garden/install_ubuntu) installation instructions. -->
 

--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -9,7 +9,8 @@ This environment can be used to build PX4 for [most PX4 targets](../dev_setup/de
 - [Gazebo Classic Simulation](../sim_gazebo_classic/README.md) (up to Ubuntu 20.04)
 - [jMAVSim Simulation](../simulation/jmavsim.md)
 - [Raspberry Pi](#raspberry-pi)
-- [ROS (1)](#ros-gazebo) (Robotics Operating System)
+- [ROS 2](#ros-2) (Robotics Operating System)
+- [ROS 1](#ros-gazebo-classic) (Robotics Operating System)
 
 :::tip
 This setup is supported by the PX4 dev team.
@@ -20,8 +21,7 @@ The instructions may also work on other Debian Linux based systems.
 The supported OS versions for PX4 development are [Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) 18.04 (Bionic Beaver) and 20.04 (Focal Fossa).
 Ubuntu LTS 22.04 support is expected soon.
 
-For ROS 2, Ubuntu LTS 20.04 is supported.
-For ROS (1), Ubuntu LTS 18.04 (only) is supported.
+ROS versions are tied to specific Ubuntu versions.
 :::
 
 ## Video Guide
@@ -49,7 +49,7 @@ The scripts *may* not work if installed "on top" of an existing system, or on a 
 Use the [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) script to set up a development environment that includes [Gazebo Classic](../sim_gazebo_classic/README.md) and [jMAVSim](../simulation/jmavsim.md) simulators, and/or the [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) toolchain.
 
 :::warning
-ROS(1) users should jump to [ROS Melodic /Gazebo](#rosgazebo) (skip this section).
+ROS users should first read/skip ahead to the [ROS/Gazebo](#rosgazebo) or [ROS 2](#ros-2) sections.
 :::
 
 To install the toolchain:
@@ -98,7 +98,7 @@ These notes are provided "for information only":
 
 ## Gazebo
 
-[Gazebo](../sim_gazebo_gz/README.md) "Garden" is supported on Ubuntu 18.04, Ubuntu 20.04, and Ubuntu 22.04, and recommended for working with PX4 on Ubuntu 22.04 and later.
+[Gazebo](../sim_gazebo_gz/README.md) "Garden" is supported on Ubuntu 20.04 and Ubuntu 22.04, and recommended for working with PX4 on Ubuntu 22.04 and later.
 It is not installed by the [bash scripts](#bash-scripts) above (see [PX4-Autopilot/#21090](https://github.com/PX4/PX4-Autopilot/issues/21090)), but can be installed manually.
 
 To install Gazebo:
@@ -213,18 +213,43 @@ You will need to install the normal development simulator environment in order t
 For installation instructions for the respective simulators see:
 
 - [Gazebo Classic, JMAVSim and NuttX (Pixhawk) Targets](#gazebo-classic-jmavsim-and-nuttx-pixhawk-targets)
-- [Gazebo](#gazebo)
+- [Gazebo](#gazebo) (use on Ubuntu 22.04)
 
 <a id="rosgazebo"></a>
-## ROS Melodic/Gazebo Classic
+## ROS/Gazebo Classic
 
-This section explains how to install [ROS](../ros/README.md) "Melodic" (including Gazebo 9) and PX4 on Ubuntu 18.04.
+This section explains how to install [ROS1](../ros/README.md) with PX4.
+ROS1 full desktop builds come with Gazebo Classic, so normally you will not install PX4 simulator dependencies yourself!
 
-:::warning
-ROS Melodic can *only* install on Ubuntu 18.04.
-:::
+### ROS Noetic/Ubuntu 20.04
 
-To install the development toolchain:
+If you're working with [ROS Noetic](http://wiki.ros.org/noetic) on Ubuntu 20.04:
+
+1. Install PX4 without the simulator toolchain:
+
+   1. [Download PX4 Source Code](../dev_setup/building_px4.md):
+
+      ```bash
+      git clone https://github.com/PX4/PX4-Autopilot.git --recursive
+      ```
+   1. Run the **ubuntu.sh** the `--no-sim-tools` (and optionally `--no-nuttx`):
+   
+      ```bash
+      bash ./PX4-Autopilot/Tools/setup/ubuntu.sh --no-sim-tools --no-nuttx
+      ```
+      - Acknowledge any prompts as the script progress.
+   1. Restart the computer on completion.
+1. You _may_ need to install the following additional dependencies:
+
+   ```
+   sudo apt-get install protobuf-compiler libeigen3-dev libopencv-dev -y
+   ```
+1. Follow the [Noetic Installation instructions](http://wiki.ros.org/noetic/Installation/Ubuntu#Installation) (ros-noetic-desktop-full is recommended).
+1. Intall MAVROS by following the [MAVROS Installation Guide](../ros/mavros_installation.md).
+
+### ROS Melodic/Ubuntu 18.04
+
+If you're working with ROS "Melodic on Ubuntu 18.04:
 
 1. Download the [ubuntu_sim_ros_melodic.sh](https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_ros_melodic.sh) script in a bash shell:
 

--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -2,22 +2,25 @@
 
 The following instructions set up a PX4 development environment on Ubuntu Linux 18.04 and 20.04.
 This environment can be used to build PX4 for [most PX4 targets](../dev_setup/dev_env.md#supported-targets):
-* Pixhawk and other NuttX-based hardware
-* [Gazebo Simulation](../sim_gazebo_gz/README.md) (Ubuntu 20.04 and later)
-* [Gazebo Classic Simulation](../sim_gazebo_classic/README.md) (up to Ubuntu 20.04)
-* [jMAVSim Simulation](../simulation/jmavsim.md)
-* [Raspberry Pi](#raspberry-pi)
-* [ROS (1)](#ros-gazebo) (Robotics Operating System)
+
+- Pixhawk and other NuttX-based hardware
+- [Gazebo Simulation](../sim_gazebo_gz/README.md) (Ubuntu 20.04 and later)
+- [Gazebo Classic Simulation](../sim_gazebo_classic/README.md) (up to Ubuntu 20.04)
+- [jMAVSim Simulation](../simulation/jmavsim.md)
+- [Raspberry Pi](#raspberry-pi)
+- [ROS (1)](#ros-gazebo) (Robotics Operating System)
 
 :::tip
 This setup is supported by the PX4 dev team.
+The instructions may also work on other Debian Linux based systems.
 :::
 
 :::note
 The supported OS versions for PX4 development are [Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) 18.04 (Bionic Beaver) and 20.04 (Focal Fossa).
-For ROS (1) Ubuntu LTS 18.04 (only) is supported.
+Ubuntu LTS 22.04 support is expected soon.
 
-The instructions should also work on other Debian Linux based systems, but this is not verified/officially supported.
+For ROS 2, Ubuntu LTS 20.04 is supported.
+For ROS (1), Ubuntu LTS 18.04 (only) is supported.
 :::
 
 ## Video Guide
@@ -33,7 +36,7 @@ They are intended to be run on *clean* Ubuntu LTS installations.
 
 Script | Description
 --- | ---
-**[ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh)** | Installs [Gazebo Classic](../sim_gazebo_classic/README.md) (version 9 on Ubuntu 18.04 - otherwise version 11) and [jMAVSim](../simulation/jmavsim.md) simulators and/or [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) tools.<br>Does not include dependencies for [Fast DDS](#fast-dds-installation). <!-- NEED px4_version -->
+**[ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh)** | Installs [Gazebo Classic](../sim_gazebo_classic/README.md) (version 9 on Ubuntu 18.04 - otherwise version 11) and [jMAVSim](../simulation/jmavsim.md) simulators and/or [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) tools.
 **[ubuntu_sim_ros_melodic.sh](https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_ros_melodic.sh)** | Installs [ROS "Melodic"](#rosgazebo) and PX4 on Ubuntu 18.04 LTS **only**.<br>Do not use on Ubuntu 20.04 or later!
 
 :::note
@@ -42,10 +45,10 @@ The scripts *may* not work if installed "on top" of an existing system, or on a 
 
 ## Gazebo Classic, JMAVSim and NuttX (Pixhawk) Targets
 
-Use the [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) <!-- NEED px4_version --> script to set up a development environment that includes [Gazebo 9](../sim_gazebo_classic/README.md) and [jMAVSim](../simulation/jmavsim.md) simulators, and/or the [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) toolchain.
+Use the [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) script to set up a development environment that includes [Gazebo Classic](../sim_gazebo_classic/README.md) and [jMAVSim](../simulation/jmavsim.md) simulators, and/or the [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) toolchain.
 
 :::warning
-ROS users must follow the instructions for: [ROS/Gazebo](#rosgazebo). <!-- ROS installs Gazebo automatically, as part of the ROS installation). -->
+ROS Melodic users should skip these instructions and follow the instructions at [ROS Melodic /Gazebo](#rosgazebo) (Gazebo Classic is installed by default, and there may be some conflicts).
 :::
 
 To install the toolchain:
@@ -69,11 +72,9 @@ To install the toolchain:
 1. Restart the computer on completion.
 
 :::note
-These are additional "for your information" notes.
-They only explain the implementation.
+These are additional "for your information" notes:
 
-- The script installs Gazebo Classic 9 (following [gazebosim.org instructions](http://gazebosim.org/tutorials?tut=install_ubuntu&cat=install)).
-  Gazebo 7, 8 are also supported but not recommended.
+- The script installs Gazebo Classic 9 on Ubuntu 18.04 and otherwise Gazebo Classic 11.
 - You can verify the NuttX installation by confirming the gcc version as shown:
   ```bash
    $arm-none-eabi-gcc --version
@@ -84,7 +85,8 @@ They only explain the implementation.
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
   ```
 - You're going to need the PX4 source code anyway.
-  But if you just wanted to set up the development environment without getting all the source code you could instead just download [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) and [requirements.txt](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/requirements.txt) and then run **ubuntu.sh**: <!-- NEED px4_version -->
+  But if you just wanted to set up the development environment without getting all the source code you could instead just download [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) and [requirements.txt](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/requirements.txt) and then run **ubuntu.sh**:
+
    ```bash
    wget https://raw.githubusercontent.com/PX4/PX4-Autopilot/main/Tools/setup/ubuntu.sh
    wget https://raw.githubusercontent.com/PX4/PX4-Autopilot/main/Tools/setup/requirements.txt
@@ -92,13 +94,33 @@ They only explain the implementation.
    ```
 :::
 
-<!-- Do we need to add to our scripts or can we assume correct version installs over?
-Remove any old versions of the arm-none-eabi toolchain.
-```sh
-sudo apt-get remove gcc-arm-none-eabi gdb-arm-none-eabi binutils-arm-none-eabi gcc-arm-embedded
-sudo add-apt-repository --remove ppa:team-gcc-arm-embedded/ppa
-```
--->
+
+## Gazebo
+
+[Gazebo](../sim_gazebo_gz/README.md) is supported on Ubuntu 18.04, Ubuntu 20.04, and Ubuntu 22.04, and recommended for working with PX4 on Ubuntu 22.04 and later.
+It is not installed by the [bash scripts](#bash-scripts) above (see [PX4-Autopilot/#21090](https://github.com/PX4/PX4-Autopilot/issues/21090)), but can be installed manually.
+
+To install Gazebo:
+
+1. Follow the instructions above for installing [Gazebo Classic, JMAVSim and NuttX (Pixhawk) Targets](#gazebo-classic-jmavsim-and-nuttx-pixhawk-targets).
+2. Install Gazebo:
+
+   ```sh
+    sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+    sudo apt-get update
+    sudo apt-get install gz-garden
+   ```
+   
+   This will uninstall Gazebo-Classic on Ubuntu 22.02.
+
+<!-- reproduced from the official [Gazebo "Garden"](https://gazebosim.org/docs/garden/install_ubuntu) installation instructions. -->
+
+
+:::note
+If you're working with ROS2 "Humble" or later (Ubuntu 22.04), Gazebo can alternatively be installed as part of the desktop builds, such as `ros-humble-desktop`.
+Note that ROS2 "Foxy" installs Gazebo Classic 11.
+:::
 
 
 <a id="raspberry-pi-hardware"></a>
@@ -185,22 +207,22 @@ Additional developer information for using PX4 on Raspberry Pi (including buildi
 
 
 <a id="rosgazebo"></a>
-## ROS/Gazebo Classic
+## ROS Melodic/Gazebo Classic
 
-This section explains how to install [ROS](../ros/README.md) "Melodic" and PX4 on Ubuntu 18.04.
+This section explains how to install [ROS](../ros/README.md) "Melodic" (including Gazebo 9) and PX4 on Ubuntu 18.04.
 
 :::warning
-ROS builds are tied to specific Ubuntu versions!
 ROS Melodic can *only* install on Ubuntu 18.04.
 :::
 
 To install the development toolchain:
 
-1. Download the script in a bash shell: <!-- NEED px4_version -->
+1. Download the script in a bash shell:
    ```bash
    wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_ros_melodic.sh
    ```
 1. Run the script:
+
    ```bash
    bash ubuntu_sim_ros_melodic.sh
    ```
@@ -216,7 +238,7 @@ To install the development toolchain:
 
 PX4 dependencies for working with ROS 2 are included and built into firmware by default.
 
-Information about ROS 2 development with PX4 can be found in the [ROS 2 User Guide](../ros/ros2_comm.md)
+Information about ROS 2 development with PX4 can be found in the [ROS 2 User Guide](../ros/ros2_comm.md).
 
 
 ## Next Steps

--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -113,7 +113,7 @@ To install Gazebo:
     sudo apt-get install gz-garden
    ```
    
-   Note that installing `gz-garden` will uninstall Gazebo-Classic on Ubuntu 22.02.
+   Note that installing `gz-garden` will uninstall Gazebo-Classic!
 
 <!-- reproduced from the official [Gazebo "Garden"](https://gazebosim.org/docs/garden/install_ubuntu) installation instructions. -->
 

--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -1,13 +1,15 @@
 # Ubuntu Development Environment
 
-The following instructions set up a PX4 development environment on Ubuntu Linux 18.04, 20.04 and 22.04 (not fully supported).
+The following instructions set up a PX4 development environment on the [Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) versions supported by PX4.
+This includes 18.04 (Bionic Beaver), 20.04 (Focal Fossa).
+The instructions also work for Ubuntu 22.04 (Jammy Jellyfish), although PX4 does not yet fully support this version.
 
-This environment can be used to build PX4 for [most PX4 targets](../dev_setup/dev_env.md#supported-targets):
+Bash scripts are provided to simplify the process.
+They are intended to be run on *clean* Ubuntu LTS installations, and may not work if run "on top" of an existing system, or on a different Ubuntu release.
 
-- Pixhawk and other NuttX-based hardware
-- [Gazebo Simulation](../sim_gazebo_gz/README.md) (Ubuntu 20.04 and later)
-- [Gazebo Classic Simulation](../sim_gazebo_classic/README.md) (up to Ubuntu 20.04)
-- [jMAVSim Simulation](../simulation/jmavsim.md)
+The [supported targets](../dev_setup/dev_env.md#supported-targets) are:
+
+- [Simulation and NuttX (Pixhawk) Targets](#simulation-and-nuttx-pixhawk-targets). This includes: [Gazebo](../sim_gazebo_gz/README.md), [Gazebo Classic](../sim_gazebo_classic/README.md), [jMAVSim](../simulation/jmavsim.md), [Pixhawk and other NuttX-based hardware](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards)).
 - [Raspberry Pi](#raspberry-pi)
 - [ROS 2](#ros-2) (Robotics Operating System)
 - [ROS 1](#ros-gazebo-classic) (Robotics Operating System)
@@ -17,40 +19,20 @@ This setup is supported by the PX4 dev team.
 The instructions may also work on other Debian Linux based systems.
 :::
 
-:::note
-The supported OS versions for PX4 development are [Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) 18.04 (Bionic Beaver) and 20.04 (Focal Fossa).
-Ubuntu LTS 22.04 support is expected soon.
-
-ROS versions are tied to specific Ubuntu versions.
-:::
-
 ## Video Guide
 
-This video shows how to install the toolchain for NuttX and simulation targets ([as covered below](#gazebo-jmavsim-and-nuttx-pixhawk-targets)) along with the basic testing covered in [Building PX4 Software](../dev_setup/building_px4.md).
+This video shows how to install the toolchain for NuttX and simulation targets ([as covered below](#simulation-and-nuttx-pixhawk-targets)) along with the basic testing covered in [Building PX4 Software](../dev_setup/building_px4.md).
 
-@[youtube](https://youtu.be/OtValQdAdrU)
+@[youtube](https://youtu.be/OtValQdAdrU).
 
-## Bash Scripts
-
-Bash scripts are provided to help make it easy to install development environment for different target platforms.
-They are intended to be run on *clean* Ubuntu LTS installations.
-
-Script | Description
---- | ---
-**[ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh)** | Installs [Gazebo Classic](../sim_gazebo_classic/README.md) (version 9 on Ubuntu 18.04, version 11 on Ubuntu 20.04) and [jMAVSim](../simulation/jmavsim.md) simulators and/or [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) tools.
-**[ubuntu_sim_ros_melodic.sh](https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_ros_melodic.sh)** | Installs [ROS "Melodic"](#rosgazebo) and PX4 on Ubuntu 18.04 LTS **only**.<br>Do not use on Ubuntu 20.04 or later!
-
-:::note
-The scripts *may* not work if installed "on top" of an existing system, or on a different Ubuntu release.
-:::
-
-## Gazebo Classic, JMAVSim and NuttX (Pixhawk) Targets
-
-Use the [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) script to set up a development environment that includes [Gazebo Classic](../sim_gazebo_classic/README.md) and [jMAVSim](../simulation/jmavsim.md) simulators, and/or the [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) toolchain.
+## Simulation and NuttX (Pixhawk) Targets
 
 :::warning
 ROS users should first read/skip ahead to the [ROS/Gazebo](#rosgazebo) or [ROS 2](#ros-2) sections.
 :::
+
+Use the [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) script to set up a development environment that allows you to build for simulators and/or the [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) toolchain.
+The script installs [jMAVSim](../simulation/jmavsim.md) on all targets, [Gazebo Classic](../sim_gazebo_classic/README.md) 9 on Ubuntu 18.04, Gazebo Classic 11 on Ubuntu 20.04, and [Gazebo](../sim_gazebo_gz/README.md) "Garden" on Ubuntu 22.04.
 
 To install the toolchain:
 
@@ -72,9 +54,11 @@ To install the toolchain:
    - You can use the `--no-nuttx` and `--no-sim-tools` options to omit the NuttX and/or simulation tools.
 1. Restart the computer on completion.
 
+
 :::details Additional notes
 These notes are provided "for information only":
-- The script installs Gazebo Classic 9 on Ubuntu 18.04 and otherwise Gazebo Classic 11.
+- If you want to use Gazebo on Ubuntu 20.08 you can add it manually.
+  See [Gazebo > Installation](../sim_gazebo_gz/README.md#installation-ubuntu-linux).
 - You can verify the NuttX installation by confirming the gcc version as shown:
 
   ```bash
@@ -93,32 +77,9 @@ These notes are provided "for information only":
    wget https://raw.githubusercontent.com/PX4/PX4-Autopilot/main/Tools/setup/requirements.txt
    bash ubuntu.sh
    ```
+   <!-- From https://gazebosim.org/docs/garden/install_ubuntu -->
 :::
 
-
-## Gazebo
-
-[Gazebo](../sim_gazebo_gz/README.md) "Garden" is supported on Ubuntu 20.04 and Ubuntu 22.04, and recommended for working with PX4 on Ubuntu 22.04 and later.
-It is not installed by the [bash scripts](#bash-scripts) above (see [PX4-Autopilot/#21090](https://github.com/PX4/PX4-Autopilot/issues/21090)), but can be installed manually.
-
-To install Gazebo:
-
-1. Follow the instructions above for installing [Gazebo Classic, JMAVSim and NuttX (Pixhawk) Targets](#gazebo-classic-jmavsim-and-nuttx-pixhawk-targets).
-   The NuttX components are optional, but you will need the simulator dependencies.
-2. Install Gazebo:
-
-   ```sh
-    sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-    sudo apt-get update
-    sudo apt-get install gz-garden
-   ```
-   
-   :::note
-   Installing `gz-garden` will uninstall Gazebo-Classic!
-   :::
-
-<!-- reproduced from the official [Gazebo "Garden"](https://gazebosim.org/docs/garden/install_ubuntu) installation instructions. -->
 
 <a id="raspberry-pi-hardware"></a>
 ## Raspberry Pi
@@ -209,11 +170,7 @@ Information about ROS 2 setup and development with PX4 can be found in the [ROS 
 
 Generally speaking if you're working with hardware and don't need to modify PX4 itself, then you do not need a PX4 development environment (dependencies for working with ROS 2 are included and built into PX4 firmware by default).
 
-You will need to install the normal development simulator environment in order to work with the PX4 simulator.
-For installation instructions for the respective simulators see:
-
-- [Gazebo Classic, JMAVSim and NuttX (Pixhawk) Targets](#gazebo-classic-jmavsim-and-nuttx-pixhawk-targets)
-- [Gazebo](#gazebo) (use on Ubuntu 22.04)
+You will need to install the normal development [simulator environment](#simulation-and-nuttx-pixhawk-targets) in order to work with the PX4 simulator.
 
 <a id="rosgazebo"></a>
 ## ROS/Gazebo Classic

--- a/en/ros/mavros_installation.md
+++ b/en/ros/mavros_installation.md
@@ -1,36 +1,28 @@
 # ROS with MAVROS Installation Guide
 
-[mavros](http://wiki.ros.org/mavros#mavros.2BAC8-Plugins.sys_status) is a ROS (1) package that enables MAVLink extendable communication between computers running ROS (1) for any MAVLink enabled autopilot, ground station, or peripheral.
+[MAVROS](http://wiki.ros.org/mavros#mavros.2BAC8-Plugins.sys_status) is a ROS (1) package that enables MAVLink extendable communication between computers running ROS (1) for any MAVLink enabled autopilot, ground station, or peripheral.
 *MAVROS* is the "official" supported bridge between ROS (1) and the MAVLink protocol.
 
 While MAVROS can be used to communicate with any MAVLink-enabled autopilot, this documentation explains how to set up communication between the PX4 Autopilot and a ROS (1) enabled companion computer.
 
-:::tip
-The easiest way to setup PX4 simulation with ROS on Ubuntu Linux is to use the standard installation script that can be found at [Development Environment on Linux > Gazebo with ROS](../dev_setup/dev_env_linux_ubuntu.md#rosgazebo).
-
-The script automates the installation instructions covered in this topic, installing everything you need: PX4, ROS, the [Gazebo Classic](../sim_gazebo_classic/README.md) simulator, and [MAVROS](../ros/mavros_installation.md).
-:::
-
-:::warning Note
+:::warning
 The PX4 development team recommend that all users [upgrade to ROS 2](../ros/ros2.md).
 This documentation reflects the "old approach".
 :::
 
-## Resources
-
-- [mavros ROS Package Summary](http://wiki.ros.org/mavros#mavros.2BAC8-Plugins.sys_status)
-- [mavros source](https://github.com/mavlink/mavros/)
-- [ROS Melodic installation instructions](http://wiki.ros.org/melodic/Installation)
-
 ## Installation
 
-MAVROS can be installed either from source or binary.
-We recommend that developers use the source installation.
+:::note
+First install ROS and PX4 following the instructions in [Development Environment on Linux > ROS/Gazebo Classic](../dev_setup/dev_env_linux_ubuntu.md#ros-gazebo-classic).
+:::
 
 :::tip
 These instructions are a simplified version of the [official installation guide](https://github.com/mavlink/mavros/tree/master/mavros#installation).
 They cover the *ROS Melodic* release.
 :::
+
+MAVROS can be installed either from source or binary.
+We recommend that developers use the source installation.
 
 ### Binary Installation (Debian / Ubuntu)
 
@@ -133,3 +125,9 @@ The [MAVROS Offboard Example (C++)](../ros/mavros_offboard_cpp.md), will show yo
 :::note
 If you have an example app using the PX4 Autopilot and MAVROS, we can help you get it on our docs.
 :::
+
+## See Also
+
+- [mavros ROS Package Summary](http://wiki.ros.org/mavros#mavros.2BAC8-Plugins.sys_status)
+- [mavros source](https://github.com/mavlink/mavros/)
+- [ROS Melodic installation instructions](http://wiki.ros.org/melodic/Installation)

--- a/en/sim_gazebo_classic/README.md
+++ b/en/sim_gazebo_classic/README.md
@@ -1,7 +1,7 @@
 # Gazebo Classic Simulation
 
 :::warning
-_Gazebo Classic_ is supported up to Ubuntu Linux 20.04.
+_Gazebo Classic_ is supported with PX4 up to Ubuntu Linux 20.04.
 It has been superseded by [Gazebo](../sim_gazebo_gz/README.md) (which was [formerly known](https://www.openrobotics.org/blog/2022/4/6/a-new-era-for-gazebo)  as "Gazebo Ignition") for use on Ubuntu 22.04 and later.
 :::
 

--- a/en/sim_gazebo_gz/README.md
+++ b/en/sim_gazebo_gz/README.md
@@ -18,8 +18,16 @@ See [Simulation](../simulation/README.md) for general information about simulato
 
 ## Installation (Ubuntu Linux)
 
-Instructions for installing on Ubuntu Linux are provided in [Ubuntu Dev Environment Setup > Gazebo](../dev_setup/dev_env_linux_ubuntu.md#gazebo).
+Gazebo is installed by default on Ubuntu 22.04 as part of the development environment setup: [Ubuntu Dev Environment Setup > Simulation and NuttX (Pixhawk) Targets](../dev_setup/dev_env_linux_ubuntu.md#simulation-and-nuttx-pixhawk-targets)
 
+If you want to use Gazebo on Ubuntu 20.08 you can install it manually after following the normal setup process (installing `gz-garden` will uninstall Gazebo-Classic!):
+
+```sh
+sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+sudo apt-get update
+sudo apt-get install gz-garden
+```
 
 ## Running the Simulation
 

--- a/en/sim_gazebo_gz/README.md
+++ b/en/sim_gazebo_gz/README.md
@@ -18,22 +18,8 @@ See [Simulation](../simulation/README.md) for general information about simulato
 
 ## Installation (Ubuntu Linux)
 
-:::note
-These instructions were tested on Ubuntu 18.04, Ubuntu 20.04, and Ubuntu 22.04.
-The are reproduced from the official [Gazebo "Garden"](https://gazebosim.org/docs/garden/install_ubuntu) installation instructions.
-:::
+Instructions for installing on Ubuntu Linux are provided in [Ubuntu Dev Environment Setup > Gazebo](../dev_setup/dev_env_linux_ubuntu.md#gazebo).
 
-To install Gazebo:
-
-1. Install the usual [Development Environment on Ubuntu LTS / Debian Linux](../dev_setup/dev_env_linux_ubuntu.md).
-2. Install Gazebo:
-
-   ```sh
-    sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-    sudo apt-get update
-    sudo apt-get install gz-garden
-   ```
 
 ## Running the Simulation
 


### PR DESCRIPTION
@beniaminopozzan , this attempts to capture the Gazebo/ROS installation story as discussed in https://github.com/PX4/PX4-user_guide/pull/2266#issuecomment-1432293966.

1. This moves the Gazebo build instructions into the Ubuntu setup and cross links them. That way there is just one place to note how to install everything.

2. I understand from your note above that ROS desktop builds include Gazebo or Gazebo Classic. However specific builds include specific Gazebo releases, so if you want Gazebo "garden" you need to follow our instructions.
   1. I assume Gazebo "Garden" is the only "supported" version for PX4, and that's why we recommend it?
   2. What if I install Gazebo Garden on PX4 and then ROS (Foxy or Humble, say). Does this fall over - i.e. does the order of installation matter?
      - Or to put it another way, do I generally need a note when installing Gazebo/Classic about ROS.

4. Note that our instructions for the Gazebo section now state that if you're working on ROS melodic you skip the section and use the ROS script.
  - @Jaeyoung-Lim Is ROS melodic the "right" version? If there is another version we could suggest they run https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_common_deps.sh and then follow the instructions for installing ROS in the ROS docs? 
  - Note I'd rather tell them to run the ubuntu.sh with `--nosim` but that omits the simulator dependencies that are needed for PX4.
  
I'll adjust base on your responses.
   