### PR TITLE
quick_start_pixhawk4: remove outdated motor vs servo connection tip

### DIFF
--- a/en/assembly/quick_start_pixhawk4.md
+++ b/en/assembly/quick_start_pixhawk4.md
@@ -87,7 +87,7 @@ PWR2 | 5v output 3A, connect to *Pixhawk 4* POWER 2
 :::note
 Depending on your airframe type, refer to [Airframe Reference](../airframes/airframe_reference.md) to connect **I/O PWM OUT** and **FMU PWM OUT** ports of *Pixhawk 4* to PM board. 
 **MAIN** outputs in PX4 firmware map to **I/O PWM OUT** port of *Pixhawk 4* whereas **AUX outputs** map to **FMU PWM OUT** of *Pixhawk 4*. 
-For example, **MAIN1** maps to IO_CH1 pin of **I/O PWM OUT** and **AUX1** maps to FMU_CH1 pin of **FMU PWM OUT**. **FMU PWM-IN** of PM board is internally connected to **FMU PWM-OUT**, which is used to drive servos (e.g. aileron, elevator, rudder, elevon, gear, flaps, gimbal, steering). **I/O PWM-IN** of PM board is internally connected to **M1-8**, which is used to drive motors (e.g. throttle in Plane, VTOL and Rover). 
+For example, **MAIN1** maps to IO_CH1 pin of **I/O PWM OUT** and **AUX1** maps to FMU_CH1 pin of **FMU PWM OUT**. **FMU PWM-IN** of PM board is internally connected to **FMU PWM-OUT**. **I/O PWM-IN** of PM board is internally connected to **M1-8**. 
 :::
 
 The following table summarizes how to connect *Pixhawk 4*'s PWM OUT ports to PM board's PWM-IN ports, depending on the Airframe Reference.

--- a/en/assembly/quick_start_pixhawk4.md
+++ b/en/assembly/quick_start_pixhawk4.md
@@ -152,7 +152,8 @@ The vehicle-based radio should be connected to the **TELEM1** port as shown belo
 ![Pixhawk 4/Telemetry Radio](../../assets/flight_controller/pixhawk4/pixhawk4_telemetry_radio.jpg)
 
 
-<span id="sd_card"></span>
+<a id="sd_card"></a>
+
 ## SD Card (Optional)
 
 SD cards are highly recommended as they are needed to [log and analyse flight details](../getting_started/flight_reporting.md), to run missions, and to use UAVCAN-bus hardware.


### PR DESCRIPTION
It's by now (with the new control allocation for example) completely possible to connect servos to FMU and motors to IO, so let's remove this confusing tip.