### PR TITLE
Update uorb top documentation re: Mavlink Console

### DIFF
--- a/en/middleware/uorb.md
+++ b/en/middleware/uorb.md
@@ -102,6 +102,10 @@ For more information see: [Sensor/Topic Debugging](../debug/sensor_uorb_topic_de
 
 ### uorb top Command
 
+:::note
+`uorb top` has been known to have issues when operating over the Mavlink Console, and may not start. The [PX4 System Console](../debug/system_console.md) is generally more reliable when using `uorb top`
+:::
+
 The command `uorb top` shows the publishing frequency of each topic in real-time:
 
 ```sh
@@ -122,7 +126,6 @@ sensor_baro                          0    1   42     0 1
 sensor_combined                      0    6  242   636 1
 ```
 The columns are: topic name, multi-instance index, number of subscribers, publishing frequency in Hz, number of lost messages per second (for all subscribers combined), and queue size.
-
 
 ## Multi-instance
 

--- a/en/middleware/uorb.md
+++ b/en/middleware/uorb.md
@@ -127,6 +127,7 @@ sensor_combined                      0    6  242   636 1
 ```
 The columns are: topic name, multi-instance index, number of subscribers, publishing frequency in Hz, number of lost messages per second (for all subscribers combined), and queue size.
 
+
 ## Multi-instance
 
 uORB provides a mechanism to publish multiple independent instances of the same topic through `orb_advertise_multi`.


### PR DESCRIPTION
Edit the `uorb top` documentation to reflect that the command does not work reliably in the Mavlink Console. This is in response to @AlexKlimaj's comment on Discord recently after I was unable to run `uorb top` over the Mavlink Console on a Pixhawk 6X running PX4 1.13.2.

If this is still applicable to main then this change should likely be applied there, too.