### PR TITLE
Update building_px4.md

### DIFF
--- a/zh/dev_setup/building_px4.md
+++ b/zh/dev_setup/building_px4.md
@@ -13,9 +13,7 @@ The PX4 source code is stored on Github in the [PX4/PX4-Autopilot](https://githu
 To get the *very latest* ("main") version onto your computer, enter the following command into a terminal:
 
 ```sh
-git clone --recursive https://github.com/google/bloaty.git /tmp/bloaty \
-      && cd /tmp/bloaty && cmake -GNinja . && ninja bloaty && cp bloaty /usr/local/bin/ \
-      && rm -rf /tmp/*
+git clone https://github.com/PX4/PX4-Autopilot.git --recursive
 ```
 
 :::note


### PR DESCRIPTION
When, I was browsing the documentation translation in Chinese,I noticed an simple but dangerous error in "Download the PX4 Source Code" section. The command is obviously wrong. It points to another repository ([google/bloaty](https://github.com/google/bloaty)).

I have made the necessary corrections to it and would like to submit a pull request to merge this change. I have already forked the repository and made the change in my local branch. This problem is easy to correct, but it make me thought whether we should make more check before update the translation.

By the way, this is the first time I open a pull request. If I have made a mistake, please let me know. Thank you for your attention to this matter.