### PR TITLE
PX4 Release procedure

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -681,5 +681,6 @@
   * [Terminology/Notation](contribute/notation.md)
   * [Licenses](contribute/licenses.md)
 * [Releases](releases/README.md)
+  * [PX4 Core Components](releases/core_components.md)
   * [1.13](releases/1.13.md)
   * [1.12](releases/1.12.md)

--- a/en/releases/README.md
+++ b/en/releases/README.md
@@ -1,8 +1,115 @@
 # Releases
 
-A list of PX4 release notes, they contain a list of the changes that went into each release, explaining the included features, bug fixes, deprecations and updates in detail.
+## Release Notes
+
+List of the changes that went into each release, explaining the included features, bug fixes, deprecations and updates in detail.
 
 * [v1.13](../releases/1.13.md)
 * [v1.12](../releases/1.12.md)
 
 The full archive of releases for the PX4 autopilot project can be found on [GitHub](https://github.com/PX4/PX4-Autopilot/releases)
+
+## Release Versioning
+
+PX4 uses a Semantic versioning (`Major.minor.patch[-beta#]`) system ([Wikipedia article](https://en.wikipedia.org/wiki/Software_versioning)).
+
+- Change in `Major`: Breaking changes
+- Change in `minor`: New non-breaking changes
+- Change in `patch`: All other non-breaking changes
+
+## Release Schedule
+
+PX4 follows the following release schedule:
+
+<!-- TO BE DEFINED -->
+
+- `Major` releases: By consensus among Maintainers & Community
+- `minor` releases: Roughly every 6 months
+- `patch` releases: When critical bug-fix / hardware support is needed
+- `beta` releases: Every 1 week during beta testing phase
+
+### Past Major/Minor releases
+
+There has been roughly 14 minor release in the past, with roughly 6 months ~ 1 year between new minor version releases. And there hasn't been any new major version releases yet.
+
+- [v1.13.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.13.0): June 22nd, 2022
+- [v1.12.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.12.0): July 11th, 2021
+- [v1.11.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.11.0): September 7th, 2020
+- [v1.10.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.10.0): December 17th, 2019
+- [v1.9.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.9.0): May 25, 2019
+- [v1.8.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.8.0): June 19th, 2018
+- [v1.7.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.7.0): December 15th, 2017
+- [v1.6.2](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.6.2): June 7th, 2017
+- [v1.5.1](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.5.1): December 7th, 2016
+- [v1.4.1](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.4.1): August 6th, 2016
+- [v1.3.1](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.3.1): May 22nd, 2016
+- [v1.2.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.2.0): February 21st, 2016
+- [v1.1.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.1.0): December 24th, 2015
+- [v1.0.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.0.0): August 23rd, 2015
+
+## Release Procedure
+
+### Point release (Major/Minor change)
+
+Point releases are the ones where the major/minor version tag changes. It comes with major new features, hardware supports as well as refactors.
+
+#### Initial branch out deadline
+
+For the initial beta release of a new major/minor change, a "branch out deadline" gets set during the Maintainers Call.
+
+The procedure is:
+
+1. Agreement on branch out deadline: By consensus during Maintainers call
+2. Publication in social media & mailing list about the branch out deadline: By [Ramon](https://github.com/mrpollo)
+3. Project board with the name for the new release gets created: By [Daniel](https://github.com/dagar)
+   1. The board must include a `patch version` field (selectable)
+4. Until the branch out date
+   1. All the PR/Issues that a contributor wants to finish before the deadline gets added to the Project Board: By Maintainers & during Maintainers call
+   2. All the release blocking Issues / PRs gets added to the Project Board by each Maintainer
+
+On the branch out date, the `release/Major.minor` branch gets branched out and a `Major.minor.0-beta1` gets released for testing.
+
+#### Beta testing
+
+Before the new major/minor release, the beta version gets released for a testing phase. During the beta testing phase following changes are **allowed**:
+
+- Critical bug fixes
+- New hardware supports
+
+And following changes are **not allowed**:
+
+- Big new features
+- Refactors (with no functional changes)
+
+During the beta testing, the procedure is:
+
+1. During the Maintainers call
+   1. Remaining issues for the next beta release gets discussed, and maintains make an effort to resolve all issues before the next beta release
+   2. Discussion on certain PRs that may be worth to be included in the next beta gets discussed, and gets added to Project Board appropriately
+2. Test reports from users get collected as a Github Issue / Discord message / Flight Review log / Discuss forum post
+   1. If it is valid issue, the maintainer in charge of the sector creates / adds an Issue to keep track of it in the Project tracker and assign the next beta version to it's `patch version` field.
+
+#### Maintainers Agreement before the release
+
+After numerous beta testings & before the official new major/minor release, PX4 Maintainers need to reach a consensus that the new version is release-able from each of their perspectives. This means (for each maintainer):
+
+- The [core functionalities](core_components.md) they maintain has been tested, and has no major issues are found
+- All the outstanding issues/PRs with `patch version` as the last beta version are resolved
+
+#### Point release execution
+
+After the consensus from the Maintainers, the point release gets made:
+
+1. The `patch version` of the last beta release (e.g. `M.m.0-beta9`) gets renamed to include the release name (e.g. `M.m.0/M.m.0-beta9`)
+2. New tag for the last beta release commit gets tagged (as `M.m.0`) by [Daniel](https://github.com/dagar)
+3. Release notes are prepared in Github side collaboratively by Maintainers
+4. Public new point release announcement gets made via Social media / Mailing list by [Ramon](https://github.com/mrpollo)
+
+### Patch release
+
+Patch releases are the ones where we apply a patch (e.g. bugfix, hardware support) to a previous point release without big feature changes. Often, we need a quick patch release after the point release, as the number of testing increases significantly & new errors get found.
+
+Only the following **allowed** changes will be accepted for patch releases:
+
+- Critical bug fixes
+- New hardware support

--- a/en/releases/README.md
+++ b/en/releases/README.md
@@ -2,7 +2,7 @@
 
 ## Release Notes
 
-List of the changes that went into each release, explaining the included features, bug fixes, deprecations and updates in detail.
+The release notes archive for each release contains a detailed list of included features, bug fixes, deprecations, and updates.
 
 * [v1.13](../releases/1.13.md)
 * [v1.12](../releases/1.12.md)
@@ -23,8 +23,7 @@ PX4 follows the following release schedule:
 
 <!-- TO BE DEFINED -->
 
-- `Major` releases: By consensus among Maintainers & Community
-- `minor` releases: Roughly every 6 months
+- `Major` or `minor` releases: Roughly every 6 months
 - `patch` releases: When critical bug-fix / hardware support is needed
 - `beta` releases: Every 1 week during beta testing phase
 
@@ -32,28 +31,16 @@ PX4 follows the following release schedule:
 
 There has been roughly 14 minor release in the past, with roughly 6 months ~ 1 year between new minor version releases. And there hasn't been any new major version releases yet.
 
-- [v1.13.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.13.0): June 22nd, 2022
-- [v1.12.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.12.0): July 11th, 2021
-- [v1.11.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.11.0): September 7th, 2020
-- [v1.10.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.10.0): December 17th, 2019
-- [v1.9.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.9.0): May 25, 2019
-- [v1.8.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.8.0): June 19th, 2018
-- [v1.7.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.7.0): December 15th, 2017
-- [v1.6.2](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.6.2): June 7th, 2017
-- [v1.5.1](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.5.1): December 7th, 2016
-- [v1.4.1](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.4.1): August 6th, 2016
-- [v1.3.1](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.3.1): May 22nd, 2016
-- [v1.2.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.2.0): February 21st, 2016
-- [v1.1.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.1.0): December 24th, 2015
-- [v1.0.0](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.0.0): August 23rd, 2015
-
 ## Release Procedure
 
 ### Point release (Major/Minor change)
 
-Point releases are the ones where the major/minor version tag changes. It comes with major new features, hardware supports as well as refactors.
+Point releases are the ones where the major/minor version tag changes.
+They come with major new features, new hardware support, and general improvements.
 
-#### Initial branch out deadline
+#### Initial Branch-out
+
+Branch-out means when the `release/Major.minor` branch gets created off of the `main` branch of PX4-Autopilot.
 
 For the initial beta release of a new major/minor change, a "branch out deadline" gets set during the Maintainers Call.
 
@@ -83,26 +70,28 @@ And following changes are **not allowed**:
 
 During the beta testing, the procedure is:
 
-1. During the Maintainers call
+1. During the maintainers call
    1. Remaining issues for the next beta release gets discussed, and maintains make an effort to resolve all issues before the next beta release
    2. Discussion on certain PRs that may be worth to be included in the next beta gets discussed, and gets added to Project Board appropriately
 2. Test reports from users get collected as a Github Issue / Discord message / Flight Review log / Discuss forum post
-   1. If it is valid issue, the maintainer in charge of the sector creates / adds an Issue to keep track of it in the Project tracker and assign the next beta version to it's `patch version` field.
+   1. User-reported issues will be discussed by the maintainer team, and the maintainer in charge of the sector creates / adds an Issue to keep track of it in the Project tracker and assign the next beta version to it's `patch version` field.
 
 #### Maintainers Agreement before the release
 
-After numerous beta testings & before the official new major/minor release, PX4 Maintainers need to reach a consensus that the new version is release-able from each of their perspectives. This means (for each maintainer):
+Once the release branch reaches a mature state with reliable firmware builds and no major issues are reported, the maintainer team votes to promote the branch to a stable release.
 
-- The [core functionalities](core_components.md) they maintain has been tested, and has no major issues are found
+##### What should maintainers look for when making a decision?
+
+- The [core functionality](core_components.md) that they maintain has been tested, and has no major issues
 - All the outstanding issues/PRs with `patch version` as the last beta version are resolved
 
 #### Point release execution
 
-After the consensus from the Maintainers, the point release gets made:
+After the consensus from the maintainers, the point release gets made:
 
 1. The `patch version` of the last beta release (e.g. `M.m.0-beta9`) gets renamed to include the release name (e.g. `M.m.0/M.m.0-beta9`)
 2. New tag for the last beta release commit gets tagged (as `M.m.0`) by [Daniel](https://github.com/dagar)
-3. Release notes are prepared in Github side collaboratively by Maintainers
+3. Release notes are prepared in Github side collaboratively by maintainers
 4. Public new point release announcement gets made via Social media / Mailing list by [Ramon](https://github.com/mrpollo)
 
 ### Patch release

--- a/en/releases/README.md
+++ b/en/releases/README.md
@@ -13,6 +13,10 @@ The full archive of releases for the PX4 autopilot project can be found on [GitH
 
 PX4 uses a Semantic versioning (`Major.minor.patch[-beta#]`) system ([Wikipedia article](https://en.wikipedia.org/wiki/Software_versioning)).
 
+:::note
+Semantic versioning will be adopted starting from `v2.0.0` (after `v1.14.x`). The releases before that didn't follow the strict Semantic versioning process.
+:::
+
 - Change in `Major`: Breaking changes
 - Change in `minor`: New non-breaking changes
 - Change in `patch`: All other non-breaking changes
@@ -21,11 +25,13 @@ PX4 uses a Semantic versioning (`Major.minor.patch[-beta#]`) system ([Wikipedia 
 
 PX4 follows the following release schedule:
 
-<!-- TO BE DEFINED -->
-
 - `Major` or `minor` releases: Roughly every 6 months
 - `patch` releases: When critical bug-fix / hardware support is needed
 - `beta` releases: Every 1 week during beta testing phase
+
+## Stakeholders
+
+The whole process depends on the contribution of the Maintainers. However, for the release process specifically, a 'Release manager' (referred below as well) will be the person in charge of overseeing the overall process.
 
 ### Past Major/Minor releases
 
@@ -38,6 +44,12 @@ There has been roughly 14 minor release in the past, with roughly 6 months ~ 1 y
 Point releases are the ones where the major/minor version tag changes.
 They come with major new features, new hardware support, and general improvements.
 
+#### Major or minor change?
+
+The decision on whether the upcoming release will involve a change in major version, or just a minor will be discussed during the weekly Maintainers meeting.
+
+If the general consensus agrees that the change for the upcoming release is big enough, the major version will be updated. Otherwise, only the minor version will be updated.
+
 #### Initial Branch-out
 
 Branch-out means when the `release/Major.minor` branch gets created off of the `main` branch of PX4-Autopilot.
@@ -47,8 +59,8 @@ For the initial beta release of a new major/minor change, a "branch out deadline
 The procedure is:
 
 1. Agreement on branch out deadline: By consensus during Maintainers call
-2. Publication in social media & mailing list about the branch out deadline: By [Ramon](https://github.com/mrpollo)
-3. Project board with the name for the new release gets created: By [Daniel](https://github.com/dagar)
+2. Publication in social media & mailing list about the branch out deadline:
+3. Project board with the name for the new release gets created:
    1. The board must include a `patch version` field (selectable)
 4. Until the branch out date
    1. All the PR/Issues that a contributor wants to finish before the deadline gets added to the Project Board: By Maintainers & during Maintainers call
@@ -61,7 +73,7 @@ On the branch out date, the `release/Major.minor` branch gets branched out and a
 Before the new major/minor release, the beta version gets released for a testing phase. During the beta testing phase following changes are **allowed**:
 
 - Critical bug fixes
-- New hardware supports
+- New hardware support
 
 And following changes are **not allowed**:
 
@@ -90,9 +102,9 @@ Once the release branch reaches a mature state with reliable firmware builds and
 After the consensus from the maintainers, the point release gets made:
 
 1. The `patch version` of the last beta release (e.g. `M.m.0-beta9`) gets renamed to include the release name (e.g. `M.m.0/M.m.0-beta9`)
-2. New tag for the last beta release commit gets tagged (as `M.m.0`) by [Daniel](https://github.com/dagar)
+2. New tag for the last beta release commit gets tagged (as `M.m.0`) by the 'Release manager'
 3. Release notes are prepared in Github side collaboratively by maintainers
-4. Public new point release announcement gets made via Social media / Mailing list by [Ramon](https://github.com/mrpollo)
+4. Public new point release announcement gets made via Social media / Mailing list by the 'Release manager'
 
 ### Patch release
 

--- a/en/releases/core_components.md
+++ b/en/releases/core_components.md
@@ -47,6 +47,7 @@ Each core component must have:
 ### Vehicle types
 
 | Core component | Sub component | Maintainer | Tester |
+|---|---|---|---|
 | Multirotor | Acro mode |  |  |
 |  | Stabilized mode |  |  |
 |  |  |  |  |

--- a/en/releases/core_components.md
+++ b/en/releases/core_components.md
@@ -45,6 +45,7 @@ Each core component must have:
 | MAVLink | | | |
 
 ### Vehicle types
+
 | Core component | Sub component | Maintainer | Tester |
 | Multirotor | Acro mode |  |  |
 |  | Stabilized mode |  |  |

--- a/en/releases/core_components.md
+++ b/en/releases/core_components.md
@@ -24,6 +24,7 @@ Each core component must have:
 | IMU (Driver) |  |  |  |
 | Distance Sensor (Driver) |  |  |  |
 | Failure Injection (Driver) |  |  |  |
+| RTK GPS (Driver) | Heading estimate from dual RTK GPS | [Alex Klimaj](https://github.com/AlexKlimaj) |  |
 | Documentation |  |  |  |
 | Battery (Library) |  |  |  |
 | Flight Task (Library) |  |  |  |
@@ -52,6 +53,12 @@ Each core component must have:
 |  | Stabilized mode |  |  |
 |  |  |  |  |
 | Fixed wing |  |  |  |
-| VTOL |  |  |  |
+| Hybrid VTOL |  |  |  |
+|  | Altitude mode in hover |  |  |
+|  | Position mode in hover |  |  |
+|  | Auto mode in hover |  |  |
+|  | Quad-chute |  |  |
+|  | Pull/Tilter assist for forward acceleration in hover |  |  |
+|  | Weather vane (automatically aligning vehicle heading into wind) |  |  |
 | Boat |  |  |  |
 | Rover |  |  |  |

--- a/en/releases/core_components.md
+++ b/en/releases/core_components.md
@@ -1,0 +1,55 @@
+# PX4 Core Components
+
+These core components are *guaranteed* to work with a stable point release of PX4. They form the foundation of the PX4-Autopilot and it's core functionality.
+
+## Core component criteria
+
+Each core component must have:
+- Maintainer
+- Tester
+
+## PX4 Core Components List
+
+| Core component (category) | Sub component | Maintainer | Tester |
+|---|---|---|---|
+| uORB (Architecture) |  |  |  |
+| Parameters (Architecture) |  |  |  |
+| Realtime Clock (Architecture) |  |  |  |
+| Work queue (Architecture) |  |  |  |
+| GNSS (State Estimation) | Velocity / Position |  |  |
+|  | Heading |  |  |
+| Optical flow (State Estimation) |  |  |  |
+| External vision (State Estimation) |  |  |  |
+| Boards (NuttX) | Pixhawk standard |  |  |
+| IMU (Driver) |  |  |  |
+| Distance Sensor (Driver) |  |  |  |
+| Failure Injection (Driver) |  |  |  |
+| Documentation |  |  |  |
+| Battery (Library) |  |  |  |
+| Flight Task (Library) |  |  |  |
+| Matrix (Library) |  |  |  |
+| Autotuning (Library) |  |  |  |
+| Github Actions (CI Infrastructure) |  |  |  |
+| Jenkins (CI Infrastructure) |  |  |  |
+| Linux (Toolchain) |  |  |  |
+| Mac OS (Toolchain) |  |  |  |
+| Windows (Toolchain) | WSL2 |  |  |
+| ROS2 |  |  |  |
+| Gazebo Classic (Simulation) |  |  |  |
+| Gazebo (Simulation) |  |  |  |
+| Flightgear (Simulation) |  |  |  |
+| JSBSim (Simulation) |  |  |  |
+| jMAVSim (Simulation) |  |  |  |
+| SIH (Simulation) |  |  |  |
+| Multivehicle Simulation |  |  |  |
+| MAVLink | | | |
+
+### Vehicle types
+| Core component | Sub component | Maintainer | Tester |
+| Multirotor | Acro mode |  |  |
+|  | Stabilized mode |  |  |
+|  |  |  |  |
+| Fixed wing |  |  |  |
+| VTOL |  |  |  |
+| Boat |  |  |  |
+| Rover |  |  |  |

--- a/en/releases/core_components.md
+++ b/en/releases/core_components.md
@@ -1,6 +1,6 @@
 # PX4 Core Components
 
-These core components are *guaranteed* to work with a stable point release of PX4. They form the foundation of the PX4-Autopilot and it's core functionality.
+These core components define the core functionality of PX4-Autopilot. Thus whether they are functioning correctly is being constantly monitored by the Maintainers, as well as in Continuous Integration tests. These components are the first priority that should work in a stable point releases.
 
 ## Core component criteria
 
@@ -10,55 +10,57 @@ Each core component must have:
 
 ## PX4 Core Components List
 
-| Core component (category) | Sub component | Maintainer | Tester |
-|---|---|---|---|
-| uORB (Architecture) |  |  |  |
-| Parameters (Architecture) |  |  |  |
-| Realtime Clock (Architecture) |  |  |  |
-| Work queue (Architecture) |  |  |  |
+For many of the core components that has a corresponding label in Github, you can click on them to view the relevant Issue/PRs.
+
+| Core component (category) | Sub component | Maintainer |
+|---|---|---|
+| [uORB (Architecture)](https://github.com/PX4/PX4-Autopilot/issues?q=label%3AUorb+) |  |  |
+| [Parameter (Architecture)](https://github.com/PX4/PX4-Autopilot/issues?q=label%3AParameter+) |  |  |
+| Realtime Clock (Architecture) |  |  |
+| Work queue (Architecture) |  |  |
 | GNSS (State Estimation) | Velocity / Position |  |  |
-|  | Heading |  |  |
-| Optical flow (State Estimation) |  |  |  |
-| External vision (State Estimation) |  |  |  |
-| Boards (NuttX) | Pixhawk standard |  |  |
-| IMU (Driver) |  |  |  |
-| Distance Sensor (Driver) |  |  |  |
-| Failure Injection (Driver) |  |  |  |
+|  | Heading |  |
+| [Optical flow (State Estimation)](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22Optical+flow+%F0%9F%91%81%EF%B8%8F%E2%80%8D%F0%9F%97%A8%EF%B8%8F%22) |  |  |
+| [Vision](https://github.com/PX4/PX4-Autopilot/issues?q=label%3Avision) (State Estimation) |  |  |
+| [Boards (NuttX)](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22Boards+%28flight+controller%29+%F0%9F%8D%AB%22+) | [Pixhawk standard](https://github.com/PX4/PX4-Autopilot/issues?q=label%3Apixhawk) |  |
+| IMU (Driver) |  |  |
+| Distance Sensor (Driver) |  |  |
+| Failure Injection (?) |  |  |
 | RTK GPS (Driver) | Heading estimate from dual RTK GPS | [Alex Klimaj](https://github.com/AlexKlimaj) |  |
-| Documentation |  |  |  |
-| Battery (Library) |  |  |  |
-| Flight Task (Library) |  |  |  |
-| Matrix (Library) |  |  |  |
-| Autotuning (Library) |  |  |  |
-| Github Actions (CI Infrastructure) |  |  |  |
-| Jenkins (CI Infrastructure) |  |  |  |
-| Linux (Toolchain) |  |  |  |
-| Mac OS (Toolchain) |  |  |  |
-| Windows (Toolchain) | WSL2 |  |  |
-| ROS2 |  |  |  |
-| Gazebo Classic (Simulation) |  |  |  |
-| Gazebo (Simulation) |  |  |  |
-| Flightgear (Simulation) |  |  |  |
-| JSBSim (Simulation) |  |  |  |
-| jMAVSim (Simulation) |  |  |  |
-| SIH (Simulation) |  |  |  |
-| Multivehicle Simulation |  |  |  |
-| MAVLink | | | |
+| [Documentation](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22Documentation+%F0%9F%93%91%22) |  |  |
+| Battery (Library) |  |  |
+| Flight Task (Library) |  |  |
+| Matrix (Library) |  |  |
+| Autotuning (Library) |  |  |
+| [Github Actions (Continuous Integration)](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22CI+%F0%9F%A4%96%22) |  |  |
+| [Jenkins (Continuous Integration)](https://github.com/PX4/PX4-Autopilot/issues?q=label%3Ajenkins-ci) |  |  |
+| Linux (Toolchain) |  |  |
+| Mac OS (Toolchain) |  |  |
+| [Windows (Toolchain)](https://github.com/PX4/PX4-Autopilot/issues?q=label%3Awindows) | WSL2 |  |  |
+| [ROS2](https://github.com/PX4/PX4-Autopilot/issues?q=label%3AROS2) |  |  |
+| [Gazebo Classic (Simulation)](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22gazebo+classic%22) |  |  |
+| [Gazebo (Simulation)](https://github.com/PX4/PX4-Autopilot/issues?q=label%3Agazebo) |  |  |
+| Flightgear (Simulation) |  |  |
+| JSBSim (Simulation) |  |  |
+| jMAVSim (Simulation) |  |  |
+| SIH (Simulation) |  |  |
+| Multivehicle Simulation |  |  |
+| [MAVLink (Communication)](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22Communication+%28MAVLink%29+%F0%9F%93%A1%22) | | |
 
 ### Vehicle types
 
-| Core component | Sub component | Maintainer | Tester |
-|---|---|---|---|
-| Multirotor | Acro mode |  |  |
-|  | Stabilized mode |  |  |
-|  |  |  |  |
-| Fixed wing |  |  |  |
-| Hybrid VTOL |  |  |  |
-|  | Altitude mode in hover |  |  |
-|  | Position mode in hover |  |  |
-|  | Auto mode in hover |  |  |
-|  | Quad-chute |  |  |
-|  | Pull/Tilter assist for forward acceleration in hover |  |  |
-|  | Weather vane (automatically aligning vehicle heading into wind) |  |  |
-| Boat |  |  |  |
-| Rover |  |  |  |
+| Core component | Sub component | Maintainer |
+|---|---|---|
+| [Multirotor](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22Multirotor+%F0%9F%9B%B8%22) | Acro mode |  |
+|  | Stabilized mode |  |
+|  |  |
+| [Fixed wing](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22Fixed+Wing+%F0%9F%9B%A9%EF%B8%8F%22) |  |
+| [Hybrid VTOL](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22Hybrid+VTOL+%F0%9F%9B%A9%EF%B8%8F%F0%9F%9A%81%22) |  |
+|  | Altitude mode in hover |
+|  | Position mode in hover |
+|  | Auto mode in hover |  |
+|  | Quad-chute |  |
+|  | Pull/Tilter assist for forward acceleration in hover |  |
+|  | Weather vane (automatically aligning vehicle heading into wind) |  |
+| [Boat](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22Boat+%F0%9F%9A%A4%22) |  |  |
+| [Rover](https://github.com/PX4/PX4-Autopilot/issues?q=label%3A%22Rover+%F0%9F%9A%99%22) |  |  |


### PR DESCRIPTION
## About
This adds the initial PX4 Release procedure documentation, as discussed in today's [Maintainers Call](https://discuss.px4.io/t/px4-maintainers-call-march-07-2023/31059#release-coordination-5).

PX4 didn't have a set and stone release cycle management, and this is a first step towards having that & more structure.

## Note to maintainers
Please review this carefully & provide your feedback on how our release procedure should be. Your review matters!