### PR TITLE
Remove UAVCAN_ESC_IDLT

### DIFF
--- a/en/dronecan/README.md
+++ b/en/dronecan/README.md
@@ -130,7 +130,7 @@ If successful, the firmware binary will be removed from the root directory and t
 
 **Q**: The motors don't spin until throttle is increased.
 
-**A**: Check that the `UAVCAN_ESC_IDLT` is set to `1`.
+**A**: Use [Acutator > Actuator Testing](../config/actuators.md#actuator-testing) to confirm that the motor outputs are set to the correct minimum values.
 
 ## Useful Links
 

--- a/en/dronecan/sapog.md
+++ b/en/dronecan/sapog.md
@@ -65,12 +65,6 @@ Refer to the [project page](https://github.com/PX4/sapog) to learn more, includi
 
 Connect the ESCs to the Pixhawk CAN bus. Power up the entire vehicle using a battery or power supply (not just the flight controller over USB) and enable the DroneCAN driver by setting the parameter [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE) to '3' to enable both dynamic node ID allocation and DroneCAN ESC output.
 
-### PX4 Configuration
-
-(Optional) Set [UAVCAN_ESC_IDLT](../advanced_config/parameter_reference.md#UAVCAN_ESC_IDLT) to 1 in order to ensure that the motors are always running at least at the idle throttle while the system is armed.
-:::note
-Some systems will not benefit from this behavior, e.g. glider drones).
-:::
 
 ### Automatic ESC Enumeration using QGroundControl
 
@@ -116,6 +110,11 @@ This assigns the following Sapog configuration parameters for each enumerated ES
 :::note
 See [Sapog reference manual](https://files.zubax.com/products/io.px4.sapog/Sapog_v2_Reference_Manual.pdf) for more information about the parameters.
 :::
+
+### PX4 Configuration
+
+Assign motors to outputs using the [Acutator](../config/actuators.md#actuator-testing) configuration screen.
+
 
 ## Troubleshooting
 

--- a/en/dronecan/zubax_telega.md
+++ b/en/dronecan/zubax_telega.md
@@ -42,18 +42,14 @@ Connect the ESCs to the Pixhawk CAN bus. Power up the entire vehicle using a bat
 
 ### PX4 Configuration
 
-(Optional) Set [UAVCAN_ESC_IDLT](../advanced_config/parameter_reference.md#UAVCAN_ESC_IDLT) to `1` in order to ensure that the motors are always running at least at the idle throttle while the system is armed.
-
-:::note
-Some systems will not benefit from this behavior, e.g. glider drones).
-:::
+Assign motors to outputs using the [Acutator](../config/actuators.md#actuator-testing) configuration screen.
 
 ## Troubleshooting
 
 ### Motors not spinning when armed
 
 If the PX4 Firmware arms but the motors do not start to rotate, check that parameter `UAVCAN_ENABLE=3` to use DroneCAN ESCs.
-If the motors do not start spinning before thrust is increased, check `UAVCAN_ESC_IDLT=1`.
+If the motors do not start spinning before thrust is increased, use [Acutator > Actuator Testing](../config/actuators.md#actuator-testing) to confirm that the motor outputs are set to the correct minimum values.
 
 ### DroneCAN devices dont get node ID/Firmware Update Fails
 

--- a/en/peripherals/vesc.md
+++ b/en/peripherals/vesc.md
@@ -41,16 +41,13 @@ Connect the ESCs to the Pixhawk CAN bus. Power up the entire vehicle using a bat
 
 ### PX4 Configuration
 
-(Optional) Set [UAVCAN_ESC_IDLT](../advanced_config/parameter_reference.md#UAVCAN_ESC_IDLT) to 1 in order to ensure that the motors are always running at least at the idle throttle while the system is armed.
-
-:::note
-Some systems will not benefit from this behavior, e.g. glider drones).
-:::
+Assign motors to outputs using the [Acutator](../config/actuators.md#actuator-testing) configuration screen.
 
 ## Troubleshooting
 
 See [DroneCAN Troubleshooting](README.md#troubleshooting).
 
 ## Further Information
+
 * [VESC Project ESCs](https://vesc-project.com/)
 * [Benjamin Vedder's blog](http://vedder.se) (project owner)


### PR DESCRIPTION
This removes the UAVCAN_ESC_IDLT param, gone in PX4 v1.14.

@bkueng I have assumed that instead of using this you simply run actuator tests and set the minimum output values appropriately - right?

