### PR TITLE
Update computer vision docs

### DIFF
--- a/en/advanced/computer_vision.md
+++ b/en/advanced/computer_vision.md
@@ -13,7 +13,7 @@ PX4 uses computer vision systems (primarily running on [Companion Computers](../
 
 :::tip
 The [PX4 Vision Autonomy Development Kit](../complete_vehicles/px4_vision_kit.md) (Holybro) is a robust and inexpensive kit for developers working with computer vision on PX4.
-It comes with [PX4 avoidance](https://github.com/PX4/PX4-Avoidance) software pre-installed, and can be used as the base for your own algorithms.
+It comes with no pre-installed software, but does include an example implementation of obstacle avoidance to demonstrate the capabilities of the platform.
 :::
 
 ## Motion Capture

--- a/en/complete_vehicles/px4_vision_kit.md
+++ b/en/complete_vehicles/px4_vision_kit.md
@@ -8,9 +8,7 @@ The kit contains a near-ready-to-fly carbon-fiber quadcopter equipped with a *Pi
 
 :::note
 This vehicle comes with no pre-installed software.
-A pre-imaged USB stick that contains a reference implementation of the [PX4/PX4-Avoidance](../computer_vision/obstacle_avoidance.md) local planner software is provided by *Auterion*.
-This software provides only a very basic example of what you can do with the PX4 Vision Autonomy Kit.
-Developers can use the kit to try out other features provided by the [PX4 Avoidance](https://github.com/PX4/PX4-Avoidance) project, modify the existing code, or experiment with completely new computer vision-based functionality.
+A USB stick is included in the kit with an example of an [obstacle avoidance](../computer_vision/obstacle_avoidance.md) feature implementation, based on the [PX4 Avoidance](https://github.com/PX4/PX4-Avoidance) project. This example is intended as a reference only and serves to demonstrate the capabilities of the platform. The software is not compatible with the latest version of PX4, nor is it actively maintained or supported.
 :::
 
 The guide explains the minimal additional setup required to get the vehicle ready to fly (installing an RC system and battery). It also covers the first flight, and how to get started with modifying the computer vision code.
@@ -93,7 +91,7 @@ The PX4 Vision DevKit contains following components:
   - Telemetry: ESP8266 connected to flight controller (attached to external antenna #2). Enables wireless connection to the ground station.
 
 
-- A USB2.0 stick with pre-flashed software provided by Auterion that bundles:
+- A USB2.0 stick with pre-flashed software that bundles:
   - Ubuntu 18.04 LTS
   - ROS Melodic
   - Occipital Structure Core ROS driver

--- a/en/computer_vision/README.md
+++ b/en/computer_vision/README.md
@@ -17,7 +17,7 @@ PX4 uses computer vision systems (primarily running on [Companion Computers](../
 
 :::tip
 The [PX4 Vision Autonomy Development Kit](../complete_vehicles/px4_vision_kit.md) (Holybro) is a robust and inexpensive kit for developers working with computer vision on PX4.
-It comes with [PX4 avoidance](https://github.com/PX4/PX4-Avoidance) software pre-installed, and can be used as the base for your own algorithms.
+It comes with no pre-installed software, but does include an example implementation of obstacle avoidance to demonstrate the capabilities of the platform.
 :::
 
 ## External Resources

--- a/en/computer_vision/obstacle_avoidance.md
+++ b/en/computer_vision/obstacle_avoidance.md
@@ -9,15 +9,13 @@ Obstacle avoidance is intended for automatic modes, and is currently supported f
 
 This topic explains how the feature is set up and enabled in both modes.
 
-@[youtube](https://youtu.be/PrGt7pKj3tI)
-
 
 ## Limitations/Capabilities
 
 - The maximum speed for obstacle avoidance is currently approximately 3 m/s (due to the cost of computing the avoidance path).
 
   :::note
-  Obstacle avoidance can use the *local planner* planner emits messages at ~30Hz and can move at around 3 m/s) or global planner (emits messages at ~10Hz and mission speed with obstacle avoidance is around 1-1.5 m/s).
+  Obstacle avoidance can use the *local planner* (emits messages at ~30Hz and can move at around 3 m/s) or *global planner* (emits messages at ~10Hz and mission speed with obstacle avoidance is around 1-1.5 m/s).
   :::
 
 
@@ -47,10 +45,10 @@ Mission behaviour with obstacle avoidance enabled is *slightly different* to the
 The difference when avoidance is active are:
 - A waypoint is "reached" when the vehicle is within the acceptance radius, regardless of its heading.
   - This differs from normal missions, in which the vehicle must reach a waypoint with a certain heading (i.e. in a "close to" straight line from the previous waypoint). This constraint cannot be fulfilled when obstacle avoidance is active because the obstacle avoidance algorithm has full control of the vehicle heading, and the vehicle always moves in the current field of view. 
-- PX4 starts emitting a new current/next waypoint once the previous waypoint is reached (i.e. as soon as vehicle enters its acceptance radius).
-- If a waypoint is *inside* an obstacle it may unreachable (and the mission will be stuck).
+- PX4 starts emitting a new current/next waypoint once the previous waypoint is reached (i.e. as soon as the vehicle enters its acceptance radius).
+- If a waypoint is *inside* an obstacle it may be unreachable (and the mission will be stuck).
   - If the vehicle projection on the line previous-current waypoint passes the current waypoint, the acceptance radius is enlarged such that the current waypoint is set as reached
-  - If the vehicle within the x-y acceptance radius, the altitude acceptance is modified such that the mission progresses (even if it is not in the altitude acceptance radius).
+  - If the vehicle is within the x-y acceptance radius, the altitude acceptance is modified such that the mission progresses (even if it is not in the altitude acceptance radius).
 - The original mission speed (as set in *QGroundControl*/PX4) is ignored.
   The speed will be determined by the avoidance software:
   - *local planner* mission speed is around 3 m/s.
@@ -84,7 +82,4 @@ The interface (messages sent) between PX4 and the companion are *exactly* the sa
 ## Supported Hardware
 
 Tested companion computers and cameras are listed in [PX4/PX4-Avoidance](https://github.com/PX4/PX4-Avoidance#run-on-hardware).
-
-<!-- ## Further Information -->
-<!-- @mrivi is expert! -->
 

--- a/en/computer_vision/safe_landing.md
+++ b/en/computer_vision/safe_landing.md
@@ -8,7 +8,6 @@ It can also be used for VTOL vehicles in MC mode.
 If commanded to land, the vehicle first descends to a height where it can measure the surface (companion computer `loiter_height` parameter).
 If the landing area is not sufficiently flat, the vehicle moves outwards in a square-spiral pattern, periodically stopping to re-check the terrain for a landing spot that isn't too rough.
 
-@[youtube](https://youtu.be/9SuJYcT0Mgc)
 
 ## Limitations/Capabilities
 

--- a/en/computer_vision/visual_inertial_odometry.md
+++ b/en/computer_vision/visual_inertial_odometry.md
@@ -5,18 +5,22 @@ It is commonly used to navigate a vehicle in situations where GPS is absent or u
 
 VIO uses [Visual Odometry](https://en.wikipedia.org/wiki/Visual_odometry) to estimate vehicle *pose* from camera images, combined with inertial measurements from the vehicle IMU (to correct for errors associated with rapid vehicle movement resulting in poor image capture).
 
-This topic shows how to set up PX4 and a companion computer to use the *supported* VIO setup.
+This topic gives guidance on configuring PX4 and a companion computer for a VIO setup.
 
 :::note
-This (supported) solution uses ROS for routing VIO information to PX4.
-PX4 itself does not care about the source of messages, provided they are provided via the appropriate [MAVLink Interface](../ros/external_position_estimation.md#px4-mavlink-integration).
+The suggested setup uses ROS for routing VIO information to PX4.
+However, PX4 itself does not care about the source of messages, provided they are provided via the appropriate [MAVLink Interface](../ros/external_position_estimation.md#px4-mavlink-integration).
 :::
 
-<a id="supported_setup"></a>
-## Supported Setup
 
-The supported setup uses the [T265 Intel Realsense Tracking Camera](../peripherals/camera_t265_vio.md) and ROS (running on a companion computer) to supply odometry information to PX4.
-The Auterion [VIO bridge ROS node](https://github.com/Auterion/VIO_bridge) provides a bridge between this (particular) camera and ROS.
+
+<a id="suggested_setup"></a>
+## Suggested Setup
+
+A hardware and software setup for VIO is suggested in the sections below as an illustration of how to interface a VIO system with PX4. It makes use of an off-the-shelf tracking camera and a companion computer running ROS.
+ROS is used to read odometry information from the camera and supply it to PX4.
+
+An example of a suitable tracking camera is the [Intel® RealSense™ Tracking Camera T265](../peripherals/camera_t265_vio.md).
 
 
 
@@ -24,55 +28,44 @@ The Auterion [VIO bridge ROS node](https://github.com/Auterion/VIO_bridge) provi
 
 Attach the camera to the companion computer and mount it to the frame:
 
-- Connect the [T265 Intel Realsense Tracking Camera](../peripherals/camera_t265_vio.md) using the supplied cable.
 - Mount the camera with lenses pointing down if at all possible (default).
-- The camera is very sensitive to vibration; a soft mounting is recommended (e.g. using vibration isolation foam).
+- Cameras are typically very sensitive to vibration; a soft mounting is recommended (e.g. using vibration isolation foam).
 
 
-### ROS/VIO Setup
 
-To setup the Bridge, ROS and PX4:
+### Companion Setup
+
+To setup ROS and PX4:
 - On the companion computer, install and configure [MAVROS](../ros/mavros_installation.md).
-- Get the Auterion [VIO bridge ROS node](https://github.com/Auterion/VIO_bridge):
-  - Clone this repository in your catkin workspace.
-    ```
-	cd ~/catkin_ws/src
-	git clone https://github.com/Auterion/VIO.git
-	```
-  - Build the package:
-    ```
-	cd ~/catkin_ws/src
-	catkin build px4_realsense_bridge
-	```
-- Configure the camera orientation if needed:
-  - The VIO bridge doesn't require any configuration if the camera is mounted with the lenses facing down (the default).
-  - For any other orientation modify [bridge_mavros.launch](https://github.com/Auterion/VIO/blob/master/launch/bridge_mavros.launch) in the section below:
-    ```xml
-    <node pkg="tf" type="static_transform_publisher" name="tf_baseLink_cameraPose"
-        args="0 0 0 0 1.5708 0 base_link camera_pose_frame 1000"/>
-    ```
-   This is a static transform that links the camera ROS frame `camera_pose_frame` to the mavros drone frame `base_link`.
-   - the first three `args` specify *translation* x,y,z in metres from the center of flight controller to camera.
-     For example, if the camera is 10cm in front of the controller and 4cm up, the first three numbers would be : [0.1, 0, 0.04,...]
-   - the next three `args` specify rotation in radians (yaw, pitch, roll).
-     So `[... 0, 1.5708, 0]` means pitch down by 90deg (facing the ground). Facing straight forward would be [... 0 0 0].
-  
+- Implement and run a ROS node to read data from the camera and publish the VIO odometry using MAVROS.
+  - See the [VIO ROS node](#vio_ros_node) section below for details of the requirements for this node.
 - Follow the instructions [below](#ekf2_tuning) for tuning the PX4 EKF2 estimator.
-- Run VIO by calling `roslaunch` with an appropriate launch file: 
-  ```
-  cd ~/catkin_ws/src
-  roslaunch px4_realsense_bridge bridge_mavros.launch
-  ```
-  The launch file options are:
-  - [bridge_mavros.launch](https://github.com/Auterion/VIO/blob/master/launch/bridge_mavros.launch): Use on vehicle in most cases (starts bridge and MAVROS).
-  - [bridge.launch](https://github.com/Auterion/VIO/blob/master/launch/bridge.launch): Use if some other component is responsible for starting MAVROS (only starts bridge)
-  - [bridge_mavros_sitl.launch](https://github.com/Auterion/VIO/blob/master/launch/bridge_mavros_sitl.launch):Use for simulation (starts bridge, MAVROS, SITL)
 - Verify the connection to the flight controller.
 
   :::tip
   You can use the *QGroundControl* [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_inspector.html) to verify that you're getting `ODOMETRY` or `VISION_POSITION_ESTIMATE` messages (or check for `HEARTBEAT` messages that have the component id 197 (`MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY`)).
   :::
-- [Verify that VIO is Setup Correctly](#verify_estimate) before your first flight!
+- [Verify that VIO is set up correctly](#verify_estimate) before your first flight!
+
+
+
+<a id="vio_ros_node"></a>
+### ROS VIO node
+
+In this suggested setup, a ROS node is required to
+1. interface with the chosen camera or sensor hardware,
+2. produce odometry messages containing the position estimate, which will be sent to PX4 using MAVROS, and
+3. publish messages to indicate the VIO system status.
+
+The implementation of the ROS node will be specific to the camera used and will need to be developed to use the interface and drivers appropriate for the camera.
+
+The odometry messages should be of the type [`nav_msgs/Odometry`](http://docs.ros.org/en/noetic/api/nav_msgs/html/msg/Odometry.html) and published to the topic `/mavros/odometry/out`.
+
+System status messages of the type [`mavros_msgs/CompanionProcessStatus`](https://github.com/mavlink/mavros/blob/master/mavros_msgs/msg/CompanionProcessStatus.msg) should be published to the topic `/mavros/companion_process/status`. These should identify the component as `MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY` (197) and indicate the `state` of the system. Recommended status values are:
+
+- `MAV_STATE_ACTIVE` when the VIO system is functioning as expected,
+- `MAV_STATE_CRITICAL` when the VIO system is functioning, but with low confidence, and
+- `MAV_STATE_FLIGHT_TERMINATION` when the system has failed or the estimate confidence is unacceptably low.
 
 
 
@@ -86,7 +79,7 @@ Parameter | Setting for External Position Estimation
 [EKF2_EV_CTRL](../advanced_config/parameter_reference.md#EKF2_EV_CTRL) | Set *horizontal position fusion*, *vertical vision fusion*, *velocity fusion*, and *yaw fusion* according to your desired fusion model.
 [EKF2_HGT_REF](../advanced_config/parameter_reference.md#EKF2_HGT_REF) | Set to *Vision* to use the vision as the reference sensor for altitude estimation.
 [EKF2_EV_DELAY](../advanced_config/parameter_reference.md#EKF2_EV_DELAY) | Set to the difference between the timestamp of the measurement and the "actual" capture time. For more information see [below](#tuning-EKF2_EV_DELAY).
-[EKF2_EV_POS_X](../advanced_config/parameter_reference.md#EKF2_EV_POS_X), [EKF2_EV_POS_Y](../advanced_config/parameter_reference.md#EKF2_EV_POS_Y), [EKF2_EV_POS_Z](../advanced_config/parameter_reference.md#EKF2_EV_POS_Z) | Set the position of the vision sensor with respect to the vehicles body frame.
+[EKF2_EV_POS_X](../advanced_config/parameter_reference.md#EKF2_EV_POS_X), [EKF2_EV_POS_Y](../advanced_config/parameter_reference.md#EKF2_EV_POS_Y), [EKF2_EV_POS_Z](../advanced_config/parameter_reference.md#EKF2_EV_POS_Z) | Set the position of the vision sensor with respect to the vehicle's body frame.
 
 These can be set in *QGroundControl* > **Vehicle Setup > Parameters > EKF2** (remember to reboot the flight controller in order for parameter changes to take effect).
 
@@ -100,9 +93,9 @@ For more detailed/additional information, see: [ECL/EKF Overview & Tuning > Exte
 [EKF2_EV_DELAY](../advanced_config/parameter_reference.md#EKF2_EV_DELAY) is the *Vision Position Estimator delay relative to IMU measurements*.
 In other words, it is the difference between the vision system timestamp and the "actual" capture time that would have been recorded by the IMU clock (the "base clock" for EKF2).
 
-Technically this can be set to 0 if there is correct timestamping (not just arrival time) and timesync (e.g NTP) between MoCap and (for example) ROS computers.
+Technically this can be set to 0 if there is correct timestamping (not just arrival time) and timesync (e.g. NTP) between MoCap and (for example) ROS computers.
 In reality, this may need some empirical tuning because delays in the communication chain are very setup-specific.
-It is rare that a system is setup with an entirely synchronised chain!
+It is rare that a system is set up with an entirely synchronised chain!
 
 A rough estimate of the delay can be obtained from logs by checking the offset between IMU rates and the EV rates:
 
@@ -124,13 +117,13 @@ Perform the following checks to verify that VIO is working properly *before* you
   PX4 will then stream back the received external pose as MAVLink [ODOMETRY](https://mavlink.io/en/messages/common.html#ODOMETRY) messages.
   You can check these MAVLink messages with the *QGroundControl* [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_inspector.html)
 * Yaw the vehicle until the quaternion of the `ODOMETRY` message is very close to a unit quaternion (w=1, x=y=z=0).
-  * At this point the body frame is aligned with the reference frame of the external pose system.
+  * At this point, the body frame is aligned with the reference frame of the external pose system.
   * If you do not manage to get a quaternion close to the unit quaternion without rolling or pitching your vehicle, your frame probably still has a pitch or roll offset.
     Do not proceed if this is the case and check your coordinate frames again.
-* Once aligned you can pick the vehicle up from the ground and you should see the position's z coordinate decrease.
-  Moving the vehicle in forward direction, should increase the position's x coordinate.
-  While moving the vehicle to the right should increase the y coordinate.
-* Check that linear velocities in the message are in expressed in the *FRD* body frame reference frame.
+* Once aligned, you can pick the vehicle up from the ground and you should see the position's z coordinate decrease.
+  Moving the vehicle in the forward direction should increase the position's x coordinate.
+  Moving the vehicle to the right should increase the y coordinate.
+* Check that linear velocities in the message are expressed in the *FRD* body frame reference frame.
 * Set the PX4 parameter `MAV_ODOM_LP` back to 0.
   PX4 will stop streaming the `ODOMETRY` message back.
 
@@ -144,19 +137,19 @@ If those steps are consistent, you can try your first flight:
 
 1. Put the throttle stick in the middle (the dead zone) so that the vehicle maintains its altitude.
    Raising the stick will increase the reference altitude while lowering the value will decrease it.
-   Similarly the other stick will change position over ground.
-1. Increase the value of the throttle stick and the vehicle will take off, put it back to the middle right after.
+   Similarly, the other stick will change the position over the ground.
+1. Increase the value of the throttle stick and the vehicle will take off. Move it back to the middle immediately afterwards.
 1. Confirm that the vehicle can hold its position.
 
 
 ## Troubleshooting
 
-First make sure MAVROS is able to connect successfully to the flight controller.
+First, make sure MAVROS is able to connect successfully to the flight controller.
 
 If it is connecting properly common problems/solutions are:
 
 - **Problem:** I get drift / flyaways when the drone flies, but not when I carry it around with the props off.
-  - If using the [T265](../peripherals/camera_t265_vio.md) try soft-mounting it (this camera is very sensitive to high frequency vibrations).
+  - If using the [T265](../peripherals/camera_t265_vio.md) try soft-mounting it (this camera is very sensitive to high-frequency vibrations).
 
 - **Problem:** I get toilet-bowling when VIO is enabled.
   - Make sure the orientation of the camera matches the transform in the launch file.

--- a/en/computer_vision/visual_inertial_odometry.md
+++ b/en/computer_vision/visual_inertial_odometry.md
@@ -7,13 +7,6 @@ VIO uses [Visual Odometry](https://en.wikipedia.org/wiki/Visual_odometry) to est
 
 This topic shows how to set up PX4 and a companion computer to use the *supported* VIO setup.
 
-<iframe width="650" height="365" src="https://www.youtube.com/embed/gWtrka2mK7U" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<!-- https://youtu.be/gWtrka2mK7U -->
-
-:::tip
-The [Auterion product video](https://auterion.com/enabling_uav_navigation_in_environments_with_limited_or_no_gps_signal/) above shows a vehicle flying using the [supported setup](#supported_setup).
-:::
-
 :::note
 This (supported) solution uses ROS for routing VIO information to PX4.
 PX4 itself does not care about the source of messages, provided they are provided via the appropriate [MAVLink Interface](../ros/external_position_estimation.md#px4-mavlink-integration).

--- a/en/peripherals/camera_t265_vio.md
+++ b/en/peripherals/camera_t265_vio.md
@@ -1,12 +1,12 @@
-# T265 Intel Realsense Tracking Camera (VIO)
+# Intel® RealSense™ Tracking Camera T265 (VIO)
 
-The [Intel Realsense Tracking Camera T265](https://www.intelrealsense.com/tracking-camera-t265/) provides odometry information that can be used for [VIO](../computer_vision/visual_inertial_odometry.md), augmenting or replacing other positioning systems on PX4.
+The [Intel® RealSense™ Tracking Camera T265](https://www.intelrealsense.com/tracking-camera-t265/) provides odometry information that can be used for [VIO](../computer_vision/visual_inertial_odometry.md), augmenting or replacing other positioning systems on PX4.
 
 :::tip
-This camera is recommended, and is used in the [Visual Inertial Odometry (VIO) > Supported Setup](../computer_vision/visual_inertial_odometry.md#supported_setup).
+This camera is recommended, and is used in the [Visual Inertial Odometry (VIO) > Suggested Setup](../computer_vision/visual_inertial_odometry.md#suggested_setup).
 :::
 
-![Intel Realsense Tracking Camera T265 - Angled Image](../../assets/peripherals/camera_vio/t265_intel_realsense_tracking_camera_photo_angle.jpg)
+![Intel® RealSense™ Tracking Camera T265 - Angled Image](../../assets/peripherals/camera_vio/t265_intel_realsense_tracking_camera_photo_angle.jpg)
 
 
 ## Where to Buy
@@ -16,31 +16,18 @@ This camera is recommended, and is used in the [Visual Inertial Odometry (VIO) >
 
 ## Setup Instructions
 
-The instructions in [Visual Inertial Odometry (VIO)](../computer_vision/visual_inertial_odometry.md) explain how to set up this camera.
-
-At high level:
-- The [VIO bridge ROS node](https://github.com/Auterion/VIO_bridge) provides a bridge between ROS and this camera.
-  This node is only intended for use with this camera.
+At a high level:
+- The [`realsense-ros` wrapper](https://github.com/IntelRealSense/realsense-ros) provided by Intel should be used to extract the raw data from the camera.
 - The camera should be mounted with lenses facing down (default).
-  For other orientations modify [bridge.launch](https://github.com/Auterion/VIO/blob/master/launch/bridge.launch) in the section below:
+  Be sure to specify the camera orientation by publishing the static transform between the `base_link` and `camera_pose_frame` in a ROS launch file, for example:
     ```xml
     <node pkg="tf" type="static_transform_publisher" name="tf_baseLink_cameraPose"
         args="0 0 0 0 1.5708 0 base_link camera_pose_frame 1000"/>
     ```
-   This is a static transform that links the camera ROS frame `camera_pose_frame` to the mavros drone frame `base_link`.
-   - the first three `args` specify *translation* x,y,z in metres from the center of flight controller to camera.
+   This is a static transform that links the camera ROS frame `camera_pose_frame` to the MAVROS drone frame `base_link`.
+   - the first three `args` specify *translation* x,y,z in metres from the center of the flight controller to the camera.
      For example, if the camera is 10cm in front of the controller and 4cm up, the first three numbers would be : [0.1, 0, 0.04,...]
    - the next three `args` specify rotation in radians (yaw, pitch, roll).
-     So `[... 0, 1.5708, 0]` means pitch down by 90deg (facing the ground). Facing straight forward would be [... 0 0 0].
-- The camera is sensitive to high frequency vibrations!
+     So `[... 0, 1.5708, 0]` means pitch down by 90° (facing the ground). Facing straight forward would be [... 0 0 0].
+- The camera is sensitive to high-frequency vibrations!
   It should be soft-mounted with, for example, vibration isolation foam.
-
-
-<span id="launch_files"></span>
-Launch files are provided for a number of different scenarios.
-
-Launch File | Starts | Description
---- | --- | ---
-[bridge_mavros.launch](https://github.com/Auterion/VIO/blob/master/launch/bridge_mavros.launch) | Bridge, MAVROS | Use on vehicle in most cases
-[bridge.launch](https://github.com/Auterion/VIO/blob/master/launch/bridge.launch) | Bridge only | Use if some other component is responsible for starting MAVROS).
-[bridge_mavros_sitl.launch](https://github.com/Auterion/VIO/blob/master/launch/bridge_mavros_sitl.launch) | Bridge, MAVROS, SITL| Use for simulation.


### PR DESCRIPTION
This updates various pages relating to computer vision features. Many were out of date and did not reflect the current level of support and maintenance.

**Specific changes:**

- Clarify that the PX4 Vision Kit does not come with any pre-installed software and that the _reference_ software provided on the side is an example only. It is neither up-to-date nor supported.
- Remove Auterion product videos and any indications that Auterion is the provider/owner of any open-source code.
- Update the VIO docs, as the "VIO bridge" repo that was linked is no longer publicly available and was specific to the T265 tracking camera.
   - The docs now mention that camera but are not specific to it.
   - The guide instead describes what a custom implementation like the previous VIO bridge should look like when developed for any camera.