### PR TITLE
Magnetometer calibration - disconnect USB

### DIFF
--- a/en/config/compass.md
+++ b/en/config/compass.md
@@ -99,7 +99,7 @@ To disable an internal compass:
 ## Debugging
 
 Raw comparison data for magnetometers (in fact, for all sensors) can be logged by setting [SDLOG_MODE=1](../advanced_config/parameter_reference.md#SDLOG_MODE) and [SDLOG_PROFILE=64](../advanced_config/parameter_reference.md#SDLOG_PROFILE).
-See [Logging](/dev_log/logging.md) for more information.
+See [Logging](../dev_log/logging.md) for more information.
 
 ## Further Information
 

--- a/en/config/compass.md
+++ b/en/config/compass.md
@@ -3,7 +3,14 @@
 The compass calibration process configures all connected internal and external [magnetometers](../gps_compass/README.md).
 *QGroundControl* will guide you to position the vehicle in a number of set orientations and rotate the vehicle about the specified axis.
 
+## Overview
+
 You will need to calibrate your compass on first use, and you may need to recalibrate it if the vehicles is ever exposed to a very strong magnetic field, or if it is used in an area with abnormal magnetic characteristics.
+
+:::tip
+Indications of a poor compass calibration include multicopter circling during hover, toilet bowling (circling at increasing radius/spiraling-out, usually constant altitude, leading to fly-way), or veering off-path when attempting to fly straight.
+_QGroundControl_ should also notify the error `mag sensors inconsistent`.
+:::
 
 Two types of compass calibration are available:
 
@@ -12,27 +19,26 @@ Two types of compass calibration are available:
 1. [Partial](#partial-quick-calibration) ("Quick Calibration"): This calibration can be performed as a routine when preparing the vehicle for a flight, after changing the payload, or simply when the compass rose seems inaccurate.
   This type of calibration only estimates the offsets to compensate for a hard iron effect.
 
-:::note
-If you are using an external magnetometer/compass (or a compass integrated into a GPS module) make sure it is [mounted](../assembly/mount_gps_compass.md) as far as possible from other electronics and in a _supported orientation_.
-Instructions for _connecting_ your GPS+compass can be found in [Basic Assembly](../assembly/README.md) for your specific autopilot hardware.
-Once connected, *QGroundControl* will automatically detect the external magnetometer.
-:::
 
-:::tip
-Indications of a poor compass calibration include multicopter circling during hover, toilet bowling (circling at increasing radius/spiraling-out, usually constant altitude, leading to fly-way), or veering off-path when attempting to fly straight.
-:::
+## Performing the Calibration
 
-## Performing the Calibration 
+### Preconditions
 
-### Complete Calibration
-
-The calibration steps are:
+Before starting the calibration:
 
 1. Choose a location away from large metal objects or magnetic fields.
    :::tip
    Metal is not always obvious! Avoid calibrating on top of an office table (often contain metal bars) or next to a vehicle. 
    Calibration can even be affected if you're standing on a slab of concrete with uneven distribution of re-bar.
    :::
+1. Connect via telemetry radio rather than USB if at all possible.
+   USB can potentially cause significant magnetic interference.
+1. If using an external compass (or a combined GPS/compass module), make sure it is [mounted](../assembly/mount_gps_compass.md) as far as possible from other electronics in order to reduce magnetic interference, and in a _supported orientation_.
+
+### Complete Calibration
+
+The calibration steps are:
+
 1. Start *QGroundControl* and connect the vehicle.
 1. Select the **Gear** icon (Vehicle Setup) in the top toolbar and then **Sensors** in the sidebar.
 1. Click the **Compass** sensor button.
@@ -56,6 +62,7 @@ Once you've calibrated the vehicle in all the positions *QGroundControl* will di
 This calibration is similar to the well-known figure-8 compass calibration done on a smartphone:
 
 1. Hold the vehicle in front of you and randomly perform partial rotations on all its axes.
+   2-3 oscillations of ~30 degrees in every direction is usually sufficient.
 1. Wait for the heading estimate to stabilize and verify that the compass rose is pointing to the correct direction (this can take a couple of seconds).
 
 Notes:
@@ -63,8 +70,7 @@ Notes:
 - There is no start/stop for this type of calibration (the algorithm runs continuously when the vehicle is disarmed).
 - The calibration is immediately applied to the data (no reboot is required) but is saved to the calibration parameters after disarming the vehicle only (the calibration is lost if no arming/disarming sequence is performed between calibration and shutdown).
 - The amplitude and the speed of the partial rotations done in step 1 can affect the calibration quality.
-  However, 2-3 oscillations of ~30 degrees in every direction is usually enough.
-
+  Following the advice above is ususally enough.
 
 ## Additional Calibration/Configuration
 
@@ -90,10 +96,15 @@ To disable an internal compass:
 - Then use [CAL_MAGx_PRIO](../advanced_config/parameter_reference.md#CAL_MAG0_PRIO) to disable the compass.
   This can also be used to change the relative priority of a compass.
 
+## Debugging
+
+Raw comparison data for magnetometers (in fact, for all sensors) can be logged by setting [SDLOG_MODE=1](../advanced_config/parameter_reference.md#SDLOG_MODE) and [SDLOG_PROFILE=64](../advanced_config/parameter_reference.md#SDLOG_PROFILE).
+See [Logging](/dev_log/logging.md) for more information.
 
 ## Further Information
 
 - [Peripherals > GPS & Compass](../gps_compass/README.md)
+- [Basic Assembly](../assembly/README.md) (setup guides for each flight controller)
 - [Compass Power Compensation](../advanced_config/compass_power_compensation.md) (Advanced Configuration)
 - [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/SetupView/sensors_px4.html#compass)
 - [PX4 Setup Video - @2m38s](https://youtu.be/91VGmdSlbo4?t=2m38s) (Youtube)

--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -8,6 +8,7 @@ All existing instances of a topic are logged.
 The output log format is [ULog](../dev_log/ulog_file_format.md).
 
 ## Usage
+
 By default, logging is automatically started when arming, and stopped when disarming.
 A new log file is created for each arming session on the SD card.
 To display the current state, use `logger status` on the console.
@@ -15,16 +16,16 @@ If you want to start logging immediately, use `logger on`.
 This overrides the arming state, as if the system was armed.
 `logger off` undoes this.
 
-Use
+For a list of all supported logger commands and parameters, use:
+
 ```
 logger help
 ```
-for a list of all supported logger commands and parameters.
 
 
 ## Configuration
 
-The logging system is configured by default to collect sensible logs for use with [Flight Review](http://logs.px4.io).
+The logging system is configured by default to collect sensible logs for [flight reporting](../getting_started/flight_reporting.md) with [Flight Review](http://logs.px4.io).
 
 Logging may further be configured using the [SD Logging](../advanced_config/parameter_reference.md#sd-logging) parameters.
 The parameters you are most likely to change are listed below.
@@ -35,10 +36,15 @@ Parameter | Description
 [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) | Logging profile. Use this to enable less common logging/analysis (e.g. for EKF2 replay, high rate logging for PID & filter tuning, thermal temperature calibration).
 [SDLOG_MISSION](../advanced_config/parameter_reference.md#SDLOG_MISSION) | Create very small additional "Mission Log".<br>This log can *not* be used with *Flight Review*, but is useful when you need a small log for geotagging or regulatory compliance.
 
-:::note
-*Developers* can further configure what information is logged via the [logger](../modules/modules_system.md#logger) module (you would use this, for example, if you want to log your own topics).
-For more information see: [Logging](../dev_log/logging.md).
-:::
+Useful settings for specific cases:
+
+- Raw sensor data for comparison: [SDLOG_MODE=1](../advanced_config/parameter_reference.md#SDLOG_MODE) and [SDLOG_PROFILE=64](../advanced_config/parameter_reference.md#SDLOG_PROFILE).
+
+### Logger module
+
+_Developers_ can further configure what information is logged via the [logger](../modules/modules_system.md#logger) module.
+This allows, for example, logging of your own uORB topics.
+
 
 ### SD Card Configuration
 
@@ -56,24 +62,26 @@ To specify `<instance>`, `<interval>` must be specified. It can be set to 0 to l
 
 The topics in this file replace all of the default logged topics.
 
-Example : 
+Example :
+
 ```
 sensor_accel 0 0
 sensor_accel 100 1
 sensor_gyro 200
 sensor_mag 200 1
 ```
+
 This configuration will log sensor_accel 0 at full rate, sensor_accel 1 at 10Hz, all sensor_gyro instances at 5Hz and sensor_mag 1 at 5Hz.
 
-
-
 ## Scripts
+
 There are several scripts to analyze and convert logging files in the [pyulog](https://github.com/PX4/pyulog) repository.
 
-
 ## Dropouts
+
 Logging dropouts are undesired and there are a few factors that influence the
 amount of dropouts:
+
 - Most SD cards we tested exhibit multiple pauses per minute.
   This shows itself as a several 100 ms delay during a write command.
   It causes a dropout if the write buffer fills up during this time.
@@ -130,12 +138,14 @@ There are different clients that support ulog streaming:
 - [MAVGCL](https://github.com/ecmnet/MAVGCL)
 
 ### Diagnostics
+
 - If log streaming does not start, make sure the `logger` is running (see above), and inspect the console output while starting.
 - If it still does not work, make sure that MAVLink 2 is used.
   Enforce it by setting `MAV_PROTO_VER` to 2.
 - Log streaming uses a maximum of 70% of the configured MAVLink rate (`-r` parameter).
   If more is needed, messages are dropped.
   The currently used percentage can be inspected with `mavlink status` (1.8% is used in this example):
+
   ```
   instance #0:
           GCS heartbeat:  160955 us ago
@@ -152,5 +162,6 @@ There are different clients that support ulog streaming:
           MAVLink version: 2
           transport protocol: UDP (14556)
   ```
+  
   Also make sure `txerr` stays at 0.
   If this goes up, either the NuttX sending buffer is too small, the physical link is saturated or the hardware is too slow to handle the data.

--- a/en/flight_controller/pixracer.md
+++ b/en/flight_controller/pixracer.md
@@ -221,6 +221,12 @@ To [build PX4](../dev_setup/building_px4.md) for this target:
 make px4_fmu-v4_default
 ```
 
+## Configuration
+
+[Compass calibration](../config/compass.md) should be done with USB disconnected.
+This is always recommended, but is necessary on Pixracer because the USB connection produces particularly large levels of magnetic interference.
+
+Configuration is otherwise the same as for other boards.
 
 ## Credits
 


### PR DESCRIPTION
Fixes #128

USB can cause magnetic interference. This adds a note for Pixracer, which is particularly affected. Also adds removing USB to compass calibration as a precondition "if at all possible", and information on how to get logs. 