### PR TITLE
[uxrce-dds]: add new parameter UXRCE_DDS_SYNCT

### DIFF
--- a/en/middleware/uxrce_dds.md
+++ b/en/middleware/uxrce_dds.md
@@ -260,7 +260,9 @@ The configuration can be done using the [UXRCE-DDS parameters](../advanced_confi
     By default, ROS 2 operates on ID 0.
   - [UXRCE_DDS_PTCFG](../advanced_config/parameter_reference.md#UXRCE_DDS_PTCFG): uXRCE-DDS participant configuration.
     It allows to restrict the visibility of the DDS topics to the _localhost_ only and to use user-customized participant configuration files stored on the agent side.
-
+  - [UXRCE_DDS_SYNCT](../advanced_config/parameter_reference.md#UXRCE_DDS_SYNCT): Bridge time synchronization enable.
+    The uXRCE-DDS client module can synchronize the timestamp of the messages exchanged over the bridge.
+    This is the default configuration. In certain situations, for example during [simulations](../ros/ros2_comm.md#ros-gazebo-and-px4-time-synchronization), this feature may be disabled.
 
 :::note
 Many ports are already have a default configuration.

--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -428,6 +428,39 @@ Similarly to vectors, also quanternions representing the attitude of the vehicle
 
 [PX4/px4_ros_com](https://github.com/PX4/px4_ros_com) provides the shared library [frame_transforms](https://github.com/PX4/px4_ros_com/blob/main/include/px4_ros_com/frame_transforms.h) to easily perform such conversions.
 
+### ROS, Gazebo and PX4 time synchronization
+
+By default, time synchronization between ROS 2 and PX4 is automatically managed by the [uXRCE-DDS middleware](https://micro-xrce-dds.docs.eprosima.com/en/latest/time_sync.html) and time synchronization statistics are available listening to the bridged topic `/fmu/out/timesync_status`.
+When the uXRCE-DDS client runs on a flight controller and the Agent runs on a companion computer this is the desired behavior as time offsets, time drift and communication latency are computed and automatically compensated.
+
+Instead, during Gazebo simulations, PX4 uses the Gazebo `/clock` topic as [time source](../sim_gazebo_gz/README.md#px4-gazebo-time-synchronization). This clock is always slightly off-sync w.r.t. the OS clock (the real time factor is never exactly one) and it can can even run much faster or much slower depending on the [user preferences](http://sdformat.org/spec?elem=physics&ver=1.9).
+Note that this is different from the [simulation lockstep](../simulation/README.md#lockstep-simulation) procedure adopted with Gazebo Classic.
+
+ROS2 users have then two possibilities regarding the [time source](https://design.ros2.org/articles/clock_and_time.html) of their nodes.
+
+#### ROS2 nodes use the OS clock as time source
+
+This scenario, which is the one considered in this page and in the [offboard_control](./offboard_control.md) guide, is also the standard behavior of the ROS2 nodes.
+The OS clock acts as time source and therefore it can be used only when the simulation real time factor is very close to one.
+The time synchronizer of the uXRCE-DDS client then bridges the OS clock on the ROS2 side with the Gazebo clock on the PX4 side.
+No further action is required by the user.
+
+#### ROS2 nodes use the Gazebo clock as time source
+
+In this scenario, ROS2 also uses the Gazebo `/clock` topic as time source.
+This approach makes sense if the Gazebo simulation is running with real time factor different from one or if ROS2 need to directly interact with Gazebo.
+The procedure requires to:
+
+- Directly bridge ROS and Gazebo using [ros_gz](https://github.com/gazebosim/ros_gz) and the [ros_gz_bridge](https://github.com/gazebosim/ros_gz) package.
+- Bridge the Gazebo `/clock` topic over ROS
+  ```sh
+  ros2 run ros_gz_bridge parameter_bridge /clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock
+  ```
+- Run all your nodes with the parameter `use_sim_time` set to `true` (see [ROS clock and Time design](https://design.ros2.org/articles/clock_and_time.html)).
+
+On the PX4 side, you are only required to stop the uXRCE-DDS time synchronization, setting the parameter [UXRCE_DDS_SYNCT](../advanced_config/parameter_reference.md#UXRCE_DDS_SYNCT) to `false`.
+
+By doing so, Gazebo will act as main and only time source for both ROS2 and PX4.
 
 ## ROS 2 Example Applications
 

--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -431,9 +431,10 @@ Similarly to vectors, also quanternions representing the attitude of the vehicle
 ### ROS, Gazebo and PX4 time synchronization
 
 By default, time synchronization between ROS 2 and PX4 is automatically managed by the [uXRCE-DDS middleware](https://micro-xrce-dds.docs.eprosima.com/en/latest/time_sync.html) and time synchronization statistics are available listening to the bridged topic `/fmu/out/timesync_status`.
-When the uXRCE-DDS client runs on a flight controller and the Agent runs on a companion computer this is the desired behavior as time offsets, time drift and communication latency are computed and automatically compensated.
+When the uXRCE-DDS client runs on a flight controller and the agent runs on a companion computer this is the desired behavior as time offsets, time drift, and communication latency, are computed and automatically compensated.
 
-Instead, during Gazebo simulations, PX4 uses the Gazebo `/clock` topic as [time source](../sim_gazebo_gz/README.md#px4-gazebo-time-synchronization). This clock is always slightly off-sync w.r.t. the OS clock (the real time factor is never exactly one) and it can can even run much faster or much slower depending on the [user preferences](http://sdformat.org/spec?elem=physics&ver=1.9).
+For Gazebo simulations PX4 uses the Gazebo `/clock` topic as [time source](../sim_gazebo_gz/README.md#px4-gazebo-time-synchronization) instead.
+This clock is always slightly off-sync w.r.t. the OS clock (the real time factor is never exactly one) and it can can even run much faster or much slower depending on the [user preferences](http://sdformat.org/spec?elem=physics&ver=1.9).
 Note that this is different from the [simulation lockstep](../simulation/README.md#lockstep-simulation) procedure adopted with Gazebo Classic.
 
 ROS2 users have then two possibilities regarding the [time source](https://design.ros2.org/articles/clock_and_time.html) of their nodes.
@@ -448,19 +449,14 @@ No further action is required by the user.
 #### ROS2 nodes use the Gazebo clock as time source
 
 In this scenario, ROS2 also uses the Gazebo `/clock` topic as time source.
-This approach makes sense if the Gazebo simulation is running with real time factor different from one or if ROS2 need to directly interact with Gazebo.
-The procedure requires to:
+This approach makes sense if the Gazebo simulation is running with real time factor different from one, or if ROS2 needs to directly interact with Gazebo.
+The procedure requires you to:
 
 - Directly bridge ROS and Gazebo using [ros_gz](https://github.com/gazebosim/ros_gz) and the [ros_gz_bridge](https://github.com/gazebosim/ros_gz) package.
-- Bridge the Gazebo `/clock` topic over ROS
+- Bridge the Gazebo `/clock` topic over ROS:
+
   ```sh
   ros2 run ros_gz_bridge parameter_bridge /clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock
-  ```
-- Run all your nodes with the parameter `use_sim_time` set to `true` (see [ROS clock and Time design](https://design.ros2.org/articles/clock_and_time.html)).
-
-On the PX4 side, you are only required to stop the uXRCE-DDS time synchronization, setting the parameter [UXRCE_DDS_SYNCT](../advanced_config/parameter_reference.md#UXRCE_DDS_SYNCT) to `false`.
-
-By doing so, Gazebo will act as main and only time source for both ROS2 and PX4.
 
 ## ROS 2 Example Applications
 

--- a/en/sim_gazebo_gz/README.md
+++ b/en/sim_gazebo_gz/README.md
@@ -176,6 +176,14 @@ As long as the world file and the model file are in the Gazebo search path `IGN_
 However, `make px4_sitl gz_<model>_<world>` won't work with them.
 :::
 
+## PX4-Gazebo time synchronization
+
+Differently from Gazebo Classic and jMAVSim simulators, PX4 and Gazebo do not implement a lockstep mechanism.
+During Gazebo simulations PX4 subscribes to the Gazebo `\clock` topic and uses it as clock source.
+This guarantees that PX4 will always wait for Gazebo before moving forward in time even if Gazebo is running with real time factors different from 1.
+Note, however, that as the lockstep is missing, Gazebo will never wait for PX4 to finish its computations.
+In the worst case scenario, PX4 can completely go offline and Gazebo will keep running, with obvious crashes of the simulated drone.
+
 ## Multi-Vehicle Simulation
 
 Multi-Vehicle simulation is supported on Linux hosts.

--- a/en/sim_gazebo_gz/README.md
+++ b/en/sim_gazebo_gz/README.md
@@ -176,11 +176,11 @@ As long as the world file and the model file are in the Gazebo search path `IGN_
 However, `make px4_sitl gz_<model>_<world>` won't work with them.
 :::
 
-## PX4-Gazebo time synchronization
+## PX4-Gazebo Time Synchronization
 
-Differently from Gazebo Classic and jMAVSim simulators, PX4 and Gazebo do not implement a lockstep mechanism.
+Unlike the Gazebo Classic and jMAVSim simulators, PX4 and Gazebo do not implement a lockstep mechanism.
 During Gazebo simulations PX4 subscribes to the Gazebo `\clock` topic and uses it as clock source.
-This guarantees that PX4 will always wait for Gazebo before moving forward in time even if Gazebo is running with real time factors different from 1.
+This guarantees that PX4 will always wait for Gazebo before moving forward in time, even if Gazebo is running with real time factors different from 1.
 Note, however, that as the lockstep is missing, Gazebo will never wait for PX4 to finish its computations.
 In the worst case scenario, PX4 can completely go offline and Gazebo will keep running, with obvious crashes of the simulated drone.
 


### PR DESCRIPTION
PX-Autopilot PR: PX4/PX4-Autopilot#21757

`UXRCE_DDS_SYNCT` controls the uxrce-dds-client time synchronization feature.
In ROS + Gazebo + PX4 simulations, if ROS uses the Gazebo clock as time source, uxrce-dds-client time synchronization must be disabled.

This PR describes the parameter and gives a user case where it is relevant to use it. It also gives an overview about how to use Gazebo clock as PX4 time source.