### PR TITLE
Mission.md: remove reference to MIS_DIST_WPS

### DIFF
--- a/en/flight_modes/mission.md
+++ b/en/flight_modes/mission.md
@@ -76,7 +76,6 @@ If any of the checks fail, the user is notified and it is not possible to start 
 A subset of the most important checks are listed below:
 
 - First mission item too far away from vehicle ([MIS_DIST_1WP](#MIS_DIST_1WP))
-- Distance between two subsequent items is too large ([MIS_DIST_WPS](#MIS_DIST_WPS))
 - Any mission item conflicts with a plan or safety geofence
 - More than one land start mission item defined ([MAV_CMD_DO_LAND_START](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_LAND_START))
 - A fixed-wing landing has an infeasible slope angle ([FW_LND_ANG](#FW_LND_ANG))
@@ -112,7 +111,6 @@ Parameters related to [mission feasibility checks](#mission-feasibility-checks):
 Parameter | Description
 --- | ---
 <a id="MIS_DIST_1WP"></a>[MIS_DIST_1WP](../advanced_config/parameter_reference.md#MIS_DIST_1WP) | The mission will not be started if the current waypoint is more distant than this value from the home position. Disabled if value is 0 or less.
-<a id="MIS_DIST_WPS"></a>[MIS_DIST_WPS](../advanced_config/parameter_reference.md#MIS_DIST_WPS) | The mission will not be started if any distance between two subsequent waypoints is greater than this value. Disabled if value is 0 or less.
 <a id="FW_LND_ANG"></a>[FW_LND_ANG](../advanced_config/parameter_reference.md#FW_LND_ANG) | Maximum landing slope angle.
 <a id="MIS_TKO_LAND_REQ"></a>[MIS_TKO_LAND_REQ](../advanced_config/parameter_reference.md#MIS_TKO_LAND_REQ) | Mission takeoff/landing requirement configuration. FW and VTOL both have it set to 2 by default, which means that the mission has to contain a landing.
 


### PR DESCRIPTION
Was removed on the PX4 side with https://github.com/PX4/PX4-Autopilot/pull/21262.