### PR TITLE
Initial Ambassadors Documentation

### DIFF
--- a/en/contribute/README.md
+++ b/en/contribute/README.md
@@ -13,6 +13,7 @@ This code aims to foster an open and welcoming environment.
 This section contains information about contributing to PX4, including the source code, documentation, and translations, and their relevant licenses.
 * [Dev Call](../contribute/dev_call.md) - Discuss architecture, pull requests, impacting issues with the dev team
 * [Codeline Management](../contribute/code.md) - Work with PX4 code
+* [Ambassadors](./ambassadors.md) - Ambassadors who help the Community in Forum / Development
 * [Documentation](../contribute/docs.md) - Improve the docs
 * [Translation](../contribute/translation.md) - Translate using Crowdin
 * [Terminology/Notation](../contribute/notation.md)

--- a/en/contribute/ambassadors.md
+++ b/en/contribute/ambassadors.md
@@ -1,0 +1,12 @@
+# PX4 Ambassadors
+
+PX4 Ambassadors are community members who help out in various aspects of PX4.
+
+## Recruitment
+
+Interested in becoming a PX4 Ambassador? Please apply through [this form](TODO)!
+
+<!-- TODO: Insert Form Link -->
+
+## Role description
+<!-- TODO: Move this to automated process under Dronecode -->


### PR DESCRIPTION
## About
To resurrect the ambassadors (previously called volunteers) program :wink: 

### Notes
The role description/individual contacting is in progress, so **this PR is blocked on that**

The description prototyping document can be found here: https://docs.google.com/document/d/11v5JVsJbzFiq3kazE_PbghPXpEB7TgIgZ7322V9VVpE/edit?usp=sharing