### PR TITLE
Ethernet_setup: migrate from micrortps to microdds

### DIFF
--- a/en/advanced_config/ethernet_setup.md
+++ b/en/advanced_config/ethernet_setup.md
@@ -15,7 +15,7 @@ This topic covers:
   - [PX4 MAVLink Serial Port Configuration](#px4-mavlink-serial-port-configuration)
   - [QGroundControl Setup Example](#qgroundcontrol-setup-example)
   - [MAVSDK-Python Setup Example](#mavsdk-python-setup-example)
-  - [ROS2 Setup Example](#ros2-setup-example)
+  - [ROS 2 Setup Example](#ros-2-setup-example)
 
 ## Supported Flight Controllers
 
@@ -202,47 +202,27 @@ However this is not recommended because the default configuration is optimised f
 :::
 
 
-## ROS2 Setup Example
-
-:::warning
-**This section is out of date!**
-It relies on the [PX4-Fast RTPS(DDS) Bridge](/middleware/micrortps.md), which is no longer supported.
-We plan to retest and update it for the [XRCE-DDS (PX4-ROS2/DDS Bridge)](../middleware/xrce_dds.md) in the near future.
-:::
+## ROS 2 Setup Example
 
 Prerequisites:
 
-- You have a supported autopilot hardware with RTPS feature enabled firmware on it by using [this guide](../middleware/micrortps.md#client-px4-px4-autopilot).
-- [ROS2](../ros/ros2_comm.md#sanity-check-the-installation) has been set up correctly and [sanity check](../ros/ros2_comm.md#sanity-check-the-installation) has been confirmed. 
+- You have a supported autopilot hardware with [XRCE-DDS feature](../middleware/xrce_dds.md) enabled firmware on it.
+- [ROS 2](../ros/ros2_comm.md) has been set up correctly on the companion computer.
 - You have followed the Ethernet network and port setup as discussed at the top of this page. 
 
 In this example it is assumed that you have followed the example to set your IP addresses.
 
-1. Connect your Flight controller via Ethernet
-2. Open **QGroundControl > Analyze Tools > MAVLink Console**
-3. Enter the command below to start the micro_rtps client on your flight controller.
-   Note that the remote IP here is your companion computer IP.
-   This by default starts the micrortps_client connected to UDP ports 2019 and 2020
-   To make changes you can take a look at [RTPS guide](../middleware/micrortps.md#client-px4-px4-autopilot)
+1. Connect your Flight controller via Ethernet.
+2. [Start the micro XRCE-DDS client](../middleware/xrce_dds.md#starting-the-client), either manually or customizing the system startup script taking care of using the right IP address and UDP port adopted by the agent.
+3. Then we need to [run the agent](../middleware/xrce_dds.md#starting-the-agent) by typing the below commands in a new terminal on either our companion computer.
+   This will start the agent listening on UDP port `8888`.
    ```
-   micrortps_client start -t UDP -i <remote IP>
+   MicroXRCEAgent udp4 -p 8888
    ```
-   An output like below is expected in the console:
+4. In a new terminal you can run a [listener node](../ros/ros2_comm.md#running-the-example) to confirm the connection is established:
    ```
-   INFO  [micrortps_client] UDP transport: ip address: 192.168.0.1; recv port: 2019; send port: 2020
-   INFO  [micrortps_client] UDP transport: Trying to connect...
-   INFO  [micrortps_client] UDP transport: Connected to server!
-   ```
-5. Then we need to run the agent by typing the below commands in a new terminal on either our Linux computer.
-   This will start the agent on `localhost` which is `127.0.0.1`.
-   ```
-   $ source ~/px4_ros_com_ros2/install/setup.bash
-   $ micrortps_agent start -t UDP
-   ```
-6. In a new terminal you can run a listener node to confirm the connection is established:
-   ```
-   $ source ~/px4_ros_com_ros2/install/setup.bash
-   $ ros2 launch px4_ros_com sensor_combined_listener.launch.py
+   source ~/ws_sensor_combined/install/setup.bash
+   ros2 launch px4_ros_com sensor_combined_listener.launch.py
    ```
 
 If everything goes ok and there is an established connection you can see the output below in your terminal:


### PR DESCRIPTION
ROS 2 setup example for Ethernet configuration now uses micro XRCE-DDS documentation.

Related issue: #2345