### PR TITLE
holybro_qav250: add note about actuator configuration

### DIFF
--- a/en/frames_multicopter/holybro_qav250_pixhawk4_mini.md
+++ b/en/frames_multicopter/holybro_qav250_pixhawk4_mini.md
@@ -215,7 +215,7 @@ First update the firmware, airframe, and actuator mappings:
   
 - [Actuators](../config/actuators.md)
   - You should not need to update the vehicle geometry (as this is a preconfigured airframe).
-  - Assign actuator functions to outputs to match your wiring.
+  - Assign actuator functions to outputs to match your wiring. 
   - Test the configuration using the sliders.
 
 Then perform the mandatory setup/calibration:

--- a/en/frames_multicopter/holybro_qav250_pixhawk4_mini.md
+++ b/en/frames_multicopter/holybro_qav250_pixhawk4_mini.md
@@ -214,7 +214,9 @@ First update the firmware, airframe, and actuator mappings:
   :::
   
 - [Actuators](../config/actuators.md)
-  - You should not need to update the vehicle geometry (as this is a preconfigured airframe).
+  - Here is the main difference between the _discontinued_ Holybro Pixhawk 4 Mini QAV250 Kit and the new one based on the Pix32 v6.
+    - The default actuator configuration assumes that a flight controller with [I/O board](../hardware/reference_design.md#mainio-function-breakdown) such as the Pix32 v6 is used.
+    - The Pixhawk 4 Mini does not have the I/O board. Therefore, the actuator configuration MUST be updated: MAIN -> AUX.
   - Assign actuator functions to outputs to match your wiring.
   - Test the configuration using the sliders.
 

--- a/en/frames_multicopter/holybro_qav250_pixhawk4_mini.md
+++ b/en/frames_multicopter/holybro_qav250_pixhawk4_mini.md
@@ -214,9 +214,7 @@ First update the firmware, airframe, and actuator mappings:
   :::
   
 - [Actuators](../config/actuators.md)
-  - Here is the main difference between the _discontinued_ Holybro Pixhawk 4 Mini QAV250 Kit and the new one based on the Pix32 v6.
-    - The default actuator configuration assumes that a flight controller with [I/O board](../hardware/reference_design.md#mainio-function-breakdown) such as the Pix32 v6 is used.
-    - The Pixhawk 4 Mini does not have the I/O board. Therefore, the actuator configuration MUST be updated: MAIN -> AUX.
+  - You should not need to update the vehicle geometry (as this is a preconfigured airframe).
   - Assign actuator functions to outputs to match your wiring.
   - Test the configuration using the sliders.
 

--- a/en/frames_multicopter/holybro_qav250_pixhawk4_mini.md
+++ b/en/frames_multicopter/holybro_qav250_pixhawk4_mini.md
@@ -215,7 +215,9 @@ First update the firmware, airframe, and actuator mappings:
   
 - [Actuators](../config/actuators.md)
   - You should not need to update the vehicle geometry (as this is a preconfigured airframe).
-  - Assign actuator functions to outputs to match your wiring. 
+  - Assign actuator functions to outputs to match your wiring.
+    - For the Pixhawk 4 Mini, and other controllers that do not have an [I/O board](../hardware/reference_design.md#mainio-function-breakdown), you will need to assign actuators to outputs on the `PWM AUX` tab in the configuration screen.
+    - The Pix32 v6 has an I/O board, so you can assign to either AUX or MAIN.    
   - Test the configuration using the sliders.
 
 Then perform the mandatory setup/calibration:


### PR DESCRIPTION
The default configuration for the frame `HolyBro QAV250` is assuming a flight controller with [I/O board](https://github.com/PX4/PX4-Autopilot/blob/319f3db5e1f0f799be45064330d9c9504f5b5bcc/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250#L63-L66) (such as the new pix32 v6). However the discontinued _Holybro QAV250 + Pixhawk 4 Mini Build_ does not have the I/O board.

To avoid confusion an additional note is added.