### PR TITLE
Mission: fix L1 param names (replaced by NPFG with same meaning)

### DIFF
--- a/en/flight_modes/mission.md
+++ b/en/flight_modes/mission.md
@@ -196,7 +196,7 @@ The diagram below shows the sorts of paths that you might expect.
 Vehicles switch to the next waypoint as soon as they enter the acceptance radius:
 - For MC this radius is defined by [NAV_ACC_RAD](../advanced_config/parameter_reference.md#NAV_ACC_RAD).
 - For FW the acceptance radius is defined by the "L1 distance".
-  - The L1 distance is computed from two parameters: [FW_L1_DAMPING](../advanced_config/parameter_reference.md#FW_L1_DAMPING) and [FW_L1_PERIOD](../advanced_config/parameter_reference.md#FW_L1_PERIOD), and the current ground speed.
+  - The L1 distance is computed from two parameters: [NPFG_DAMPING](../advanced_config/parameter_reference.md#NPFG_DAMPING) and [NPFG_PERIOD](../advanced_config/parameter_reference.md#NPFG_PERIOD), and the current ground speed.
   - By default, it's about 70 meters.
   - The equation is: 
     $$L_{1_{distance}}=\frac{1}{\pi}L_{1_{damping}}L_{1_{period}}\left \| \vec{v}_{ {xy}_{ground} } \right \|$$


### PR DESCRIPTION
@tstastny I guess this documentation is also valid for NPFG? 