### PR TITLE
ROS2 Offboard control example - update to XRCE-DDS

### DIFF
--- a/en/flight_modes/offboard.md
+++ b/en/flight_modes/offboard.md
@@ -2,8 +2,8 @@
 
 [<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
 
-The vehicle obeys a position, velocity or attitude setpoint provided over MAVLink.
-The setpoint may be provided by a MAVLink API (e.g. [MAVSDK](https://mavsdk.mavlink.io/) or [MAVROS](https://github.com/mavlink/mavros)) running on a companion computer (and usually connected via serial cable or wifi).
+The vehicle obeys a position, velocity or attitude setpoint provided by some source that is external to the flight stack.
+The setpoint may be provided via MAVLink (or a MAVLink API such as [MAVSDK](https://mavsdk.mavlink.io/)) or by [ROS2](../ros/ros2.md) running on a companion computer.
 
 :::tip
 Not all coordinate frames and field values allowed by MAVLink are supported for all setpoint messages and vehicles. 

--- a/en/ros/ros2_offboard_control.md
+++ b/en/ros/ros2_offboard_control.md
@@ -22,7 +22,7 @@ To subscribe to data coming from nodes that publish in a different frame (for ex
 
 ## Trying it out
 
-Follow the instructions in [ROS 2 User Guide](..ros/ros2_comm.md) to install PX and run the simulator, install ROS2, and start the XRCE-DDS Agent.
+Follow the instructions in [ROS 2 User Guide](..ros/ros2_comm.md) to install PX4 and run the simulator, install ROS2, and start the XRCE-DDS Agent.
 After that we can follow a similar set of steps to those in [ROS 2 User Guide > Build ROS2 Workspace](..ros/ros2_comm.md#build-ros-2-workspace) to run the example.
 
 To build and run the example:

--- a/en/ros/ros2_offboard_control.md
+++ b/en/ros/ros2_offboard_control.md
@@ -64,6 +64,12 @@ To build and run the example:
 1. Launch the example.
 
    ```
+   ros2 launch px4_ros_com offboard_control_launch.yaml
+   ```
+   
+   or
+   
+   ```
    ros2 run px4_ros_com offboard_control
    ```
 

--- a/en/ros/ros2_offboard_control.md
+++ b/en/ros/ros2_offboard_control.md
@@ -1,116 +1,162 @@
 # ROS 2 Offboard Control Example
 
+The following C++ example shows how to do position control in [offboard mode](../flight_modes/offboard.md) from a ROS 2 node.
+
+The example starts sending setpoints, enters offboard mode, arms, ascends to 5 metres, and waits.
+While simple, it shows the main principles of how to use offboard control and how to send vehicle commands.
+
+It has been tested on Ubuntu 20.04 with ROS2 Foxy and PX4 `main` after PX4 v1.13.
+
 :::warning
 *Offboard* control is dangerous.
 If you are operating on a real vehicle be sure to have a way of gaining back manual control in case something goes wrong.
 :::
 
-:::warning
+:::note
 ROS and PX4 make a number of different assumptions, in particular with respect to [frame conventions](../ros/external_position_estimation.md#reference-frames-and-ros).
-For example, for the body frame PX4 uses the Forward-Right-Down (FRD) frame, while ROS uses Forward-Left-Up (FLU).
+There is no implicit conversion between frame types when topics are published or subscribed!
 
-There is no implicit conversion between frame types when topics are published or subscribed in PX4, so you will need to manage this in your own code!
+This example publishes positions in the NED frame, as expected by PX4.
+To subscribe to data coming from nodes that publish in a different frame (for example the ENU, which is the standard frame of reference in ROS/ROS 2), use the helper functions in the [frame_transforms](https://github.com/PX4/px4_ros_com/blob/main/src/lib/frame_transforms.cpp) library.
 :::
 
-The following C++ example shows how to do offboard position control from a ROS 2 node.
+## Trying it out
 
-It has been tested on Ubuntu 20.04 with ROS2 Foxy and PX4 `main` after PX4 v1.13.
+Follow the instructions in [ROS 2 User Guide](..ros/ros2_comm.md) to install PX and run the simulator, install ROS2, and start the XRCE-DDS Agent.
+After that we can follow a similar set of steps to those in [ROS 2 User Guide > Build ROS2 Workspace](..ros/ros2_comm.md#build-ros-2-workspace) to run the example.
 
-## Requirements
+To build and run the example:
 
-First set up ROS and the PX4 simulation environment as described in the [ROS 2 User Guide](..ros/ros2_comm.md).
+1. Open a new terminal.
+1. Create and navigate into a new colcon workspace directory using:
 
-The example uses the [OffboardControlMode](../msg_docs/OffboardControlMode.md), [TrajectorySetpoint](../en/msg_docs/TrajectorySetpoint.md) and [VehicleCommand](../msg_docs/VehicleCommand.md) messages.
-These are published as ROS topics by default (see [dds_topics.yaml](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/microdds_client/dds_topics.yaml)) but you will need to add the [px4_msgs](https://github.com/PX4/px4_msgs) repo to your colcon workspace `src` directory to make these available to the ROS2 node.
-The instructions below show you how.
+   ```sh
+   mkdir -p ~/ws_offboard_control/src/
+   cd ~/ws_offboard_control/src/
+   ```
+
+1. Clone the [px4_msgs](https://github.com/PX4/px4_msgs) repo to the `/src` directory (this repo is needed in every ROS2 PX4 workspace!):
+
+   ```sh
+   git clone https://github.com/PX4/px4_msgs.git
+   # checkout the matching release branch if not using PX4 main.
+   ```
+
+1. Clone the example repository [px4_ros_com](https://github.com/PX4/px4_ros_com) to the `/src` directory:
+
+   ```sh
+   git clone https://github.com/PX4/px4_ros_com.git
+   ```
+
+1. Source the ROS2 development environment ("foxy") into the current terminal and compile the workspace using `colcon`:
+
+   ```sh
+   cd ..
+   source /opt/ros/foxy/setup.bash
+   colcon build
+   ```
+
+1. Source the `local_setup.bash`:
+
+   ```sh
+   source install/local_setup.bash
+   ```
+1. Launch the example.
+
+   ```
+   ros2 run px4_ros_com offboard_control
+   ```
+
+The vehicle should arm, ascend 5 metres, and then wait (perpetually).
 
 ## Implementation
 
 The source code of the offboard control example can be found in [PX4/px4_ros_com](https://github.com/PX4/px4_ros_com) in the directory [/src/examples/offboard/offboard_control.cpp](https://github.com/PX4/px4_ros_com/blob/main/src/examples/offboard/offboard_control.cpp).
 
-Here are some details about the implementation:
+:::note
+PX4 publishes all the messages used in this example as ROS topics by default (see [dds_topics.yaml](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/microdds_client/dds_topics.yaml)).
+:::
 
-```cpp
-timesync_sub_ = this->create_subscription<px4_msgs::msg::Timesync>("/fmu/timesync/out",
-    10,
-    [this](const px4_msgs::msg::Timesync::UniquePtr msg) {
-        timestamp_.store(msg->timestamp);
-    });
-```
-
-The above is required in order to obtain a synchronized timestamp to be set and sent with the [OffboardControlMode](../msg_docs/OffboardControlMode.md) and [TrajectorySetpoint](../en/msg_docs/TrajectorySetpoint.md) messages.
+PX4 requires that the vehicle is already receiving setpoints before switching to offboard mode, and will switch out of offboard mode if the stream rate drops below approximately 2Hz.
+The required behaviour is implemented by the main loop spinning in the ROS2 node, as shown below:
 
 ```cpp
 auto timer_callback = [this]() -> void {
 
-			if (offboard_setpoint_counter_ == 10) {
-				// Change to Offboard mode after 10 setpoints
-				this->publish_vehicle_command(VehicleCommand::VEHICLE_CMD_DO_SET_MODE, 1, 6);
+	if (offboard_setpoint_counter_ == 10) {
+		// Change to Offboard mode after 10 setpoints
+		this->publish_vehicle_command(VehicleCommand::VEHICLE_CMD_DO_SET_MODE, 1, 6);
 
-				// Arm the vehicle
-				this->arm();
-			}
-
-            		// offboard_control_mode needs to be paired with trajectory_setpoint
-			publish_offboard_control_mode();
-			publish_trajectory_setpoint();
-
-           		 // stop the counter after reaching 11
-			if (offboard_setpoint_counter_ < 11) {
-				offboard_setpoint_counter_++;
-			}
-		};
-		timer_ = this->create_wall_timer(100ms, timer_callback);
+		// Arm the vehicle
+		this->arm();
 	}
+
+	// OffboardControlMode needs to be paired with TrajectorySetpoint
+	publish_offboard_control_mode();
+	publish_trajectory_setpoint();
+
+	// stop the counter after reaching 11
+	if (offboard_setpoint_counter_ < 11) {
+		offboard_setpoint_counter_++;
+	}
+};
+timer_ = this->create_wall_timer(100ms, timer_callback);
 ```
 
-The above is the main loop spinning on the ROS 2 node.
-It first sends 10 setpoint messages before sending the command to allow PX4 to change to offboard mode.
-At the same time, both `OffboardControlMode` and `TrajectorySetpoint` messages are sent to the flight controller.
+The loop runs on a 100ms timer.
+For the first 10 cycles it calls `publish_offboard_control_mode()` and `publish_trajectory_setpoint()` to send [OffboardControlMode](../msg_docs/OffboardControlMode.md) and [TrajectorySetpoint](../en/msg_docs/TrajectorySetpoint.md) messages to PX4.
+These messages are required in order for PX4 to switch to offboard mode, even though they are "ignored" because the vehicle is not in offboard mode.
+
+After 10 cycles `publish_vehicle_command()` is called to change to offboard mode, and `arm()` is called to arm the vehicle.
+After the vehicle arms and changes mode it starts tracking the position setpoints.
+The setpoints are still sent in every cycle so that the vehicle does not fall out of offboard mode.
+
+The implementations of the `publish_offboard_control_mode()` and `publish_trajectory_setpoint()` methods are shown below.
+These publish the [OffboardControlMode](../msg_docs/OffboardControlMode.md) and [TrajectorySetpoint](../en/msg_docs/TrajectorySetpoint.md) messages to PX4 (respectively).
+
+The `OffboardControlMode` is required in order to inform PX4 of the _type_ of offboard control behing used.
+Here we're only using _position control_, so the `position` field is set to `true` and all the other fields are set to `false`.
 
 ```cpp
 /**
  * @brief Publish the offboard control mode.
  *        For this example, only position and altitude controls are active.
  */
-void OffboardControl::publish_offboard_control_mode() const {
+void OffboardControl::publish_offboard_control_mode()
+{
 	OffboardControlMode msg{};
-	msg.timestamp = timestamp_.load();
 	msg.position = true;
 	msg.velocity = false;
 	msg.acceleration = false;
 	msg.attitude = false;
 	msg.body_rate = false;
-
+	msg.timestamp = this->get_clock()->now().nanoseconds() / 1000;
 	offboard_control_mode_publisher_->publish(msg);
 }
+```
 
+`TrajectorySetpoint` provides the position setpoint.
+In this case, the `x`, `y`, `z` and `yaw` fields are hardcoded to certain values, but they can be updated dynamically according to an algorithm or even by a subscription callback for messages coming from another node.
 
+```cpp
 /**
  * @brief Publish a trajectory setpoint
  *        For this example, it sends a trajectory setpoint to make the
  *        vehicle hover at 5 meters with a yaw angle of 180 degrees.
  */
-void OffboardControl::publish_trajectory_setpoint() const {
+void OffboardControl::publish_trajectory_setpoint()
+{
 	TrajectorySetpoint msg{};
-	msg.timestamp = timestamp_.load();
-	msg.x = 0.0;
-	msg.y = 0.0;
-	msg.z = -5.0;
+	msg.position = {0.0, 0.0, -5.0};
 	msg.yaw = -3.14; // [-PI:PI]
-
+	msg.timestamp = this->get_clock()->now().nanoseconds() / 1000;
 	trajectory_setpoint_publisher_->publish(msg);
 }
 ```
 
-The above functions show how the fields on both `OffboardControlMode` and `TrajectorySetpoint` messages can be set.
-Notice that the above example is applicable for offboard position control, where on the `OffboardControlMode` message, the `position` field is set to `true`, while all the others get set to `false`.
-Also, in this case, the `x`, `y`, `z` and `yaw` fields are hardcoded to certain values, but they can be updated dynamically according to an algorithm or even by a subscription callback for messages coming from another node.
-
-:::tip
-The position is published in the NED coordinate frame for simplicity.
-If a user wants to subscribe to data coming from nodes that publish in a different frame (for example the ENU, which is the standard frame of reference in ROS/ROS 2), they can use the helper functions in the [frame_transforms](https://github.com/PX4/px4_ros_com/blob/main/src/lib/frame_transforms.cpp) library.
-:::
+The `publish_vehicle_command()` sends [VehicleCommand](../msg_docs/VehicleCommand.md) messages with commands to the flight controller.
+We use it above to change the mode to offboard mode, and also in `arm()` to arm the vehicle.
+While we don't call `disarm()` in this example, it is also used in the implementation of that function.
 
 ```cpp
 /**
@@ -119,10 +165,9 @@ If a user wants to subscribe to data coming from nodes that publish in a differe
  * @param param1    Command parameter 1
  * @param param2    Command parameter 2
  */
-void OffboardControl::publish_vehicle_command(uint16_t command, float param1,
-					      float param2) const {
+void OffboardControl::publish_vehicle_command(uint16_t command, float param1, float param2)
+{
 	VehicleCommand msg{};
-	msg.timestamp = timestamp_.load();
 	msg.param1 = param1;
 	msg.param2 = param2;
 	msg.command = command;
@@ -131,22 +176,19 @@ void OffboardControl::publish_vehicle_command(uint16_t command, float param1,
 	msg.source_system = 1;
 	msg.source_component = 1;
 	msg.from_external = true;
-
+	msg.timestamp = this->get_clock()->now().nanoseconds() / 1000;
 	vehicle_command_publisher_->publish(msg);
 }
 ```
 
-As the description suggests, the above code serves the purpose of sending [VehicleCommand](../msg_docs/VehicleCommand.md) messages with commands to the flight controller.
+:::note
+[VehicleCommand](../msg_docs/VehicleCommand.md) is one of the simplest and most powerful ways to command PX4, and by subscribing to [VehicleCommandAck](../msg_docs/VehicleCommandAck.md) you can also confirm that setting a particular command was successful.
+The param and command fields map to [MAVLink commands](https://mavlink.io/en/messages/common.html#mav_commands) and their parameter values.
+:::
 
-## Usage
-
-After building the colcon workspace, and after starting PX4 SITL (`make px4_sitl_rtps gazebo-classic`, which starts the microRTPS client automatically on UDP ports 2019 and 2020) and the microRTPS agent (`micrortps_agent -t UDP`, starting the agent connected to UDP ports 2020 and 2019):
-
-```sh
-$ source path_to_colcon_workspace/install/setup.bash
-$ ros2 run px4_ros_com offboard_control
-```
+<!--
 
 ## Demo with PX4 SITL and Gazebo Classic
 
 @[youtube](https://youtu.be/Nbc7fzxFlYo)
+-->

--- a/en/ros/ros2_offboard_control.md
+++ b/en/ros/ros2_offboard_control.md
@@ -74,7 +74,7 @@ The vehicle should arm, ascend 5 metres, and then wait (perpetually).
 The source code of the offboard control example can be found in [PX4/px4_ros_com](https://github.com/PX4/px4_ros_com) in the directory [/src/examples/offboard/offboard_control.cpp](https://github.com/PX4/px4_ros_com/blob/main/src/examples/offboard/offboard_control.cpp).
 
 :::note
-PX4 publishes all the messages used in this example as ROS topics by default (see [dds_topics.yaml](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/microdds_client/dds_topics.yaml)).
+PX4 publishes and subscribes all the messages used in this example as ROS topics by default (see [dds_topics.yaml](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/microdds_client/dds_topics.yaml)).
 :::
 
 PX4 requires that the vehicle is already receiving setpoints before switching to offboard mode, and will switch out of offboard mode if the stream rate drops below approximately 2Hz.


### PR DESCRIPTION
This updates the ROS2 offboard example docs to to XRCE-DDS.

This essentially just worked "out of the box" when run using the instructions in the ROS2 User Guide for setup. The only difference is that this uses `ros2 run` rather than `ros2 launch`. No launch file I guess.
Most of my confusion was why we had a disarm() command and no implementation.

This example could do with some love. Specifically, it would be nice to monitor for the command ack, and to actually land the vehicle. But anyhow ....

IN terms of structure and explanation this is much simpler. Some of the detail is already in the ROS2 user guide so did not have to be here. Some comments inline.