### PR TITLE
Add information for the logger module error behavior and file size limitations

### DIFF
--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -14,7 +14,9 @@ A new log file is created for each arming session on the SD card.
 To display the current state, use `logger status` on the console.
 If you want to start logging immediately, use `logger on`.
 This overrides the arming state, as if the system was armed.
-`logger off` undoes this.
+`logger off` undoes this. 
+
+If logging stops due to a write error, or reaching the [maximum file size](#file-size-limitations), PX4 will automatically restart logging in a new file.
 
 For a list of all supported logger commands and parameters, use:
 

--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -79,6 +79,12 @@ This configuration will log sensor_accel 0 at full rate, sensor_accel 1 at 10Hz,
 
 There are several scripts to analyze and convert logging files in the [pyulog](https://github.com/PX4/pyulog) repository.
 
+
+## File size limitations
+
+The maximum file size depends on the file system and OS.
+The size limit on NuttX is currently around 2GB.
+
 ## Dropouts
 
 Logging dropouts are undesired and there are a few factors that influence the


### PR DESCRIPTION
Add information from a [forum thread](https://discuss.px4.io/t/how-does-people-deal-with-large-ulog-file/32918/11) regarding the limitations and behavior on error of the logger module.
