### PR TITLE
flaw checker - run on pull_request target - fix flaw running on forks

### DIFF
--- a/.github/workflows/flaw_checker.yml
+++ b/.github/workflows/flaw_checker.yml
@@ -2,9 +2,9 @@ name: Check for flaws
 # So far:
   # Modifications of translations files
   # Broken internal links
-
+    
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 jobs:


### PR DESCRIPTION
This attempts to allow commenting on pull requests originating from forks. 