### PR TITLE
Fixes for vtol tailsitter now just one frame

### DIFF
--- a/en/config/actuators.md
+++ b/en/config/actuators.md
@@ -76,7 +76,7 @@ Note, this may not be the same as the position of the flight controller!
 
 #### Motor Geometry: VTOL Quadrotor Tailsitter
 
-The motor geometry for a [VTOL Quad Tailsitter](../airframes/airframe_reference.md#vtol-quad-tailsitter) is shown below (the approach for configuring other tailsitter VTOL vehicles will be similar). 
+The motor geometry for a [VTOL Quad Tailsitter](../airframes/airframe_reference.md#vtol-tailsitter) is shown below (the approach for configuring other tailsitter VTOL vehicles will be similar). 
 
 Motors have the same configuration fields as for the [multicopter geometry](#motor-geometry-multicopter).
 

--- a/en/flight_controller/autopilot_pixhawk_standard.md
+++ b/en/flight_controller/autopilot_pixhawk_standard.md
@@ -22,4 +22,4 @@ The boards in this category are:
 - [CUAV Pixhack v3](../flight_controller/pixhack_v3.md) (FMUv3)
 - [Hex Cube Black](../flight_controller/pixhawk-2.md) (FMUv3)
 - [mRo Pixhawk](../flight_controller/mro_pixhawk.md) (FMUv3)
-- [Holybro Pixhawk Mini](../flight_controller/pixhawk_mini.md) (FMUv3)
+- [Holybro Pixhawk Mini](../flight_controller/pixhawk_mini.md) (FMUv3) - Discontinued by Holybro but supported by PX4

--- a/en/frames_vtol/tailsitter.md
+++ b/en/frames_vtol/tailsitter.md
@@ -10,7 +10,7 @@ However they are aerodynamically more complex, and can be harder to tune and fly
 
 <div class="grid_wrapper two_column">
   <div class="grid_item">
-    <div class="grid_item_heading"><big><a href="../airframes/airframe_reference.html#vtol-duo-tailsitter">VTOL Duo Tailsitter</a></big></div>
+    <div class="grid_item_heading"><big><a href="../airframes/airframe_reference.html#vtol-tailsitter">VTOL Duo Tailsitter</a></big></div>
     <div class="grid_text">
     Two rotor VTOL that uses elevons to flip from hover into fixed-wing flight.<br><br>
     <img src="../../assets/airframes/vtol/wingtraone/hero.jpg" title="Wingtra: WingtraOne VTOL Duo Tailsitter" alt="wingtraone" /> 
@@ -23,8 +23,8 @@ However they are aerodynamically more complex, and can be harder to tune and fly
     </div>
   </div>
 <div class="grid_item">
-  <div class="grid_item_heading"><big><a href="../airframes/airframe_reference.html#vtol-quad-tailsitter">VTOL Quad Tailsitter</a></big></div>
-  Four rotor VTOL with optional elevons. Uses rotors to transition between modes (along with elevons if present).
+  <div class="grid_item_heading"><big><a href="../airframes/airframe_reference.html#vtol-tailsitter">VTOL Tailsitter</a></big></div>
+  VTOL with optional elevons. Uses rotors to transition between modes (along with elevons if present).
   <div class="grid_text">
   <img title="Skypull SP-1 VTOL QuadTailsitter" src="../../assets/airframes/vtol/skypull/skypull_sp1.jpg" />
   <ul>
@@ -39,6 +39,7 @@ However they are aerodynamically more complex, and can be harder to tune and fly
 Duo Tailsitters are generally more efficient in cruise flight (4 smaller propellers are less efficient than 2 larger ones) and physically more compact.
 However as they are aerodynamically much more complex in hover mode, they are much harder to tune for both hover and transition.
 Quad tailsitters are easier to fly in hover mode, and more stable in windy conditions.
+Both are supported using the same aiframe type in PX4.
 
 ## Setup/Flying
 
@@ -46,7 +47,7 @@ VTOL setup and flying are covered in the [VTOL](../frames_vtol/README.md) parent
 
 :::note
 The instructions are essentially the same for all VTOL.
-The main frame-specific differences are the motor wiring (see [VTOL Duo Tailsitter](../airframes/airframe_reference.md#vtol-duo-tailsitter) and [VTOL Quad Tailsitter](../airframes/airframe_reference.md#vtol-quad-tailsitter)), and some aspects of tuning the configuration.
+The main frame-specific differences are the motor wiring, and some aspects of tuning the configuration.
 :::
 
 ## Build Logs


### PR DESCRIPTION
@sfuhrer This follows on from the fact that we only have one tailsitter frame in the reference (https://github.com/PX4/PX4-user_guide/pull/2359#discussion_r1144217840). 

IN particular, I'm after confirmation `en/frames_vtol/tailsitter.md` updates are OK - i.e. fixing this https://docs.px4.io/main/en/frames_vtol/tailsitter.html#tailsitter-airframes

I've basically left everything in place but made a note that they use the same frame.