### PR TITLE
Update kakuteh7.md

### DIFF
--- a/en/flight_controller/kakuteh7.md
+++ b/en/flight_controller/kakuteh7.md
@@ -26,7 +26,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - OSD: AT7456E
 - Onboard Bluetooth chip: Disabled with PX4
 - 2x JST-SH1.0_8pin port (For Single or 4in1 ESCs, x8/Octocopter plug & play compatible)
-- 1x JST-GH1.5_6pin port (For HD System like Caddx Vista & Air Unit)
+- 1x JST-GH1.25_6pin port (For HD System like Caddx Vista & Air Unit)
 - Battery input voltage: 2S - 8S
 - BEC 5V 2A Cont.
 - BEC 9V 1.5A Cont.


### PR DESCRIPTION
Fixing a typo in one of the connector specifications. It is currently listed as JST-GH1.5 but the Holybro docs (and physical measurement) show JST-GH1.25.