### PR TITLE
[DRAFT] PX4 Mainatiner Role Documentation

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -806,6 +806,7 @@
     - [External Position Estimation (Vision/Motion based)](ros/external_position_estimation.md)
 - [Community](contribute/index.md)
   - [Dev Call](contribute/dev_call.md)
+  - [Maintainers](contribute/maintainers.md)
   - [Support](contribute/support.md)
   - [Source Code Management](contribute/code.md)
     - [GIT Examples](contribute/git_examples.md)

--- a/en/contribute/index.md
+++ b/en/contribute/index.md
@@ -20,6 +20,7 @@ We pledge to adhere to the [PX4 code of conduct](https://github.com/PX4/PX4-Auto
 This section contains information about how you can meet with the community and contribute to PX4:
 
 - [Dev Call](../contribute/dev_call.md) - Discuss architecture, pull requests, impacting issues with the dev team
+- [Maintainers](./maintainers.md) - Maintainers of PX4 Subsystems and Ecosystem
 - [Support](../contribute/support.md) - Get help and raise issues
 - [Source Code Management](../contribute/code.md) - Work with PX4 code
 - [Documentation](../contribute/docs.md) - Improve the docs

--- a/en/contribute/maintainers.md
+++ b/en/contribute/maintainers.md
@@ -1,0 +1,89 @@
+# Maintainer Role
+
+[PX4 maintainers](#role-description) have technical leadership and responsibility for specific areas of PX4, and for other ecosystem components such as MAVSDK, and QGroundControl.
+
+The maintainer role is defined by the community with help and supervision from the [Dronecode Foundation](https://www.dronecode.org/).
+A detailed description can be found in the [role description](#role-description) section below.
+
+To find the most up-to-date maintainers list, visit [PX4-Autopilot README](https://github.com/PX4/PX4-Autopilot#maintenance-team).
+
+## Maintainers Call
+
+The weekly maintainer's call discusses the overall health of the ecosystem and community, and open source projects.
+You can find the relevant information below:
+
+* Time: Tuesday 17h00 CET ([subscribe to calendar](https://www.dronecode.org/calendar/)).
+* Place: [Dev-Call-Maintainers channel in Discord](https://discord.gg/RjxYXFSnj3).
+* Meeting note is published week before in [Discuss Forum - PX4 Coordination](https://discuss.px4.io/c/weekly-dev-call/px4-dev-call/39).
+  Attendees are encouraged to add to the agenda as a reply before the meeting starts.
+* To nominate Issues and PRs for the call you can use the [maintainers-call](https://github.com/PX4/PX4-Autopilot/labels/maintainers-call) label to flag them
+
+## Recruitment Process
+
+If you would like to join the PX4 maintainers team:
+
+1. Read the [role description](#dronecode-maintainer-role-description), and make sure you understand the responsibilities of the role.
+2. To nominate yourself, reach out to one of the maintainers (see the complete list in the [PX4-Autopilot README](https://github.com/PX4/PX4-Autopilot#maintenance-team)), and seek their sponsorship.
+3. Express your interest in becoming a maintainer, and specify which area you would like to maintain.
+4. Your sponsoring maintainer needs to bring this up for discussion in one of the [weekly maintainers calls](#maintainers-call).
+   The maintainer team will vote on the call to accept you as a maintainer.
+
+## Onboarding Process
+
+Maintainers go through the following onboarding process:
+
+1. **Discord** server admin will grant you the `dev team` role, which gives you:
+   1. Permission to speak during maintainers call.
+   2. Access to the `#maintainers` channel.
+2. You will be given access to the GitHub team: "[`Dev Team`](https://github.com/orgs/PX4/teams/dev-team)"  which grants you:
+   1. Permission to merge the PR of any of PX4 workspace repositories after it's approved
+   2. Permission to trigger GitHub actions when a new contributor opens a PR.
+   3. Permission to edit Issue/PR contents.
+3. **Add your info to official PX4 channels**:
+   1. Include your information on the PX4 [README](https://github.com/PX4/PX4-Autopilot/blob/main/README.md) next to the rest of the team
+   2. Listed on the [Maintainers section](https://px4.io/community/maintainers/) of the PX4 website.
+   3. Add your information to the internal Dronecode database of maintainers to keep you in sync.
+   4. Community introduction to the new maintainer in the form of a forum post, which is promoted through ever growing official channels
+
+## Dronecode Maintainer Role Description
+
+### Summary
+
+Maintainers lead/manage the development of a **specific category (referred to as category below)** of any Open Source Projects hosted within the Dronecode Foundation, such as the PX4 Autopilot. 
+
+### Responsibilities
+
+1. Take charge of overseeing the development in their category.
+2. Provide guidance/advice on community members in their category.
+3. Review relevant pull requests and issues from the community on GitHub.
+4. Coordinate with the maintainer group.
+5. Keep regular attendance at the [maintainers meeting](#maintainers-call).
+6. Help create and maintain a roadmap for the project your represent.
+7. Uphold the [Code of Conduct](https://github.com/Dronecode/foundation/blob/main/CODE-OF-CONDUCT.md) of our community.
+
+### Qualifications
+
+1. Proven track record of valuable contributions.
+2. Domain expertise in the category field.
+3. Good overview of the project you are applying to.
+4. You need to manage approval from your employer when relevant.
+
+### Perks
+
+1. **Official recognition** as the maintainer in Dronecode/PX4 website, documentation, community and social media.
+2. **Github & Discord privileges** (described in the [onboarding process](#onboarding-process)).
+3. Priority placement to the yearly **PX4 Developer Summit** scholarship which helps you cover travel.
+
+### Tools we Provide to Assist You
+
+Dronecode will provide the following tools to help you:
+
+1. **Community survey**: If you need any insight into the community's opinion, we will send out social media posts, mailing lists, announcements in Discord server to get that answer for you.
+1. **Workflow automation**: We will provide workflow for PR/Issue review & tagging process to help you.
+
+And as always, don't hesitate to reach out if you need help with anything. We are here for you!
+
+### Point of Contact
+
+Regarding questions about the maintainer role, please contact the maintainer team.
+The easiest way to do this is to join a weekly [maintainers meeting](#maintainers-call).


### PR DESCRIPTION
## About
PX4 is introducing the maintainer role in the overall PX4 ecosystem. This adds initial documentation to give a structure on what it means & where users can find more information about them & recruitment link (TODO).

Note: This was discussed in the last Maintainers call: https://discuss.px4.io/t/px4-maintainers-call-february-21-2023/30919#maintainer-role-description-5

## Files Changed
- Initial documentation for the 'PX4 Maintainer' Role.
- Links need to be updated when available!