### PR TITLE
Fix typo in dfu-util command

### DIFF
--- a/en/advanced_config/bootloader_update_from_betaflight.md
+++ b/en/advanced_config/bootloader_update_from_betaflight.md
@@ -86,7 +86,7 @@ The button can be released after the board is powered up.
 The [Holybro Kakute H7 v2](../flight_controller/kakuteh7v2.md) and mini flight controllers may require that you first run an additional command to erase flash parameters (in order to fix problems with parameter saving):
 
 ```
-dfu-util -a 0 --dfuse-address:force:mass-erase:leave 0x08000000 -D  build/<target>/<target>.bin
+dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D build/<target>/<target>.bin
 ```
 
 The command may generate an error which can be ignored.


### PR DESCRIPTION
Fixed a typo in the DFU command.
This was tested this time and it works.