### PR TITLE
simulation: fix last rtps in hyperlink

### DIFF
--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -101,7 +101,7 @@ The different parts of the system connect via UDP, and can be run on either the 
   PX4 on SITL and the simulator can run on either the same computer or different computers on the same network.
   :::note
   Simulators can also use the *microdds bridge* ([XRCE-DDS](../middleware/xrce_dds.md)) to directly interact with PX4 (i.e. via [UORB topics](../middleware/uorb.md) rather than MAVLink).
-  This approach *may* used by Gazebo Classic for [multi-vehicle simulation](../sim_gazebo_classic/multi_vehicle_simulation_gazebo.md#build-and-test-rtps-dds).
+  This approach *may* used by Gazebo Classic for [multi-vehicle simulation](../sim_gazebo_classic/multi_vehicle_simulation_gazebo.md#build-and-test-xrce-dds).
   :::
 * PX4 uses the normal MAVLink module to connect to ground stations and external developer APIs like MAVSDK or ROS
   - Ground stations listen to PX4's remote UDP port: `14550`


### PR DESCRIPTION
This should be the last remaining RTPS reference to be removed.