### PR TITLE
Cube Orange Plus - add pinouts

### DIFF
--- a/en/flight_controller/cubepilot_cube_orange.md
+++ b/en/flight_controller/cubepilot_cube_orange.md
@@ -12,6 +12,10 @@ The [Cube Orange](https://www.cubepilot.com/#/cube/features) flight controller i
 The controller is designed to be used with a domain-specific carrier board in order to reduce the wiring, improve reliability, and ease of assembly.
 For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, while a carrier board for a racer could includes ESCs for the frame of the vehicle.
 
+The ADS-B carrier board includes a customized 1090MHz ADSB-In receiver from uAvionix.
+This provides attitude and location of commercial manned aircraft within the range of Cube.
+This is automatically configured and enabled in the default PX4 firmware.
+
 Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as a reference / backup.
 
 :::tip
@@ -87,17 +91,124 @@ The manufacturer [Cube Docs](https://docs.cubepilot.org/user-guides/autopilot/th
   - 3.3v ADC input
   - Internal microUSB port and external microUSB port extension
 
-## Pinouts and Schematics
-
-Board schematics and other documentation can be found here: [The Cube Project](https://github.com/proficnc/The-Cube).
-
-
 ## Ports
 
 ### Top-Side (GPS, TELEM etc)
 
 ![Cube Ports - Top (GPS, TELEM etc) and Main/AUX](../../assets/flight_controller/cube/cube_ports_top_main.jpg)
 
+
+## Pinouts
+
+#### TELEM1, TELEM2 ports
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC       | +5V
+2 (blk) | TX (OUT)  | +3.3V
+3 (blk) | RX (IN)   | +3.3V
+4 (blk) | CTS (IN)  | +3.3V
+5 (blk) | RTS (OUT) | +3.3V
+6 (blk) | GND       | GND
+
+
+#### GPS1 port
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC           | +5V
+2 (blk) | TX (OUT)      | +3.3V
+3 (blk) | RX (IN)       | +3.3V
+4 (blk) | SCL I2C2      | +3.3V
+5 (blk) | SDA I2C2      | +3.3V
+6 (blk) | Safety Button | GND
+7 (blk) | Button LED    | GND
+8 (blk) | GND           | GND
+
+<!-- check is i2c2 -->
+
+#### GPS2 port
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC      | +5V
+2 (blk) | TX (OUT) | +3.3V
+3 (blk) | RX (IN)  | +3.3V
+4 (blk) | SCL I2C1 | +3.3V
+5 (blk) | SDA I2C1 | +3.3V
+6 (blk) | GND      | GND
+
+
+#### ADC
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC       | +5V
+2 (blk) | ADC IN    | up to +6.6V
+3 (blk) | GND       | GND
+
+
+#### I2C
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC       | +5V
+2 (blk) | SCL       | +3.3 (pullups)
+3 (blk) | SDA       | +3.3 (pullups)
+4 (blk) | GND       | GND
+
+
+#### CAN1 & CAN2
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC      | +5V
+2 (blk) | CAN_H    | +12V
+3 (blk) | CAN_L    | +12V
+4 (blk) | GND      | GND
+
+#### POWER1 & POWER2
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC               | +5V
+2 (red) | VCC               | +5V
+3 (blk) | CURRENT sensing   | +3.3V
+4 (blk) | VOLTAGE sensing   | +3.3V
+5 (blk) | GND               | GND
+6 (blk) | GND               | GND
+
+
+#### USB
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC           | +5V
+2 (blk) | OTG_DP1       | +3.3V
+3 (blk) | OTG_DM1       | +3.3V
+4 (blk) | GND           | GND
+5 (blk) | BUZZER        | Battery voltage
+6 (blk) | FMU Error LED | 
+
+#### SPKT
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (blk) | IN  | 
+2 (blk) | GND | GND
+3 (red) | OUT | +3.3V
+
+
+#### TELEM1, TELEM2
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC       | +5V
+2 (blk) | TX (OUT)  | +3.3V to 5V
+3 (blk) | RX (IN)   | +3.3V to 5V
+4 (blk) | CTS (OUT) | +3.3V to 5V
+5 (blk) | RTS (IN)  | +3.3V to 5V
+6 (blk) | GND       | GND
 
 ## Serial Port Mapping
 
@@ -133,6 +244,11 @@ To [build PX4](../dev_setup/building_px4.md) for this target, open up the termin
 ```
 make cubepilot_cubeorange
 ```
+
+## Schematics
+
+Board schematics and other documentation can be found here: [The Cube Project](https://github.com/proficnc/The-Cube).
+
 
 ## Further Information/Documentation
 

--- a/en/flight_controller/cubepilot_cube_orangeplus.md
+++ b/en/flight_controller/cubepilot_cube_orangeplus.md
@@ -6,11 +6,16 @@ Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or
 :::
 
 The [Cube Orange+](https://www.cubepilot.com/#/cube/features) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems.
+Cube Orange+ is similar to Cube Orange, but has a more powerful dual-core processor (STM32H757, and some different sensors parts.
 
 ![Cube Orange](../../assets/flight_controller/cube/orangeplus/cubepilot_cube_orangeplus_standard_set.jpg)
 
 The controller is designed to be used with a domain-specific carrier board in order to reduce the wiring, improve reliability, and ease of assembly.
 For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, while a carrier board for a racer could includes ESCs for the frame of the vehicle.
+
+The ADS-B carrier board includes a customized 1090MHz ADSB-In receiver from uAvionix.
+This provides attitude and location of commercial manned aircraft within the range of Cube.
+This is automatically configured and enabled in the default PX4 firmware.
 
 Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as a reference / backup.
 

--- a/en/flight_controller/cubepilot_cube_orangeplus.md
+++ b/en/flight_controller/cubepilot_cube_orangeplus.md
@@ -87,16 +87,125 @@ The manufacturer [Cube Docs](https://docs.cubepilot.org/user-guides/autopilot/th
   - 3.3v ADC input
   - Internal microUSB port and external microUSB port extension
 
-## Pinouts and Schematics
-
-Board schematics and other documentation can be found here: [The Cube Project](https://github.com/proficnc/The-Cube).
-
 
 ## Ports
 
 ### Top-Side (GPS, TELEM etc)
 
 ![Cube Ports - Top (GPS, TELEM etc) and Main/AUX](../../assets/flight_controller/cube/cube_ports_top_main.jpg)
+
+
+## Pinouts
+
+#### TELEM1, TELEM2 ports
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC       | +5V
+2 (blk) | TX (OUT)  | +3.3V
+3 (blk) | RX (IN)   | +3.3V
+4 (blk) | CTS (IN)  | +3.3V
+5 (blk) | RTS (OUT) | +3.3V
+6 (blk) | GND       | GND
+
+
+#### GPS1 port
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC           | +5V
+2 (blk) | TX (OUT)      | +3.3V
+3 (blk) | RX (IN)       | +3.3V
+4 (blk) | SCL I2C2      | +3.3V
+5 (blk) | SDA I2C2      | +3.3V
+6 (blk) | Safety Button | GND
+7 (blk) | Button LED    | GND
+8 (blk) | GND           | GND
+
+<!-- check is i2c2 -->
+
+#### GPS2 port
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC      | +5V
+2 (blk) | TX (OUT) | +3.3V
+3 (blk) | RX (IN)  | +3.3V
+4 (blk) | SCL I2C1 | +3.3V
+5 (blk) | SDA I2C1 | +3.3V
+6 (blk) | GND      | GND
+
+
+#### ADC
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC       | +5V
+2 (blk) | ADC IN    | up to +6.6V
+3 (blk) | GND       | GND
+
+
+#### I2C
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC       | +5V
+2 (blk) | SCL       | +3.3 (pullups)
+3 (blk) | SDA       | +3.3 (pullups)
+4 (blk) | GND       | GND
+
+
+#### CAN1 & CAN2
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC      | +5V
+2 (blk) | CAN_H    | +12V
+3 (blk) | CAN_L    | +12V
+4 (blk) | GND      | GND
+
+#### POWER1 & POWER2
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC               | +5V
+2 (red) | VCC               | +5V
+3 (blk) | CURRENT sensing   | +3.3V
+4 (blk) | VOLTAGE sensing   | +3.3V
+5 (blk) | GND               | GND
+6 (blk) | GND               | GND
+
+
+#### USB
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC           | +5V
+2 (blk) | OTG_DP1       | +3.3V
+3 (blk) | OTG_DM1       | +3.3V
+4 (blk) | GND           | GND
+5 (blk) | BUZZER        | Battery voltage
+6 (blk) | FMU Error LED | 
+
+#### SPKT
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (blk) | IN  | 
+2 (blk) | GND | GND
+3 (red) | OUT | +3.3V
+
+
+#### TELEM1, TELEM2
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC       | +5V
+2 (blk) | TX (OUT)  | +3.3V to 5V
+3 (blk) | RX (IN)   | +3.3V to 5V
+4 (blk) | CTS (OUT) | +3.3V to 5V
+5 (blk) | RTS (IN)  | +3.3V to 5V
+6 (blk) | GND       | GND
 
 
 ## Serial Port Mapping
@@ -114,6 +223,7 @@ UART8  | /dev/ttyS5 | GPS2
 <!-- Note: Got ports using https://github.com/PX4/PX4-user_guide/pull/672#issuecomment-598198434 -->
 <!-- https://github.com/PX4/PX4-Autopilot/blob/main/boards/cubepilot/cubeorange/default.px4board -->
 <!-- https://github.com/PX4/PX4-Autopilot/blob/main/boards/cubepilot/cubeorange/nuttx-config/nsh/defconfig#L188-L197 -->
+
 
 ### USB/SDCard Ports
 
@@ -135,6 +245,10 @@ make cubepilot_cubeorangeplus
 The firmware for Cube Orange+ and Cube Orange are not compatible.
 Due to a power feature of the STM32H757 it required [updates in NuttX](https://github.com/PX4/NuttX/pull/214) and therefore a new board config, bootloader, build target, etc.
 :::
+
+## Schematics
+
+Board schematics and other documentation can be found here: [The Cube Project](https://github.com/proficnc/The-Cube).
 
 ## Further Information/Documentation
 


### PR DESCRIPTION
This replaces #2585 by @afwilkin , adding the pinouts.

Many controllers follow the Pixhawk standard for ports now, but not the Cube. So it is worth adding pinouts, because it is really hard to infer them from the schematics as we suggested previously. I also don't want to cross link to ArduPilot here - either it is worth doing, or it is not.

I have updated this from https://github.com/proficnc/The-Cube/blob/master/CB_REV_C_Altium/PCB%203D%20Print%20from%20Above.PDF and https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview , and sanity checked against the ArduPilot docs.


@julianoes My understanding is that the main differentiator for Cube Orange + is that it comes with a new board that has ADSB-IN receiver on the new carrier board - is that correct? It also lacks a debug port, but that isn't documented here, so not too worried about it
1. Is that right? In which case we should add the info to make it findable on search, and also perhaps cross link from ADSB page. 
2. If it does work with ADSB-In presumably PX4 needs to configure this specially, or would the board be set up already  ?
3. Are these pinouts likely the same for all the other boards? i.e. can I copy this to Black, Orange etc?