### PR TITLE
Add info about UAVCAN sensor subscriptions

### DIFF
--- a/en/can/README.md
+++ b/en/can/README.md
@@ -71,21 +71,25 @@ See [PX4 DroneCAN Firmware](../dronecan/px4_cannode_fw.md) for more information.
 
 ## Videos
 
-Intro to UAVCAN (now DroneCAN) and practical example with setup in QGroundControl:
+### DroneCAN
+
+Intro to DroneCAN (UAVCANv0) and practical example with setup in QGroundControl:
 
 @[youtube](https://youtu.be/IZMTq9fTiOM)
 
-----
-UAVCAN (now Cyphal) for drones — PX4 Developer Summit Virtual 2020
+
+### Cyphal
+
+UAVCAN v1 for drones — PX4 Developer Summit Virtual 2020
 
 @[youtube](https://youtu.be/6Bvtn_g8liU)
 
 ----
 
-Getting started using UAVCAN v1 (now Cyphal) with PX4 on the NXP UAVCAN Board — PX4 Developer Summit Virtual 2020
+Getting started using UAVCAN v1 with PX4 on the NXP UAVCAN Board — PX4 Developer Summit Virtual 2020
 @[youtube](https://youtu.be/MwdHwjaXYKs)
 
 ----
-UAVCAN (Cyphal): a highly dependable publish-subscribe protocol for hard real-time intra-vehicular networking  — PX4 Developer Summit Virtual 2019
+UAVCAN: a highly dependable publish-subscribe protocol for hard real-time intra-vehicular networking  — PX4 Developer Summit Virtual 2019
 
 @[youtube](https://youtu.be/MBtROivYPik)

--- a/en/dronecan/README.md
+++ b/en/dronecan/README.md
@@ -98,12 +98,99 @@ To enable the DroneCAN driver, set the [UAVCAN_ENABLE](../advanced_config/parame
 - `2`: DroneCAN driver enabled for sensors, DNA server enabled
 - `3`: DroneCAN driver enabled for sensors and ESCs, DNA server enabled
 
-### Further Setup
+`2` or `3` are recommended, if DNA is supported.
 
-Most DroneCAN sensors require no further setup, unless specifically noted in their documentation.
+
+### DroneCAN Sensor Subscriptions
+
+DroneCAN sensors are not enabled by default.
+To use a sensor you must subscribe to it using the associated sensor-specific [UAVCAN parameter](../advanced_config/parameter_reference.html#uavcan).
+These can be recognised from the prefix `UAVCAN_SUB_`
+
+The set of subscriptions (sensors) that you can enable is (in PX4 v1.14):
+
+- [UAVCAN_SUB_ASPD](../advanced_config/parameter_reference.md#UAVCAN_SUB_ASPD): Airspeed
+- [UAVCAN_SUB_BARO](../advanced_config/parameter_reference.md#UAVCAN_SUB_BARO): Barometer
+- [UAVCAN_SUB_BAT](../advanced_config/parameter_reference.md#UAVCAN_SUB_BAT): Battery monitor/Power module
+- [UAVCAN_SUB_BTN](../advanced_config/parameter_reference.md#UAVCAN_SUB_BTN): Button
+- [UAVCAN_SUB_DPRES](../advanced_config/parameter_reference.md#UAVCAN_SUB_DPRES): Differential pressure
+- [UAVCAN_SUB_FLOW](../advanced_config/parameter_reference.md#UAVCAN_SUB_FLOW): Optical flow
+- [UAVCAN_SUB_GPS](../advanced_config/parameter_reference.md#UAVCAN_SUB_GPS): GPS 
+- [UAVCAN_SUB_HYGRO](../advanced_config/parameter_reference.md#UAVCAN_SUB_HYGRO): Hygrometer
+- [UAVCAN_SUB_ICE](../advanced_config/parameter_reference.md#UAVCAN_SUB_ICE): Internal combustion engine (ICE).
+- [UAVCAN_SUB_IMU](../advanced_config/parameter_reference.md#UAVCAN_SUB_IMU): IMU
+- [UAVCAN_SUB_MAG](../advanced_config/parameter_reference.md#UAVCAN_SUB_MAG): Magnetometer (compass)
+- [UAVCAN_SUB_RNG](../advanced_config/parameter_reference.md#UAVCAN_SUB_RNG): Range finder (distance sensor).
+
+
+#### GPS
+
+DroneCAN parameters:
+
+- Enable [UAVCAN_SUB_GPS](../advanced_config/parameter_reference.md#UAVCAN_SUB_GPS) (along with [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE)).
+- Enable [UAVCAN_SUB_MAG](../advanced_config/parameter_reference.md#UAVCAN_SUB_MAG) if the GPS module has an inbuilt compass.
+- Set [CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM) to `1` if this is that last node on the CAN bus.
+
+Other Parameters:
+
+- If the GPS is not positioned at the vehicle centre of gravity you can account for the offset using [EKF2_GPS_POS_X](../advanced_config/parameter_reference.md#EKF2_GPS_POS_X), [EKF2_GPS_POS_Y](../advanced_config/parameter_reference.md#EKF2_GPS_POS_Y) and [EKF2_GPS_POS_Z](../advanced_config/parameter_reference.md#EKF2_GPS_POS_Z).
+- If the GPS module provides yaw information, you can enable GPS yaw fusion by setting bit 3 of [EKF2_GPS_CTRL](../advanced_config/parameter_reference.md#EKF2_GPS_CTRL) to true.
+
+
+#### Barometer
+
+DroneCAN parameters:
+
+- Enable [UAVCAN_SUB_BARO](../advanced_config/parameter_reference.md#UAVCAN_SUB_BARO) (along with [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE)).
+
+#### Compass
+
+DroneCAN parameters:
+
+- Enable [UAVCAN_SUB_MAG](../advanced_config/parameter_reference.md#UAVCAN_SUB_MAG) (along with [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE)).
+
+#### Distance Sensor/Range Finder 
+
+DroneCAN parameters:
+
+- Enable [UAVCAN_SUB_RNG](../advanced_config/parameter_reference.md#UAVCAN_SUB_RNG) (along with [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE)).
+- Set [UAVCAN_RNG_MIN](../advanced_config/parameter_reference.md#UAVCAN_RNG_MIN) and [UAVCAN_RNG_MAX](../advanced_config/parameter_reference.md#UAVCAN_RNG_MAX), the minimum and maximum range of the distance sensors.
+
+Other parameters:
+
+- If the rangefinder is not positioned at the vehicle centre of gravity you can account for the offset using [EKF2_RNG_POS_X](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X), [EKF2_RNG_POS_Y](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Y) and [EKF2_RNG_POS_Z](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Z).
+- Other `EKF2_RNG_*` parameters may be relevant, in which case they should be documented with the specific rangefinder. 
+
+
+#### Optical Flow Sensor
+
+DroneCAN parameters:
+
+- Enable [UAVCAN_SUB_FLOW](../advanced_config/parameter_reference.md#UAVCAN_SUB_FLOW) (along with [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE)).
+
+
+Other parameters:
+
+- Set [SENS_FLOW_MINHGT](../advanced_config/parameter_reference.md#SENS_FLOW_MINHGT) and [SENS_FLOW_MAXHGT](../advanced_config/parameter_reference.md#SENS_FLOW_MAXHGT), the minimum and maximum height of the flow sensor.
+- Set [SENS_FLOW_MAXR](../advanced_config/parameter_reference.md#SENS_FLOW_MAXR) the maximum angular flow rate of the sensor.
+- Enable optical flow fusion by setting [EKF2_OF_CTRL](../advanced_config/parameter_reference.md#EKF2_OF_CTRL).
+- To disable GPS aiding (optional), set [EKF2_GPS_CTRL](../advanced_config/parameter_reference.md#EKF2_GPS_CTRL) to `0`.
+- If the optical flow unit is not positioned at the vehicle centre of gravity you can account for the offset using [EKF2_OF_POS_X](../advanced_config/parameter_reference.md#EKF2_OF_POS_X), [EKF2_OF_POS_Y](../advanced_config/parameter_reference.md#EKF2_OF_POS_Y) and [EKF2_OF_POS_Z](../advanced_config/parameter_reference.md#EKF2_OF_POS_Z).
+
+
+Optical flow sensors require rangefinder data.
+However the rangefinder need not be part of the same module, and if not, may not be connected via DroneCAN.
+If the rangefinder is connected via DroneCAN (whether inbuilt or separate), you will also need to enable it as described in the [rangefinder section](#distance-sensor-range-finder) (above).
+
+
+
+### ESC & Servos
 
 [DroneCAN ESCs and servos](../dronecan/escs.md) require the [motor order and servo outputs](../config/actuators.md) to be configured.
-If any other parameters must be set, these will be covered in device-specific documentation.
+
+### Further Setup
+
+Most DroneCAN sensors require no further setup, unless specifically noted in their device-specific documentation.
 
 ## Firmware Update
 

--- a/en/dronecan/avanon_laser_interface.md
+++ b/en/dronecan/avanon_laser_interface.md
@@ -1,4 +1,4 @@
-# Avionics Anonymous Laser Altimeter UAVCAN Interface
+# Avionics Anonymous Laser Altimeter DroneCan Interface
 
 :::note
 In 2022, UAVCAN (v0) was forked and is maintained as `DroneCAN`.
@@ -46,8 +46,8 @@ Therefore the laser must be compatible with whatever voltage is supplied to the 
 Pin | Name | Description
 --- | ---   | ---
 1   | POWER_IN | Power Supply. 4.0-5.5V supported, but must also be compatible with connected laser.
-2   | TX/SCL | TX for serial mode, Clock for I2C mode
-3   | RX/SDA | RX for serial mode, Data for I2C mode
+2   | TX/SCL | TX for serial mode, Clock for I2C mode.
+3   | RX/SDA | RX for serial mode, Data for I2C mode.
 4   | GND | Signal/power ground.
 
 ### Laser Connector
@@ -55,12 +55,14 @@ Pin | Name | Description
 Pin | Name | Description
 --- | ---   | ---
 1   | POWER_OUT | Filtered power at the supply voltage.
-2   | CAN+ | TX for serial mode, Clock for I2C mode
-3   | RX/SDA | RX for serial mode, Data for I2C mode
+2   | CAN+ | TX for serial mode, Clock for I2C mode.
+3   | RX/SDA | RX for serial mode, Data for I2C mode.
 4   | GND | Signal/power ground.
 
-## Flight Controller Setup
+## PX4 Configuration
 
-DroneCAN must be enabled by setting [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE) non zero.
+To enable the laser altimeter you will need to [set the following parameters](../advanced_config/parameters.md) (in QGroundControl): 
 
-The minimum and maximum valid range for the laser must be set in the parameters [UAVCAN_RNG_MIN](../advanced_config/parameter_reference.md#UAVCAN_RNG_MIN) and [UAVCAN_RNG_MAX](../advanced_config/parameter_reference.md#UAVCAN_RNG_MAX).
+- Enable DroneCAN by setting [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE) non zero.
+- Enable DroneCAN rangefinder subscription by setting [UAVCAN_SUB_RNG](../advanced_config/parameter_reference.md#UAVCAN_SUB_RNG)
+- Set the minimum and maximum range of the rangefinder using [UAVCAN_RNG_MIN](../advanced_config/parameter_reference.md#UAVCAN_RNG_MIN) and [UAVCAN_RNG_MAX](../advanced_config/parameter_reference.md#UAVCAN_RNG_MAX).

--- a/en/dronecan/cuav_can_pmu.md
+++ b/en/dronecan/cuav_can_pmu.md
@@ -58,11 +58,11 @@ The connection steps are:
 
 Set the following parameters in *QGroundControl* [Vehicle Setup > Parameters](../advanced_config/parameters.md) and then restart:
 
-* `UAVCAN_ENABLE`: set to: *Sensors Automatic Config*
+* [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE): set to: *Sensors Automatic Config*
 
   ![qgc set](../../assets/hardware/power_module/cuav_can/qgc_set_en.png)
 
-* `UAVCAN_SUB_BAT`: set to: *Raw data*
+* [UAVCAN_SUB_BAT](../advanced_config/parameter_reference.md#UAVCAN_SUB_BAT): set to: *Raw data*
 
   ![QGC - Set UAVCAN_SUB_BAT parameter to raw data](../../assets/hardware/power_module/cuav_can/qgc_set_usavcan_sub_bat.png)
 

--- a/en/dronecan/pomegranate_systems_pm.md
+++ b/en/dronecan/pomegranate_systems_pm.md
@@ -1,7 +1,8 @@
 # Pomegranate Systems Power Module
 
 :::note
-In 2022, UAVCAN (v0) was forked and is maintained as  `DroneCAN`. While this product still mentions "UAVCAN", it is fully compatible with PX4's DroneCAN support.
+In 2022, UAVCAN (v0) was forked and is maintained as  `DroneCAN`.
+While this product still mentions "UAVCAN", it is fully compatible with PX4's DroneCAN support.
 :::
 
 ![Module Image](../../assets/hardware/power_module/pomegranate_systems_pm/main_image.jpg)
@@ -12,25 +13,25 @@ Detailed setup, configuration, and troubleshooting information can be found on t
 
 ## Hardware Specifications
 
- - **Input Voltage:** 6-26V \(2-6S\)
- - **Max Continuous Current:**
-   - **Benchtop:** 40A
-   - **Forced Cooling:** 100A
- - **Max 5V Output Current:** 2A
- - **Voltage Resolution:** 0.04 ΔV
- - **Current Resolution:** 
-   - **Primary / Battery Bus:** 0.02 ΔA
-   - **5V bus:** 0.001 ΔA
- - **CANbus Termination:** Electronic (on by default)
- - **MCU:** STM32F302K8U
- - **Electrical Interface:**
-   - **Power:** Solder pads or XT60PW (right angle, board-mounted connectors)
-   - **CANbus** Dual JST GH-4 (standard UAVCAN micro-connector)
-   - **I2C / Serial:** JST GH-5 
-   - **5V Output:** Solder pads or CANbus / I2C connectors
- - **Device Mass:**
-   - **Without Connectors:** 9g
-   - **With XT60PW Connectors:** 16g
+- **Input Voltage:** 6-26V \(2-6S\)
+- **Max Continuous Current:**
+  - **Benchtop:** 40A
+  - **Forced Cooling:** 100A
+- **Max 5V Output Current:** 2A
+- **Voltage Resolution:** 0.04 ΔV
+- **Current Resolution:** 
+  - **Primary / Battery Bus:** 0.02 ΔA
+  - **5V bus:** 0.001 ΔA
+- **CANbus Termination:** Electronic (on by default)
+- **MCU:** STM32F302K8U
+- **Electrical Interface:**
+  - **Power:** Solder pads or XT60PW (right angle, board-mounted connectors)
+  - **CANbus** Dual JST GH-4 (standard UAVCAN micro-connector)
+  - **I2C / Serial:** JST GH-5 
+  - **5V Output:** Solder pads or CANbus / I2C connectors
+- **Device Mass:**
+  - **Without Connectors:** 9g
+  - **With XT60PW Connectors:** 16g
  
  ![Dimensions](../../assets/hardware/power_module/pomegranate_systems_pm/mechanical.png)
 
@@ -41,13 +42,14 @@ Source code and build instructions can be found on [the bitbucket](https://bitbu
 
 ## Flight Controller Setup
 
- 1. Enable DroneCAN by setting the [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE) parameter to `2` (Sensors Automatic Config) or `3`.
- 2. Set the following module parameters using the [Mavlink console](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_console.html):
-    * Battery capacity in mAh: `battery_capacity_mAh`
-    * Battery voltage when *full*: `battery_full_V`, 
-    * Battery voltage when *empty*: `battery_empty_V`
-    * Turn on current integration: `enable_current_track`
-    * (optional) Turn Off CANbus termination resistor :`enable_can_term`
+1. Enable DroneCAN by setting the [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE) parameter to `2` (Sensors Automatic Config) or `3`.
+1. Enable DroneCAN battery monitoring by setting [UAVCAN_SUB_BAT](../advanced_config/parameter_reference.md#UAVCAN_SUB_BAT) to `1` or `2` ( depending on your battery).
+1. Set the following module parameters using the [MAVLink console](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_console.html):
+   * Battery capacity in mAh: `battery_capacity_mAh`
+   * Battery voltage when *full*: `battery_full_V`, 
+   * Battery voltage when *empty*: `battery_empty_V`
+   * Turn on current integration: `enable_current_track`
+   * (optional) Turn Off CANbus termination resistor :`enable_can_term`
 
 **Example:** A Power Module with UAVCAN node id `125` connected to a `3S` LiPo with capacity of `5000mAh` can be configured with the following commands:
 

--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -78,6 +78,7 @@ These will include (minimally):
 
 ### Sensors
 
+* [DroneCAN sensors now need to be individually enabled via `UAVCAN_SUB_*` parameters](/dronecan/#dronecan-sensor-subscriptions) - [PX4-Autopilot#18471](https://github.com/PX4/PX4-Autopilot/pull/18471)
 * Battery estimation defaults, reporting improvements: Defaults: current based load compensation, higher empty cell voltage, shorter action delay - [PX4-Autopilot#19429](https://github.com/PX4/PX4-Autopilot/pull/19429), [PX4-Autopilot#19700](https://github.com/PX4/PX4-Autopilot/pull/19700), [PX4-Autopilot#19594](https://github.com/PX4/PX4-Autopilot/pull/19594), https://github.com/PX4/PX4-Autopilot/pull/19679
 * SF45 rotation Lidar serial driver - [PX4-Autopilot#19891](https://github.com/PX4/PX4-Autopilot/pull/19891)
 


### PR DESCRIPTION
PX4 v1.14 adds the requirement to specifically enable DroneCAN sensors using appropriate `UAVCAN_SUB_*` params. These were mentioned in specific hardware, but not generally. 

This adds high level PX4 configuration information in the DroneCAN home page, along with sections for the main types of hardware. There is nothing to stop individual hardware documenting the requirements too, but this provides a general starting point.
I also added a release note.