### PR TITLE
ROS2 note about MAVROS and better companion computer integration

### DIFF
--- a/en/companion_computer/README.md
+++ b/en/companion_computer/README.md
@@ -25,7 +25,7 @@ The following boards are known to provide a good integration with PX4:
 - [Holybro Pixhawk RPI CM4 Baseboard](../companion_computer/holybro_pixhawk_rpi_cm4_baseboard.md)
 
 
-## Supported Companion Computers
+## Companion Computer Options
 
 PX4 can be used with computers that can be configured to communicate via MAVLink or microROS/microDDS over over a serial port (or Ethernet port, if present).
 
@@ -49,7 +49,7 @@ Drone APIs and SDKs allow you to write software that can control PX4.
 Popular alternatives include:
 
 - [MAVSDK](https://mavsdk.mavlink.io/main/en/index.html) - libraries in various programming languages to interface with MAVLink systems such as drones, cameras or ground systems.
-- [ROS 2](../ros/ros2.md) to communicate to ROS 2 nodes ( may also be used).
+- [ROS 2](../ros/ros2.md) to communicate to ROS 2 nodes (may also be used).
 - [ROS 1 and MAVROS](../ros/mavros_installation.md)
 
 MAVSDK is generally easier to learn and use, while ROS provides more pre-written software for advanced cases like computer vision. 
@@ -65,7 +65,6 @@ You can also write your own custom MAVLink libraries from scratch:
 You will need a router if you need to bridge MAVLink from the vehicle to a ground station or IP network, or if you need multiple connections:
 - [MAVLink Router](https://github.com/intel/mavlink-router) (recommended)
 - [MAVProxy](https://ardupilot.org/mavproxy/)
-
 
 ## Ethernet Setup
 

--- a/en/companion_computer/pixhawk_companion.md
+++ b/en/companion_computer/pixhawk_companion.md
@@ -22,10 +22,13 @@ These instructions explain how to setup the connection if you're not using Ether
 
 ### Pixhawk Configuration
 
-PX4 is configured by default to connect to a companion computer connected to the `TELEM 2` serial port.
-No additional PX4-side configuration should be required if you use this port
+PX4 expects companion computers to connect via `TELEM2` for offboard control.
+The port is configured by default to interface using MAVLink.
 
-To enable MAVLink to connect on another port see [MAVLink Peripherals (GCS/OSD/Companion)](../peripherals/mavlink_peripherals.md) and [Serial Port Configuration](../peripherals/serial_configuration.md).
+If using MAVLink, no other PX4-side configuration should be required.
+To use MAVLink on another port, and/or disable it on `TELEM2`, see [MAVLink Peripherals (GCS/OSD/Companion)](../peripherals/mavlink_peripherals.md) and [Serial Port Configuration](../peripherals/serial_configuration.md).
+
+To use [ROS 2/XRCE-DDS](../ros/ros2_comm.md) instead of MAVLink on `TELEM2`, disable MAVLink on the port and then enable the XRCE-DDS client on `TELEM2`(see [XRCE-DDS > Starting the client](/middleware/xrce_dds.md#starting-the-client)).
 
 ### Serial Port Hardware Setup
 
@@ -38,8 +41,8 @@ Use a level shifter.
 In most cases the accessible hardware serial ports already have some function (modem or console) associated with them and need to be *reconfigured in Linux* before they can be used.
 :::
 
-The safe bet is to use an FTDI Chip USB-to-serial adapter board and the wiring below.
-This always works and is easy to set up.
+A safe and easy to set up option is to use an FTDI Chip USB-to-serial adapter board to connect from `TELEM2` on the Pixhawk to the USB port on the companion computer.
+The `TELEM2` to FTDI wiring map is shown below.
 
 TELEM2 | | FTDI | &nbsp;
 --- | --- | --- | ---
@@ -50,10 +53,14 @@ TELEM2 | | FTDI | &nbsp;
 5 | RTS (out)| 2 | FTDI CTS (brown) (in)
 6 | GND     | 1 | FTDI GND (black)
 
-### Serial Port Software setup on Linux
+You may also be able to directly connect `TELEM2` directly to a companion computer serial port.
+This is demonstrated for the Raspberry Pi in [Raspberry Pi Companion with Pixhawk](../companion_computer/pixhawk_rpi.md).
+
+### USB Serial Port Software setup on Linux
 
 On Linux the default name of a USB FTDI would be like `\dev\ttyUSB0`.
-If you have a second FTDI linked on the USB or an Arduino, it will registered as `\dev\ttyUSB1`. To avoid the confusion between the first plugged and the second plugged, we recommend you to create a symlink from `ttyUSBx` to a friendly name, depending on the Vendor and Product ID of the USB device. 
+If you have a second FTDI linked on the USB or an Arduino, it will registered as `\dev\ttyUSB1`.
+To avoid the confusion between the first plugged and the second plugged, we recommend you to create a symlink from `ttyUSBx` to a friendly name, depending on the Vendor and Product ID of the USB device. 
 
 Using `lsusb` we can get the vendor and product IDs.
 

--- a/en/ros/README.md
+++ b/en/ros/README.md
@@ -13,11 +13,16 @@ The PX4 development team recommend that all users [upgrade to ROS 2](../ros/ros2
 
 ## ROS Setups
 
-PX4 supports both the "original" ROS and ROS 2, with the following configurations:
+PX4 supports both ROS 2 and ROS 1, with the following configurations:
 
 - **[ROS 2](../ros/ros2.md): (Recommended)** PX4 and ROS 2 communicate over the [PX4-ROS 2 bridge](../ros/ros2_comm.md), an interface that provides a direct bridge between PX4 uORB messages and ROS 2 DDS messages/types.
   This effectively allows direct access to PX4 internals from ROS 2 workflows and nodes in realtime.
 - **[ROS 1 via MAVROS](../ros/ros1.md):** PX4 and ROS 1 communicate over [MAVLink](../middleware/mavlink.md), using the [MAVROS](../ros/mavros_installation.md) package to bridge ROS topics to MAVLink.
+
+:::note
+ROS 2 can also connect with PX4 using [MAVROS](https://github.com/mavlink/mavros/tree/ros2/mavros) (instead of XRCE-DDS).
+This option is supported by the MAVROS project.
+:::
 
 Note that ROS 2 can be installed on Ubuntu Linux, macOS, Windows, while ROS 1 is only available on Linux.
 Although it might work on the other platforms, PX4 primarily tests and documents ROS on _Linux_.

--- a/en/ros/ros2.md
+++ b/en/ros/ros2.md
@@ -9,8 +9,11 @@ The PX4 development team highly recommend that you use/migrate to this version o
 
 Communication between ROS 2 and PX4 uses middleware that implements the [XRCE-DDS protocol](../middleware/xrce_dds.md).
 This middleware exposes PX4 [uORB messages](../msg_docs/README.md) as ROS 2 messages and types, effectively allowing direct access to PX4 from ROS 2 workflows and nodes.
-The middleware uses UORB message definitions to generate code to serialise and deserialise the messages heading in and out of PX4.
+The middleware uses uORB message definitions to generate code to serialise and deserialise the messages heading in and out of PX4.
 These same message definitions are used in ROS 2 applications to allow the messages to be interpretted.
+
+To use the [ROS 2](../ros/ros2_comm.md) over XRCE-DDS effectively, you must (at time of writing) have a reasonable understanding of the PX4 internal architecture and conventions, which differ from those used by ROS.
+In the near term future we plan to provide ROS 2 APIs to abstract PX4 conventions, along with examples demonstrating their use.
 
 The main topics in this section are:
 - [ROS 2 User Guide](../ros/ros2_comm.md): A PX4-centric overview of ROS 2, covering installation, setup, and how to build ROS 2 applications that communicate with PX4.
@@ -21,13 +24,10 @@ ROS 2 is officially supported only on Linux platforms.
 Ubuntu 20.04 LTS is the official supported distribution.
 :::
 
+
 :::note
-To use the [ROS 2](../ros/ros2_comm.md) effectively you must (at time of writing) have a reasonable understanding of the PX4 internal architecture and conventions.
-
-This contrasts with ROS 1, which communicates with PX4 via MAVROS/MAVLink, hiding PX4's internal architecture and many of its conventions (e.g. frame and unit conversions).
-
-ROS 2 (and the bridge) will become easier to use as the development team provide ROS 2 APIs to abstract PX4 conventions, along with examples demonstrating their use.
-These are planned in the near-term PX4 roadmap.
+ROS 2 can also connect with PX4 using [MAVROS](https://github.com/mavlink/mavros/tree/ros2/mavros) (instead of XRCE-DDS).
+This option is supported by the MAVROS project.
 :::
 
 
@@ -35,5 +35,4 @@ These are planned in the near-term PX4 roadmap.
 
 - [ROS 2 User Guide](../ros/ros2_comm.md)
 - [XRCE-DDS (PX4-ROS 2/DDS Bridge)](../middleware/xrce_dds.md): PX4 middleware for connecting to ROS 2.
-- **ROS 1 using ROS 2 as a bridge:** The official ROS 1 Bridge package ([ros1_bridge](https://github.com/ros2/ros1_bridge)) allows ROS 1 and ROS 2 applications to be used in a single setup.
 


### PR DESCRIPTION
This notes that you can do ROS2 over MAVROS. 

For the top level Pixhawk companion computer doc, it also fixes the MAVLink focus to it is more clear that you can use ROS2 or MAVLink. 
It further makes it clear that FTDI is one option to connect to a companion - and points to the new RPi companion doc to explain how you might connect to the RPi GPIO ports.