### PR TITLE
gps_compass: add Holybro Unicore GPS module

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -240,6 +240,7 @@
       * [LOCOSYS Hawk A1 GNSS](gps_compass/gps_locosys_hawk_a1.md)
       * [Hex Here2](gps_compass/gps_hex_here2.md)
       * [Holybro M8N & M9N GPS](gps_compass/gps_holybro_m8n_m9n.md)
+      * [Holybro Unicore GPS](gps_compass/gps_holybro_unicore.md)
       * [Sky-Drones SmartAP GPS](gps_compass/gps_smartap.md)
     * [RTK GPS](gps_compass/rtk_gps.md)
       * [ARK RTK GPS](dronecan/ark_rtk_gps.md)

--- a/en/gps_compass/README.md
+++ b/en/gps_compass/README.md
@@ -49,7 +49,7 @@ Device | GPS | Compass | [RTK](../gps_compass/rtk_gps.md) | [GPS Yaw Output](#co
 [Holybro H-RTK F9P Helical or Base](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | F9P | IST8310 | &check; | | &check;|
 [Holybro H-RTK F9P Rover Lite](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | F9P | IST8310 | &check; | | |
 [Holybro H-RTK M8P GNSS](../gps_compass/rtk_gps_holybro_h-rtk-m8p.md) | M8P | IST8310 | &check; | | |
-[Holybro Unicore GPS](../gps_compass/gps_holybro_unicore.md) | UM982 | ? | &check; | | &check; |
+[Holybro Unicore GPS](../gps_compass/gps_holybro_unicore.md) | UM982 | IST8310 | &check; | &check; | |
 [Hobbyking u-blox Neo-M8N GPS with Compass](https://hobbyking.com/en_us/ublox-neo-m8n-gps-with-compass.html?gclid=Cj0KCQjwqM3VBRCwARIsAKcekb3ojv1ZhLz1-GuvCsUuGT8ZZuw8meMIV_I6pgUCj6DJRzHBY9OApekaAgI5EALw_wcB&gclsrc=aw.ds&___store=en_us) | M8N | &check; | | | |
 [LOCOSYS Hawk A1 GNSS receiver](../gps_compass/gps_locosys_hawk_a1.md) | MC-1612-V2b | optional | &cross; | | | 
 [LOCOSYS Hawk R1](../gps_compass/gps_locosys_hawk_r1.md) | MC-1612-V2b |  | &cross; | | | 

--- a/en/gps_compass/README.md
+++ b/en/gps_compass/README.md
@@ -49,6 +49,7 @@ Device | GPS | Compass | [RTK](../gps_compass/rtk_gps.md) | [GPS Yaw Output](#co
 [Holybro H-RTK F9P Helical or Base](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | F9P | IST8310 | &check; | | &check;|
 [Holybro H-RTK F9P Rover Lite](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | F9P | IST8310 | &check; | | |
 [Holybro H-RTK M8P GNSS](../gps_compass/rtk_gps_holybro_h-rtk-m8p.md) | M8P | IST8310 | &check; | | |
+[Holybro Unicore GPS](../gps_compass/gps_holybro_unicore.md) | UM982 | ? | &check; | | &check; |
 [Hobbyking u-blox Neo-M8N GPS with Compass](https://hobbyking.com/en_us/ublox-neo-m8n-gps-with-compass.html?gclid=Cj0KCQjwqM3VBRCwARIsAKcekb3ojv1ZhLz1-GuvCsUuGT8ZZuw8meMIV_I6pgUCj6DJRzHBY9OApekaAgI5EALw_wcB&gclsrc=aw.ds&___store=en_us) | M8N | &check; | | | |
 [LOCOSYS Hawk A1 GNSS receiver](../gps_compass/gps_locosys_hawk_a1.md) | MC-1612-V2b | optional | &cross; | | | 
 [LOCOSYS Hawk R1](../gps_compass/gps_locosys_hawk_r1.md) | MC-1612-V2b |  | &cross; | | | 

--- a/en/gps_compass/gps_holybro_unicore.md
+++ b/en/gps_compass/gps_holybro_unicore.md
@@ -1,0 +1,47 @@
+# Holybro Unicore UM982 GPS
+
+The [Holybro Unicore UM982 GPS](http://www.holybro.com/product/TODO/) is an multi-band high-precision [RTK GNSS System](../gps_compass/rtk_gps.md) series launched by Holybro.
+
+The module is based on the [Unicore UM982 GNSS module](https://en.unicorecomm.com/products/detail/24) which supports RTK positioning as well as dual-antenna heading calculation.
+
+One GNSS module comes with two antennas allowing for GPS heading using only one GPS connector/port.
+
+## Where to Buy
+
+* [H-RTK F9P (Holybro Website)](https://shop.holybro.com/TODO)
+
+## Configuration
+
+The Unicore module talks the NMEA protocol extended with some proprietary Unicore sentences. The serial baudrate is 230400.
+
+In order to use it in PX4, the following parameters need to be set (parameters if connected to GPS 1):
+
+- [SER_GPS1_BAUD](../advanced_config/parameter_reference.md#SER_GPS1_BAUD) -> 230400
+- [GPS_1_PROTOCOL](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL) -> 6: NMEA
+- [GPS_1_PROTOCOL](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL) -> 6: NMEA
+
+## Enable GPS heading/yaw
+
+The Unicore module comes with two antennas, a primary (right connector) and a secondary (left connector) antenna.
+
+- [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) -> Set bit 7 (128) to enable GPS yaw fusion, so to use the GPS heading
+- [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) -> Set heading offset to 0 if the primary antenna is in the front. The angle increases clock-wise, so set the offset to 90 degrees if the primary antenna is on the right side of the vehicle (and the secondary on the left side).
+
+
+## RTK corrections
+
+:::note
+The RTK functionality has not been tested and verified yet.
+:::
+
+
+## Wiring
+
+The module comes with both GH 10-pin & 6-pin cables that are compatible with the GPS1 & GPS2 ports on flight controllers that use the Pixhawk Connector Standard, such as [Pixhawk 6x](../flight_controller/pixhawk6x.md) and [Pixhawk 6c](../flight_controller/pixhawk6c.md).
+
+The module can be used with one antenna or both antennas. If it is used with one antenna only, the right/primary antenna connector needs to be connected.
+
+
+## Accessories
+
+TODO

--- a/en/gps_compass/gps_holybro_unicore.md
+++ b/en/gps_compass/gps_holybro_unicore.md
@@ -1,6 +1,6 @@
 # Holybro Unicore UM982 GPS
 
-The [Holybro Unicore UM982 GPS](http://www.holybro.com/product/TODO/) is an multi-band high-precision [RTK GNSS System](../gps_compass/rtk_gps.md) series launched by Holybro.
+The [Holybro Unicore UM982 GPS](https://holybro.com/products/h-rtk-um982) is an multi-band high-precision [RTK GNSS System](../gps_compass/rtk_gps.md) series launched by Holybro.
 
 The module is based on the [Unicore UM982 GNSS module](https://en.unicorecomm.com/products/detail/24) which supports RTK positioning as well as dual-antenna heading calculation.
 
@@ -8,7 +8,7 @@ One GNSS module comes with two antennas allowing for GPS heading using only one 
 
 ## Where to Buy
 
-* [Holybro Website](https://shop.holybro.com/TODO)
+* [Holybro Website](https://holybro.com/products/h-rtk-um982)
 
 ## Configuration
 
@@ -36,7 +36,3 @@ The module comes with both GH 10-pin & 6-pin cables that are compatible with the
 
 The module can be used with one antenna or both antennas. If it is used with one antenna only, the right/primary antenna connector needs to be connected.
 
-
-## Accessories
-
-TODO

--- a/en/gps_compass/gps_holybro_unicore.md
+++ b/en/gps_compass/gps_holybro_unicore.md
@@ -14,13 +14,13 @@ One GNSS module comes with two antennas allowing for GPS heading using only one 
 
 The Unicore module talks the NMEA protocol extended with some proprietary Unicore sentences. The serial baudrate is 230400.
 
-In order to use it in PX4, the following parameters need to be set (parameters if connected to GPS 1):
+The following PX4 parameters [must be set](../advanced_config/parameters.md) (if connected to GPS 1):
 
 - [SER_GPS1_BAUD](../advanced_config/parameter_reference.md#SER_GPS1_BAUD) -> 230400
 - [GPS_1_PROTOCOL](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL) -> 6: NMEA
 - [GPS_1_PROTOCOL](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL) -> 6: NMEA
 
-## Enable GPS heading/yaw
+## Enable GPS Heading/Yaw
 
 The Unicore module comes with two antennas, a primary (right connector) and a secondary (left connector) antenna.
 
@@ -28,7 +28,7 @@ The Unicore module comes with two antennas, a primary (right connector) and a se
 - [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) -> Set heading offset to 0 if the primary antenna is in the front. The angle increases clock-wise, so set the offset to 90 degrees if the primary antenna is on the right side of the vehicle (and the secondary on the left side).
 
 
-## RTK corrections
+## RTK Corrections
 
 :::note
 The RTK functionality has not been tested and verified yet.
@@ -37,7 +37,7 @@ The RTK functionality has not been tested and verified yet.
 
 ## Wiring
 
-The module comes with both GH 10-pin & 6-pin cables that are compatible with the GPS1 & GPS2 ports on flight controllers that use the Pixhawk Connector Standard, such as [Pixhawk 6x](../flight_controller/pixhawk6x.md) and [Pixhawk 6c](../flight_controller/pixhawk6c.md).
+The module comes with both GH 10-pin & 6-pin cables that are compatible with the GPS1 & GPS2 ports on flight controllers that use the [Pixhawk Connector Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-009%20Pixhawk%20Connector%20Standard.pdf), such as [Pixhawk 6x](../flight_controller/pixhawk6x.md) and [Pixhawk 6c](../flight_controller/pixhawk6c.md).
 
 The module can be used with one antenna or both antennas. If it is used with one antenna only, the right/primary antenna connector needs to be connected.
 

--- a/en/gps_compass/gps_holybro_unicore.md
+++ b/en/gps_compass/gps_holybro_unicore.md
@@ -10,29 +10,38 @@ One GNSS module comes with two antennas allowing for GPS heading using only one 
 
 * [Holybro Website](https://holybro.com/products/h-rtk-um982)
 
-## Configuration
-
-The Unicore module talks the NMEA protocol extended with some proprietary Unicore sentences. The serial baudrate is 230400.
-
-The following PX4 parameters [must be set](../advanced_config/parameters.md) (if connected to GPS 1):
-
-- [SER_GPS1_BAUD](../advanced_config/parameter_reference.md#SER_GPS1_BAUD) -> 230400
-- [GPS_1_PROTOCOL](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL) -> 6: NMEA
-
-## Enable GPS Heading/Yaw
-
-The Unicore module comes with two antennas, a primary (right connector) and a secondary (left connector) antenna.
-
-- [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) -> Set bit 7 (128) to enable GPS yaw fusion, so to use the GPS heading
-- [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) -> Set heading offset to 0 if the primary antenna is in the front. The angle increases clock-wise, so set the offset to 90 degrees if the primary antenna is on the right side of the vehicle (and the secondary on the left side).
-
-## RTK Corrections
-
-RTK works the same way as uBlox F9P modules. RTCMv3 corrections as sent by QGroundControl from an RTK GPS base station are consumed by the Unicore module which should then change fix type to RTK float or RTK fixed.
-
 ## Wiring
 
 The module comes with both GH 10-pin & 6-pin cables that are compatible with the GPS1 & GPS2 ports on flight controllers that use the [Pixhawk Connector Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-009%20Pixhawk%20Connector%20Standard.pdf), such as [Pixhawk 6x](../flight_controller/pixhawk6x.md) and [Pixhawk 6c](../flight_controller/pixhawk6c.md).
 
-The module can be used with one antenna or both antennas. If it is used with one antenna only, the right/primary antenna connector needs to be connected.
+The module can be used with one antenna or both antennas.
+If it is used with one antenna only, the right/primary antenna connector needs to be connected.
 
+## PX4 Configuration
+
+### Port Setup
+
+The Unicore module talks the NMEA protocol extended with some proprietary Unicore sentences.
+The serial baudrate is 230400.
+
+The following PX4 parameters [must be set](../advanced_config/parameters.md):
+
+- [SER_GPS1_BAUD](../advanced_config/parameter_reference.md#SER_GPS1_BAUD) -> 230400
+- [GPS_1_PROTOCOL](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL) -> 6: NMEA
+
+Note, the above parameters assume you are connected to `GPS 1`.
+If you are using another port you will have to use its parameters to configure the baud rate and protocol.
+
+### Enable GPS Heading/Yaw
+
+The Unicore module comes with two antennas, a primary (right connector) and a secondary (left connector) antenna, which can be used to get yaw from GPS.
+You will need to set the following parameters:
+
+- [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK): Set bit 7 (128) to enable GPS yaw fusion into the yaw estimation.
+- [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET): Set heading offset to 0 if the primary antenna is in the front.
+  The angle increases clock-wise, so set the offset to 90 degrees if the primary antenna is on the right side of the vehicle (and the secondary on the left side).
+
+### RTK Corrections
+
+RTK works the same way as uBlox F9P modules.
+RTCMv3 corrections as sent by QGroundControl from an RTK GPS base station are consumed by the Unicore module, which should then change fix type to `RTK float` or `RTK fixed`.

--- a/en/gps_compass/gps_holybro_unicore.md
+++ b/en/gps_compass/gps_holybro_unicore.md
@@ -8,7 +8,7 @@ One GNSS module comes with two antennas allowing for GPS heading using only one 
 
 ## Where to Buy
 
-* [H-RTK F9P (Holybro Website)](https://shop.holybro.com/TODO)
+* [Holybro Website](https://shop.holybro.com/TODO)
 
 ## Configuration
 
@@ -18,7 +18,6 @@ The following PX4 parameters [must be set](../advanced_config/parameters.md) (if
 
 - [SER_GPS1_BAUD](../advanced_config/parameter_reference.md#SER_GPS1_BAUD) -> 230400
 - [GPS_1_PROTOCOL](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL) -> 6: NMEA
-- [GPS_1_PROTOCOL](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL) -> 6: NMEA
 
 ## Enable GPS Heading/Yaw
 
@@ -27,13 +26,9 @@ The Unicore module comes with two antennas, a primary (right connector) and a se
 - [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) -> Set bit 7 (128) to enable GPS yaw fusion, so to use the GPS heading
 - [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) -> Set heading offset to 0 if the primary antenna is in the front. The angle increases clock-wise, so set the offset to 90 degrees if the primary antenna is on the right side of the vehicle (and the secondary on the left side).
 
-
 ## RTK Corrections
 
-:::note
-The RTK functionality has not been tested and verified yet.
-:::
-
+RTK works the same way as uBlox F9P modules. RTCMv3 corrections as sent by QGroundControl from an RTK GPS base station are consumed by the Unicore module which should then change fix type to RTK float or RTK fixed.
 
 ## Wiring
 

--- a/en/gps_compass/rtk_gps.md
+++ b/en/gps_compass/rtk_gps.md
@@ -30,6 +30,7 @@ GPS | Yaw Output | [Dual F9P GPS Heading](../gps_compass/u-blox_f9p_heading.md) 
 [Holybro H-RTK F9P Helical or Base](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | |&check; | |
 [Holybro H-RTK F9P Rover Lite](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | | | |
 [Holybro H-RTK M8P GNSS](../gps_compass/rtk_gps_holybro_h-rtk-m8p.md) | | | |
+[Holybro Unicore GPS](../gps_compass/gps_holybro_unicore.md) | &check; | | |
 [LOCOSYS Hawk R1](../gps_compass/rtk_gps_locosys_r1.md) | | | |
 [LOCOSYS Hawk R2](../gps_compass/rtk_gps_locosys_r2.md) | &check; | | |
 [SparkFun GPS-RTK2 Board - ZED-F9P](https://www.sparkfun.com/products/15136) | | &check; | |


### PR DESCRIPTION
This adds a page about the Holybro GPS based on the UM982 module.

The current state is still work in progress until we have the definite title and shop links.