### PR TITLE
RTK - fix 2 dronecan modules to have the check mark in table

### DIFF
--- a/en/gps_compass/rtk_gps.md
+++ b/en/gps_compass/rtk_gps.md
@@ -27,16 +27,16 @@ GPS | Yaw Output | [Dual F9P GPS Heading](../gps_compass/u-blox_f9p_heading.md) 
 [Femtones MINI2 Receiver](../gps_compass/rtk_gps_fem_mini2.md) | | | |
 [Freefly RTK GPS](../gps_compass/rtk_gps_freefly.md) (F9P) | | | |
 [CubePilot Here3](https://www.cubepilot.org/#/here/here3) | | | &check; |
-[Holybro H-RTK F9P Helical or Base](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | |&check; | |
-[Holybro DroneCAN H-RTK F9P Helical](https://holybro.com/products/dronecan-h-rtk-f9p-helical) | |&check; | |
+[Holybro H-RTK F9P Helical or Base](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | | &check; | |
+[Holybro DroneCAN H-RTK F9P Helical](https://holybro.com/products/dronecan-h-rtk-f9p-helical) | | &check; | &check; |
 [Holybro H-RTK F9P Rover Lite](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | | | |
-[Holybro DroneCAN H-RTK F9P Rover](https://holybro.com/products/dronecan-h-rtk-f9p-rover) | | | |
+[Holybro DroneCAN H-RTK F9P Rover](https://holybro.com/products/dronecan-h-rtk-f9p-rover) | | | &check; |
 [Holybro H-RTK M8P GNSS](../gps_compass/rtk_gps_holybro_h-rtk-m8p.md) | | | |
 [Holybro H-RTK UM982 GPS](../gps_compass/rtk_gps_holybro_unicore_um982.md) | &check; | | |
 [LOCOSYS Hawk R1](../gps_compass/rtk_gps_locosys_r1.md) | | | |
 [LOCOSYS Hawk R2](../gps_compass/rtk_gps_locosys_r2.md) | &check; | | |
-[Septentrio AsteRx-RIB](../gps_compass/septentrio_asterx-rib.md) |  &check;   |Septentrio dual antenna heading | |&check;
-[Septentrio mosaic-go](../gps_compass/septentrio_mosaic-go.md) |  &check;   |Septentrio dual antenna heading | |&check;
+[Septentrio AsteRx-RIB](../gps_compass/septentrio_asterx-rib.md) |  &check;   |Septentrio dual antenna heading | | &check;
+[Septentrio mosaic-go](../gps_compass/septentrio_mosaic-go.md) |  &check;   |Septentrio dual antenna heading | | &check;
 [SparkFun GPS-RTK2 Board - ZED-F9P](https://www.sparkfun.com/products/15136) | | &check; | |
 [SIRIUS RTK GNSS ROVER (F9P)](https://store-drotek.com/911-sirius-rtk-gnss-rover-f9p.html) | | &check; | |
 [mRo u-blox ZED-F9 RTK L1/L2 GPS](https://store.mrobotics.io/product-p/m10020d.htm) | | &check; | |


### PR DESCRIPTION
Two of the dronecan modules were missing checkmark in the RTK GPS table. 

This comes out of #2573