### PR TITLE
Update cubepilot_cube_orange.md for carrier board pinouts

### DIFF
--- a/en/flight_controller/cubepilot_cube_orange.md
+++ b/en/flight_controller/cubepilot_cube_orange.md
@@ -90,6 +90,7 @@ The manufacturer [Cube Docs](https://docs.cubepilot.org/user-guides/autopilot/th
 ## Pinouts and Schematics
 
 Board schematics and other documentation can be found here: [The Cube Project](https://github.com/proficnc/The-Cube).
+ADSB-in carrier board pinouts: [Doc](https://ardupilot.org/copter/docs/common-thecubeorange-overview.html#the-cube-connector-pin-assignments)
 
 
 ## Ports


### PR DESCRIPTION
Had to look for these for a bit. thought it might be useful to add them here