### PR TITLE
Update dev call (community QnA) description & specify CET as central timezone in calender

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -114,7 +114,7 @@ Select the links below to display the calendar in your timezone (and to add it t
 * [Australia – Melbourne/Sydney/Hobart](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_g21tvam24m7pm7jhev01bvlqh8%40group.calendar.google.com&ctz=Australia%2FSydney)
 
 :::tip 
-Calendar defaults to CET.
+Calendar shown defaults to CET, as CET is the standard timezone used for defining the meeting times (Since different timezones have different daylight saving policies, we chose CET as singular source of truth)
 :::
 
 <iframe src="https://calendar.google.com/calendar/embed?title=Dronecode%20Calendar&amp;mode=WEEK&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=linuxfoundation.org_g21tvam24m7pm7jhev01bvlqh8%40group.calendar.google.com&amp;color=%23691426&amp;ctz=Europe%2FZurich" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/en/README.md
+++ b/en/README.md
@@ -114,7 +114,8 @@ Select the links below to display the calendar in your timezone (and to add it t
 * [Australia – Melbourne/Sydney/Hobart](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_g21tvam24m7pm7jhev01bvlqh8%40group.calendar.google.com&ctz=Australia%2FSydney)
 
 :::tip 
-Calendar shown defaults to CET, as CET is the standard timezone used for defining the meeting times (Since different timezones have different daylight saving policies, we chose CET as singular source of truth)
+The calendar default timezone is Central European Time (CET).
+
 :::
 
 <iframe src="https://calendar.google.com/calendar/embed?title=Dronecode%20Calendar&amp;mode=WEEK&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=linuxfoundation.org_g21tvam24m7pm7jhev01bvlqh8%40group.calendar.google.com&amp;color=%23691426&amp;ctz=Europe%2FZurich" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/en/contribute/dev_call.md
+++ b/en/contribute/dev_call.md
@@ -23,7 +23,7 @@ This is a great opportunity to meet the team and contribute to the ongoing devel
 
 ## What gets discussed?
 
-The meeting note gets published week before the call on [PX4 Discuss - weekly-dev-call](https://discuss.px4.io/c/weekly-dev-call).
+We publish a forum post per meeting a week before the call on [PX4 Discuss - weekly-dev-call](https://discuss.px4.io/c/weekly-dev-call) and track the agenda write down the discussion for the day.
 
 We welcome any topics that you, as a community member may have questions about / want to discuss!
 

--- a/en/contribute/dev_call.md
+++ b/en/contribute/dev_call.md
@@ -40,7 +40,7 @@ The core team/subsystem maintainers will be available for up to 45 additional mi
 
 
 ## Schedule
-* TIME: Wednesday 17h00 CET, 11h00 EST, 08h00 PST ([subscribe to calendar](https://www.dronecode.org/calendar/))
+* TIME: Wednesday 17h00 CET ([subscribe to calendar](https://www.dronecode.org/calendar/))
 * **Join the call**: [https://meet.jit.si/PX4DeveloperCallWeekly](https://meet.jit.si/PX4DeveloperCallWeekly)
 
 * Agenda is published before the call on [PX4 Discuss - weekly-dev-call](https://discuss.px4.io//c/weekly-dev-call)

--- a/en/contribute/dev_call.md
+++ b/en/contribute/dev_call.md
@@ -1,13 +1,11 @@
-# Weekly Dev Call
+# Weekly Community Q&A Call
 
 <div v-if="$themeConfig.px4_version != 'main'">
   <div class="custom-block danger"><p class="custom-block-title">This page may be out of date</p>. <p>The latest version <a href="https://docs.px4.io/main/en/contribute/dev_call.html">can be found here</a>.</p>
   </div>
 </div>
 
-The PX4 dev team syncs up on platform technical details and in-depth analysis. 
-There is also space in the agenda to discuss pull requests, major impacting issues and Q&A.
-
+The PX4 dev team and Community come together to discuss anything Community may be curious / having trouble about!
 
 ## Who should attend:
 
@@ -18,30 +16,19 @@ There is also space in the agenda to discuss pull requests, major impacting issu
 * Community members
 
 :::tip
-The dev call is open to all interested developers (not just the core dev team). 
+The Community Q&A call is open to all interested community members.
+
 This is a great opportunity to meet the team and contribute to the ongoing development of the platform.
 :::
 
 ## What gets discussed?
 
-The first/main part of the meeting runs for 45 minutes and provides a high-level forum to discuss where the project is going. 
+The meeting note gets published week before the call on [PX4 Discuss - weekly-dev-call](https://discuss.px4.io/c/weekly-dev-call).
 
-This is where we discuss *contributions*, including issues/PRs that have the [dev call](https://github.com/PX4/PX4-Autopilot/labels/devcall5) label.
-We expect the proposer and the assigned reviewer to be on the call!
+We welcome any topics that you, as a community member may have questions about / want to discuss!
 
-:::note
-The main call is designed to support rapid/focused decision making.
-We don't expect deep technical discussions and we will not spend extended amounts of time on feature requests. 
-Proposals are welcome, but they need a sponsor (someone willing to *implement* the work)!
-:::
-
-The second part of the meeting is for in-depth technical discussions and open ended questions.
-The core team/subsystem maintainers will be available for up to 45 additional minutes. 
-
+Please add your agendas as a reply to the meeting note before the meeting begins, as it helps clearing up confusion about your topic & will help you formulate the topic in a better manner.
 
 ## Schedule
 * TIME: Wednesday 17h00 CET ([subscribe to calendar](https://www.dronecode.org/calendar/))
-* **Join the call**: [https://meet.jit.si/PX4DeveloperCallWeekly](https://meet.jit.si/PX4DeveloperCallWeekly)
-
-* Agenda is published before the call on [PX4 Discuss - weekly-dev-call](https://discuss.px4.io//c/weekly-dev-call)
-* To nominate Issues and PRs for the call you can use the [Dev Call](https://github.com/PX4/PX4-Autopilot/labels/Dev%20Call) label to flag them for discussion.
+* **Join the call**: [https://discord.gg/BDYmr6FA6Q](https://discord.gg/BDYmr6FA6Q)

--- a/en/contribute/dev_call.md
+++ b/en/contribute/dev_call.md
@@ -5,7 +5,7 @@
   </div>
 </div>
 
-The PX4 dev team and Community come together to discuss anything Community may be curious / having trouble about!
+The PX4 dev team and community come together to discuss any topic of interest to the community, ranging from sorting out issues to satisfying your curiosity.
 
 ## Who should attend:
 

--- a/en/contribute/dev_call.md
+++ b/en/contribute/dev_call.md
@@ -1,4 +1,4 @@
-# Weekly Community Q&A Call
+# Weekly Community Q&A Call (Previously "Dev Call")
 
 <div v-if="$themeConfig.px4_version != 'main'">
   <div class="custom-block danger"><p class="custom-block-title">This page may be out of date</p>. <p>The latest version <a href="https://docs.px4.io/main/en/contribute/dev_call.html">can be found here</a>.</p>
@@ -13,7 +13,7 @@ The PX4 dev team and community come together to discuss any topic of interest to
 * Component maintainers
 * Test team lead
 * Dronecode members
-* Community members
+* Community members (you!)
 
 :::tip
 The Community Q&A call is open to all interested community members.
@@ -23,12 +23,9 @@ This is a great opportunity to meet the team and contribute to the ongoing devel
 
 ## What gets discussed?
 
-We publish a forum post per meeting a week before the call on [PX4 Discuss - weekly-dev-call](https://discuss.px4.io/c/weekly-dev-call) and track the agenda write down the discussion for the day.
+We publish a forum post per meeting a week before the call on [PX4 Discuss - weekly-dev-call](https://discuss.px4.io/c/weekly-dev-call) and track the agenda write down the discussion for the day. We welcome any topics that you, as a community member may have questions about / want to discuss!
 
-We welcome any topics that you, as a community member may have questions about / want to discuss!
-
-Please add your topics for discussion to the agenda before the meeting begins, by replying to the meeting note.
-This will help you formulate your questions more clearly, and allow us to think about them in advance.
+Please add your topics for discussion to the agenda before the meeting begins, by replying to the meeting note. This will help you formulate your questions more clearly, and allow us to think about them in advance.
 
 ## Schedule
 * TIME: Wednesday 17h00 CET ([subscribe to calendar](https://www.dronecode.org/calendar/))

--- a/en/contribute/dev_call.md
+++ b/en/contribute/dev_call.md
@@ -27,7 +27,8 @@ The meeting note gets published week before the call on [PX4 Discuss - weekly-de
 
 We welcome any topics that you, as a community member may have questions about / want to discuss!
 
-Please add your agendas as a reply to the meeting note before the meeting begins, as it helps clearing up confusion about your topic & will help you formulate the topic in a better manner.
+Please add your topics for discussion to the agenda before the meeting begins, by replying to the meeting note.
+This will help you formulate your questions more clearly, and allow us to think about them in advance.
 
 ## Schedule
 * TIME: Wednesday 17h00 CET ([subscribe to calendar](https://www.dronecode.org/calendar/))


### PR DESCRIPTION
## About
This updates the dev call page to include updated information about the Community QnA call (former dev call), and clarifies that Central European Timezone is the main reference timezone for the Dronecode calender.

## Timezone
Today's maintainers call was wrongly scheduled due to the timezone shift differences between CET and PST (during "March 12 ~ 26 & October 30 ~ November 5th", will we have the PST vs CET time difference of 1 hour, [Source](https://savvytime.com/converter/pst-to-cet-est)), so we agreed that CET should be the reference timezone.

That's why this proposition was added to this PR!

Discord message about it can be found here: https://discord.com/channels/1022170275984457759/1045343300850290778/1085219123614732401