### PR TITLE
v1.14-RC1 Release note update

### DIFF
--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -1,4 +1,10 @@
-## PX4-Autopilot v1.14 Release Notes
+# PX4-Autopilot v1.14 Release Notes
+
+## Upgrading Notes
+
+Below important notes when upgrading to v1.14 are listed:
+
+1. Default disarmed PWM was changed from 900us to 1000us. So make sure to check whether you were using default PWM disarmed values, and if it works with your setup. You can find related information in the [step 7 of ESC calibration](../advanced_config/esc_calibration.md#steps) document for details.
 
 ## Major Changes
 
@@ -64,6 +70,8 @@ For further details please refer to the [migration guide](../middleware/uxrce_dd
 * Improved preflight failure check reporting (requires QGC [v4.2.0](https://github.com/mavlink/qgroundcontrol/releases/tag/v4.2.0) or later): [PX4-Autopilot#20030](https://github.com/PX4/PX4-Autopilot/pull/20030) and [qgroundcontrol#10362](https://github.com/mavlink/qgroundcontrol/pull/10362)
 * [Package delivery in mission](../advanced/package_delivery.md): For package delivery applications, inital support for payload delivery in mission for gripper actuator was added
 * Manual control setpoint message redefinition: `manual_control_setpoint.x`, `y`, `z`, `w` -> `roll`, `pitch`, `yaw`, `throttle`; `throttle scale [0,1] -> [-1,1]` - [PX4-Autopilot#15949](https://github.com/PX4/PX4-Autopilot/pull/15949)
+* Default motor PWM configuration - [PX4-Autopilot#21800](https://github.com/PX4/PX4-Autopilot/pull/21800)
+* Fix PWM/Oneshot calibration - [PX4-Autopilot#21726](https://github.com/PX4/PX4-Autopilot/pull/21726)
 
 ### Control
 
@@ -129,6 +137,7 @@ For further details please refer to the [migration guide](../middleware/uxrce_dd
 * Add option to disable manual yaw inputs - [PX4-Autopilot#20647](https://github.com/PX4/PX4-Autopilot/pull/20647)
 * Disable airspeed rate input into TECS	airspeed rate estimation has shwon to be unreliable, so we decided to disable it for now - [PX4-Autopilot#21317](https://github.com/PX4/PX4-Autopilot/pull/21317)
 * Support flying at different airspeeds	Add airspeed to trim throttle mapping in TECS to support flying at different airspeeds - [PX4-Autopilot#21345](https://github.com/PX4/PX4-Autopilot/pull/21345)
+* FWPositionControl: navigateWaypoints: fix logic if already past waypo… - [PX4-Autopilot#21642](https://github.com/PX4/PX4-Autopilot/pull/21642)
 
 ### Hardware Support
 
@@ -136,3 +145,32 @@ For further details please refer to the [migration guide](../middleware/uxrce_dd
 * Unicore GPS: Support for Holybro Unicore UM982 GPS - [PX4-Autopilot#21214](https://github.com/PX4/PX4-Autopilot/pull/21214))
 * VOXL2 Improved support - [PX4-Autopilot#21426](https://github.com/PX4/PX4-Autopilot/pull/21426)
 * Cubepilot Cube Black detection: Fixed Cube Black vs. Pixhawk 2 detection with CAN1 connected - [PX4-Autopilot#21342](https://github.com/PX4/PX4-Autopilot/pull/21342)
+
+## Changes between beta releases
+
+### Release Candidate 1 - beta 2
+
+* FWPositionControl: navigateWaypoints: fix logic if already past waypo… - [PX4-Autopilot#21642](https://github.com/PX4/PX4-Autopilot/pull/21642)
+* Geofence: Disable pre-emptive geofence predictor by default - [PX4-Autopilot#21657](https://github.com/PX4/PX4-Autopilot/pull/21657)
+* VTOL mission item resets and QC rework - [PX4-Autopilot#21665](https://github.com/PX4/PX4-Autopilot/pull/21665)
+* RTCM Fixes - [PX4-Autopilot#21666](https://github.com/PX4/PX4-Autopilot/pull/21666)
+* FW/VTOL: open up a couple of param constraints - [PX4-Autopilot#21671](https://github.com/PX4/PX4-Autopilot/pull/21671)
+* netman: update module description (#21664) - [PX4-Autopilot#21673](https://github.com/PX4/PX4-Autopilot/pull/21673)
+* lights: Add LP5562 RGBLED driver - [PX4-Autopilot#21685](https://github.com/PX4/PX4-Autopilot/pull/21685)
+* rc_update: throttle trim centering fix for reverse channel - [PX4-Autopilot#21692](https://github.com/PX4/PX4-Autopilot/pull/21692)
+* Fix Rover Thrust Normalization - [PX4-Autopilot#21722](https://github.com/PX4/PX4-Autopilot/pull/21722)
+* FW Rate Controller: fix saturation logic for VTOLs with differential thrust enabled - [PX4-Autopilot#21725](https://github.com/PX4/PX4-Autopilot/pull/21725)
+* Fix PWM/Oneshot calibration - [PX4-Autopilot#21726](https://github.com/PX4/PX4-Autopilot/pull/21726)
+* icp201: increase startup delay (FMUv6X) - [PX4-Autopilot#21766](https://github.com/PX4/PX4-Autopilot/pull/21766)
+* SITL Tailsitter tuning fixes and add quadtailsitter  - [PX4-Autopilot#21773](https://github.com/PX4/PX4-Autopilot/pull/21773)
+* FMUv6X: Enable ADS1115 - [PX4-Autopilot#21794](https://github.com/PX4/PX4-Autopilot/pull/21794)
+* Navigator: Loiter: always establish new Loiter with center at current… - [PX4-Autopilot#21798](https://github.com/PX4/PX4-Autopilot/pull/21798)
+* Default motor PWM configuration - [PX4-Autopilot#21800](https://github.com/PX4/PX4-Autopilot/pull/21800)
+* rc_update: fix on-off-switch with negative threshold values - [PX4-Autopilot#21801](https://github.com/PX4/PX4-Autopilot/pull/21801)
+* ROMFS: auto try RGBLED is31fl3195 - [PX4-Autopilot#21804](https://github.com/PX4/PX4-Autopilot/pull/21804)
+* netman line too long - [PX4-Autopilot#21829](https://github.com/PX4/PX4-Autopilot/pull/21829)
+* icp201: increase startup delay (FMUv6X) - [PX4-Autopilot#21834](https://github.com/PX4/PX4-Autopilot/pull/21834)
+* mag_cal: fix mag bias estimate to mag cal - [PX4-Autopilot#21835](https://github.com/PX4/PX4-Autopilot/pull/21835)
+* airframes/x500_v2: move motors from AUX to MAIN - [PX4-Autopilot#21841](https://github.com/PX4/PX4-Autopilot/pull/21841)
+* Opt flow fixes - [PX4-Autopilot#21844](https://github.com/PX4/PX4-Autopilot/pull/21844)
+* Jenkinsfile-compile board updates - [PX4-Autopilot#21860](https://github.com/PX4/PX4-Autopilot/pull/21860)

--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -12,6 +12,8 @@ This section outlines the most important changes to consider when upgrading: tho
    This is critical if you are using a custom mixer file or the airframe you assigned in an earlier version is not present in PX4 v1.14.
    However it is still recommended even if you are using an airframe that precisely matches a specific vehicle in the [Airframe Reference](../airframes/airframe_reference.md) (such as the [Holybro X500 V2](#copter_quadrotor_x_holybro_x500_v2)) as your wiring and ESCs calibration may not match the defaults.
 1. Default disarmed PWM was changed from 900us to 1000us. So make sure to check whether you were using default PWM disarmed values, and if it works with your setup. You can find related information in the [step 7 of ESC calibration](../advanced_config/esc_calibration.md#steps) document for details.
+1. ROS 2/DDS users will need to modify their code to use uXRCE-DDS (instead of Fast-RTPS, which it replaces in PX4 v1.14).
+   For more information see [uXRCE-DDS > Fast-RTPS to uXRCE-DDS Migration Guidelines](../middleware/uxrce_dds.md#fast-rtps-to-uxrce-dds-migration-guidelines)
 
 ## Major Changes
 

--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -5,6 +5,12 @@
 PX4 v1.14 contains many new features, feature upgrades, and bug fixes.
 This section outlines the most important changes to consider when upgrading: those that could affect the stability of your vehicle, and their integration with other systems.
 
+1. When updating you should use the [Actuator Configuration UI](../config/actuators.md) to confirm that the geometry of the airframe matches your vehicle, and that the correct functions (motors and servos) are mapped to outputs as they are wired to the frame and with the correct ESC type specified: the test sliders in the UI an be used to confirm motor wiring.
+
+   If using PWM ESC for motors then running an [ESC Calibration](../advanced_config/esc_calibration.md) is highly recommended, and then setting appropriate disarmed, minimum and maximum values for the motors (in the actuator UI).
+   
+   This is critical if you are using a custom mixer file or the airframe you assigned in an earlier version is not present in PX4 v1.14.
+   However it is still recommended even if you are using an airframe that precisely matches a specific vehicle in the [Airframe Reference](../airframes/airframe_reference.md) (such as the [Holybro X500 V2](#copter_quadrotor_x_holybro_x500_v2)) as your wiring and ESCs calibration may not match the defaults.
 1. Default disarmed PWM was changed from 900us to 1000us. So make sure to check whether you were using default PWM disarmed values, and if it works with your setup. You can find related information in the [step 7 of ESC calibration](../advanced_config/esc_calibration.md#steps) document for details.
 
 ## Major Changes

--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -1,8 +1,9 @@
 # PX4-Autopilot v1.14 Release Notes
 
-## Upgrading Notes
+## Upgrading to PX4 v1.14
 
-Below important notes when upgrading to v1.14 are listed:
+PX4 v1.14 contains many new features, feature upgrades, and bug fixes.
+This section outlines the most important changes to consider when upgrading: those that could affect the stability of your vehicle, and their integration with other systems.
 
 1. Default disarmed PWM was changed from 900us to 1000us. So make sure to check whether you were using default PWM disarmed values, and if it works with your setup. You can find related information in the [step 7 of ESC calibration](../advanced_config/esc_calibration.md#steps) document for details.
 


### PR DESCRIPTION
## About
As we are releasing the Release Candidate 1, as discussed in [the maintainers call](https://discuss.px4.io/t/px4-maintainers-call-july-18-2023/33189#v114-release-5), this update includes changes to the release notes for the RC1.

## Changes
1. Addition of change log (beta2 ... release candidate 1)
2. Addition of Upgrading notes (as the PWM changes from https://github.com/PX4/PX4-Autopilot/pull/21513 must be known by every user upgrading to v1.14), to grab user's attention
3. Added new changes in RC1 into appropriate sections under Minor changes

## Other
I used a python script to generate the changes between beta2 and rc1, as they were all the PRs against the 1.14 release branch

```python
from github import Github

g = Github()
repo = g.get_repo("PX4/PX4-Autopilot")
pulls = repo.get_pulls(state='closed', sort='created', base='release/1.14')

for pr in pulls:
    # https://pygithub.readthedocs.io/en/latest/github_objects/PullRequest.html
    print("* {} - [PX4-Autopilot#{}]({})".format(pr.title, pr.number, pr.html_url))
```