### PR TITLE
IMprove MAVLink and serial config docs

### DIFF
--- a/en/hardware/serial_port_mapping.md
+++ b/en/hardware/serial_port_mapping.md
@@ -1,10 +1,13 @@
 # Serial Port Mapping
 
-This topic shows how to determine the mapping between serial ports (UART), device (e.g. "ttyS0") and specific functions enabled by PX4 (e.g. TELEM1, TELEM2, GPS1, RC SBUS, Debug console).
+This topic shows how to determine the mapping between USART/UART serial port device names (e.g. "ttyS0") and the associated ports on a flight controller, such as `TELEM1`, `TELEM2`, `GPS1`, `RC SBUS`, `Debug console`.
 
-:::note
 The instructions are used to generate serial port mapping tables in flight controller documentation.
 For example: [Pixhawk 4 > Serial Port Mapping](../flight_controller/pixhawk4.md#serial-port-mapping).
+
+:::note
+The function assigned to each port does not _have to_ match the name (in most cases), and is set using a [Serial Port Configuration](../peripherals/serial_configuration.md).
+Usually the port function is configured to match the name, which is why the port labelled `GPS1` will work with a GPS out of the box.
 :::
 
 ## NuttX on STMxxyyy
@@ -45,7 +48,7 @@ Alternatively you can launch boardconfig using `make px4_fmu-v5 boardconfig` and
 
 ### nsh/defconfig
 
-The *nsh/defconfig* allows you to determine which ports are defined, whether they are UART or USARTs, and the mapping between USART/UART and device.
+The _nsh/defconfig_ allows you to determine which ports are defined, whether they are UART or USARTs, and the mapping between USART/UART and device.
 You can also determine which port is used for the [serial/debug console](../debug/system_console.md).
 
 Open the board's defconfig file, for example: [/boards/px4/fmu-v5/nuttx-config/nsh/defconfig](https://github.com/PX4/PX4-Autopilot/blob/main/boards/px4/fmu-v5/nuttx-config/nsh/defconfig#L215-L221)
@@ -67,6 +70,7 @@ The entries tell you which ports are defined, and whether they are UART or USART
 
 Copy the section above and reorder numerically by "n".
 Increment the device number _ttyS**n**_ alongside (zero based) to get the device-to-serial-port mapping.
+
 ```
 ttyS0 CONFIG_STM32F7_USART1=y
 ttyS1 CONFIG_STM32F7_USART2=y
@@ -89,17 +93,20 @@ CONFIG_UART7_SERIAL_CONSOLE=y
 For flight controllers that have an IO board, determine the PX4IO connection from **board_config.h** by searching for `PX4IO_SERIAL_DEVICE`.
 
 For example, [/boards/px4/fmu-v5/src/board_config.h](https://github.com/PX4/PX4-Autopilot/blob/main/boards/px4/fmu-v5/src/board_config.h#L59):
+
 ```
 #define PX4IO_SERIAL_DEVICE            "/dev/ttyS6"
 #define PX4IO_SERIAL_TX_GPIO           GPIO_UART8_TX
 #define PX4IO_SERIAL_RX_GPIO           GPIO_UART8_RX
 #define PX4IO_SERIAL_BASE              STM32_UART8_BASE
 ```
+
 So the PX4IO is on `ttyS6` (we can also see that this maps to UART8, which we already knew from the preceding section).
 
 ### Putting it all together
 
 The final mapping is:
+
 ```
 ttyS0 CONFIG_STM32F7_USART1=y GPS1
 ttyS1 CONFIG_STM32F7_USART2=y TEL1
@@ -112,19 +119,23 @@ ttyS6 CONFIG_STM32F7_UART8=y PX4IO
 
 In the [flight controller docs](../flight_controller/pixhawk4.md#serial-port-mapping) the resulting table is:
 
-UART | Device | Port
---- | --- | ---
-UART1 | /dev/ttyS0 | GPS
-USART2 | /dev/ttyS1 | TELEM1 (flow control)
-USART3 | /dev/ttyS2 | TELEM2 (flow control)
-UART4 | /dev/ttyS3 | TELEM4
-USART6 | /dev/ttyS4 | RC SBUS
-UART7 | /dev/ttyS5 | Debug Console
-UART8 | /dev/ttyS6 | PX4IO
-
+| UART   | Device     | Port                  |
+| ------ | ---------- | --------------------- |
+| UART1  | /dev/ttyS0 | GPS                   |
+| USART2 | /dev/ttyS1 | TELEM1 (flow control) |
+| USART3 | /dev/ttyS2 | TELEM2 (flow control) |
+| UART4  | /dev/ttyS3 | TELEM4                |
+| USART6 | /dev/ttyS4 | RC SBUS               |
+| UART7  | /dev/ttyS5 | Debug Console         |
+| UART8  | /dev/ttyS6 | PX4IO                 |
 
 ## Other Architectures
 
 :::note
 Contributions welcome!
 :::
+
+## See Also
+
+- [Serial Port Configuration](../peripherals/serial_configuration.md)
+- [MAVLink Telemetry (OSD/GCS)](../peripherals/mavlink_peripherals.md)

--- a/en/peripherals/mavlink_peripherals.md
+++ b/en/peripherals/mavlink_peripherals.md
@@ -1,49 +1,59 @@
 # MAVLink Peripherals (GCS/OSD/Companion)
 
 Ground Control Stations (GCS), On-Screen Displays (OSD), Companion Computers, ADS-B receivers, and other MAVLink peripherals interact with PX4 using separate MAVLink streams, sent via different serial ports.
-These communication channels are configured using the [MAVLink parameters](../advanced_config/parameter_reference.md#mavlink).
+
+In order to configure that a particular serial port is used for MAVLink traffic with a particular peripheral, we use [Serial Port Configuration](../peripherals/serial_configuration.md), assigning one of the abstract "MAVLink instance" configuration parameters to the desired port.
+We then set other properties of the MAVLink channel using the parameters associated with our selected MAVLink instance, so that they match the requirements of our particular peripheral.
+
+The most relevant parameters are described below (the full set are listed in the [Parameter Reference > MAVLink](../advanced_config/parameter_reference.md#mavlink)).
 
 ## MAVLink Instances
 
-In order to assign a particular peripheral to a serial port we use the (abstract) concept of a *MAVLink instance*.
+In order to assign a particular peripheral to a serial port we use the concept of a _MAVLink instance_.
 
-Each instance can represent a particular set of streamed messages (see [MAV_X_MODE](#MAV_X_MODE) below); parameters are used to define the set of messages, the port used, data rate, etc.
+Each MAVLink instance represents a particular MAVLink configuration that you can apply to a particular port.
+At time of writing three MAVLink _instances_ are defined, each represented by a parameter [MAV_X_CONFIG](#MAV_X_CONFIG), where X is 0, 1, 2.
+
+Each instance has associated parameters that you can use to define the properties of the instance on that port, such as the set of streamed messages (see [MAV_X_MODE](#MAV_X_MODE) below), data rate ([MAV_X_RATE](#MAV_X_RATE)), whether incoming traffic is forwarded to other MAVLink instances ([MAV_X_FORWARD](#MAV_X_FORWARD)), and so on.
 
 :::note
-At time of writing three MAVLink *instances* are defined, which correspond to the 0, 1, 2 in the parameters listed below.
+MAVLink instances are an abstract concept for a particular MAVLink configuration.
+The number in the name means nothing; you can assign any instance to any port.
 :::
 
 The parameters for each instance are:
-- [MAV_X_CONFIG](../advanced_config/parameter_reference.md#MAV_0_CONFIG) - Set the serial port (UART) for this instance "X", where X is 0, 1, 2. 
+
+- <a id="MAV_X_CONFIG"></a>[MAV_X_CONFIG](../advanced_config/parameter_reference.md#MAV_0_CONFIG) - Set the serial port (UART) for this instance "X", where X is 0, 1, 2.
   It can be any unused port, e.g.: `TELEM2`, `TELEM3`, `GPS2` etc.
   For more information see [Serial Port Configuration](../peripherals/serial_configuration.md).
-- <span id="MAV_X_MODE"></span>[MAV_X_MODE](../advanced_config/parameter_reference.md#MAV_0_MODE) - Specify the telemetry mode/target (the set of messages to stream for the current instance and their rate).
+- <a id="MAV_X_MODE"></a>[MAV_X_MODE](../advanced_config/parameter_reference.md#MAV_0_MODE) - Specify the telemetry mode/target (the set of messages to stream for the current instance and their rate).
   The default values are:
-  - *Normal*: Standard set of messages for a GCS. 
-  - *Custom* or *Magic*: Nothing (in the default PX4 implementation).
-     Modes may be used for testing when developing a new mode.
-  - *Onboard*: Standard set of messages for a companion computer.
-  - *OSD*: Standard set of messages for an OSD system.
-  - *Config*: Standard set of messages and rate configuration for a fast link (e.g. USB).
-  - *Minimal*: Minimal set of messages for use with a GCS connected on a high latency link.
-  - *ExtVision* or *ExtVisionMin*: Messages for offboard vision systems (ExtVision needed for VIO).
-  - *Iridium*: Messages for an [Iridium satellite communication system](../advanced_features/satcom_roadblock.md).
-  
+
+  - _Normal_: Standard set of messages for a GCS.
+  - _Custom_ or _Magic_: Nothing (in the default PX4 implementation).
+    Modes may be used for testing when developing a new mode.
+  - _Onboard_: Standard set of messages for a companion computer.
+  - _OSD_: Standard set of messages for an OSD system.
+  - _Config_: Standard set of messages and rate configuration for a fast link (e.g. USB).
+  - _Minimal_: Minimal set of messages for use with a GCS connected on a high latency link.
+  - _ExtVision_ or _ExtVisionMin_: Messages for offboard vision systems (ExtVision needed for VIO).
+  - _Iridium_: Messages for an [Iridium satellite communication system](../advanced_features/satcom_roadblock.md).
+
   :::note
   If you need to find the specific set of message for each mode search for `MAVLINK_MODE_` in [/src/modules/mavlink/mavlink_main.cpp](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_main.cpp).
   :::
 
   :::tip
-  The mode defines the *default* messages and rates.
+  The mode defines the _default_ messages and rates.
   A connected MAVLink system can still request the streams/rates that it wants using [MAV_CMD_SET_MESSAGE_INTERVAL](https://mavlink.io/en/messages/common.html#MAV_CMD_SET_MESSAGE_INTERVAL).
   :::
-- [MAV_X_RATE](../advanced_config/parameter_reference.md#MAV_0_MODE) - Set the maximum *data rate* for this instance (bytes/second).
+
+- <a id="MAV_X_RATE"></a>[MAV_X_RATE](../advanced_config/parameter_reference.md#MAV_0_MODE) - Set the maximum _data rate_ for this instance (bytes/second).
   - This is the combined rate for all streams of individual message (the rates for individual messages are reduced if the total rate exceeds this value).
   - The default setting will generally be acceptable, but might be reduced if the telemetry link becomes saturated and too many messages are being dropped.
   - A value of 0 sets the data rate to half the theoretical value.
-- [MAV_X_FORWARD](../advanced_config/parameter_reference.md#MAV_0_FORWARD) - Enable forwarding of MAVLink packets received by the current instance onto other interfaces.
+- <a id="MAV_X_FORWARD"></a>[MAV_X_FORWARD](../advanced_config/parameter_reference.md#MAV_0_FORWARD) - Enable forwarding of MAVLink packets received by the current instance onto other interfaces.
   This might be used, for example, to transfer messages between a GCS and a companion computer so that the GCS can talk to a MAVLink enabled camera connected to the companion computer.
-
 
 Next you need to set the baud rate for the serial port you assigned above (in `MAV_X_CONFIG`).
 
@@ -51,30 +61,44 @@ Next you need to set the baud rate for the serial port you assigned above (in `M
 You will need to reboot PX4 to make the parameter available (i.e. in QGroundControl).
 :::
 
-The parameter used will depend on the [assigned serial port](../advanced_config/parameter_reference.md#serial)  - for example: `SER_GPS1_BAUD`, `SER_TEL2_BAUD`, etc. 
+The parameter used will depend on the [assigned serial port](../advanced_config/parameter_reference.md#serial) - for example: `SER_GPS1_BAUD`, `SER_TEL2_BAUD`, etc.
 The value you use will depend on the type of connection and the capabilities of the connected MAVLink peripheral.
 
+<a id="default_ports"></a>
 
-<span id="default_ports"></span>
 ## Default MAVLink Ports
 
 ### TELEM1
 
-The `TELEM 1` port is almost always used for the GCS telemetry stream.
+The `TELEM 1` port is almost always configured by default for the GCS telemetry stream ("Normal").
 
 To support this there is a [default serial port mapping](../peripherals/serial_configuration.md#default_port_mapping) of MAVLink instance 0 as shown below:
+
 - [MAV_0_CONFIG](../advanced_config/parameter_reference.md#MAV_0_CONFIG) = `TELEM 1`
 - [MAV_0_MODE](../advanced_config/parameter_reference.md#MAV_0_MODE) = `Normal`
 - [MAV_0_RATE](../advanced_config/parameter_reference.md#MAV_0_RATE)= `1200` Bytes/s
 - [MAV_0_FORWARD](../advanced_config/parameter_reference.md#MAV_0_FORWARD) = `True`
 - [SER_TEL1_BAUD](../advanced_config/parameter_reference.md#SER_TEL1_BAUD) = `57600`
 
+### TELEM2
+
+The `TELEM 2` port usually configured by default for a companion computer telemetry stream ("Onboard").
+
+To support this there is a [default serial port mapping](../peripherals/serial_configuration.md#default_port_mapping) of MAVLink instance 0 as shown below:
+
+- [MAV_1_CONFIG](../advanced_config/parameter_reference.md#MAV_0_CONFIG) = `TELEM 2`
+- [MAV_1_MODE](../advanced_config/parameter_reference.md#MAV_0_MODE) = `Onboard`
+- [MAV_1_RATE](../advanced_config/parameter_reference.md#MAV_0_RATE)= `0` (Half maximum)
+- [MAV_1_FORWARD](../advanced_config/parameter_reference.md#MAV_0_FORWARD) = `Disabled`
+- [SER_TEL2_BAUD](../advanced_config/parameter_reference.md#SER_TEL2_BAUD) = `921600`
+
 ### ETHERNET
 
 Pixhawk 5x devices (and later) that have an Ethernet port, configure it by default to connect to a GCS:
 
 On this hardware, there is a [default serial port mapping](../peripherals/serial_configuration.md#default_port_mapping) of MAVLink instance 2 as shown below:
-- [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG) = `Ethernet`  (1000)
+
+- [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG) = `Ethernet` (1000)
 - [MAV_2_BROADCAST](../advanced_config/parameter_reference.md#MAV_2_BROADCAST) = `1`
 - [MAV_2_MODE](../advanced_config/parameter_reference.md#MAV_2_MODE) = `0` (normal/GCS)
 - [MAV_2_RADIO_CTL](../advanced_config/parameter_reference.md#MAV_2_RADIO_CTL) = `0`
@@ -84,14 +108,8 @@ On this hardware, there is a [default serial port mapping](../peripherals/serial
 
 For more information see: [PX4 Ethernet Setup](../advanced_config/ethernet_setup.md)
 
-## Example
+## See Also
 
-For example, to use a companion computer on `TELEM 2` you might set parameters as shown:
-- [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG) = `TELEM 2`
-- [MAV_2_MODE](../advanced_config/parameter_reference.md#MAV_2_MODE) = `Onboard`
-- [MAV_2_RATE](../advanced_config/parameter_reference.md#MAV_2_RATE)= `80000` Bytes/s
-  :::tip
-  This value might have to be tuned/reduced in the event of message losses.
-  :::
-- [MAV_2_FORWARD](../advanced_config/parameter_reference.md#MAV_2_FORWARD) = `True`
-- [SER_TEL2_BAUD](../advanced_config/parameter_reference.md#SER_TEL2_BAUD) = `921600` baud
+- [Serial Port Configuration](../peripherals/serial_configuration.md)
+- [PX4 Ethernet Setup > PX4 MAVLink Serial Port Configuration](../advanced_config/ethernet_setup.md#px4-mavlink-serial-port-configuration)
+- [Serial Port Mapping](../hardware/serial_port_mapping.md)

--- a/en/peripherals/serial_configuration.md
+++ b/en/peripherals/serial_configuration.md
@@ -1,49 +1,64 @@
 # Serial Port Configuration
 
-Many serial (UART) ports on a Pixhawk board can be fully configured via parameters: e.g.: `GPS1`, `TELEM1`, `TELEM2`, `TELEM4` (`UART+I2C`).
+PX4 defines [default functions](#default-serial-port-configuration) for many flight controller ports, which is why you can plug a GPS module into the port labelled `GPS 1`, an RC receiver into `RC IN`, or a telemetry module into `TELEM 1`, and generally they will just work.
+
+The functions assigned to ports are fully configurable using appropriate parameters (in most cases).
+You can assign any unused port to any function, or reassign a port to use it for something else.
 
 The configuration makes it easy to (for example):
-- change the baudrate on a port.
-- run MAVLink on a different port, or change the streamed messages.
-- setup dual GPS.
-- enable sensors that run on a serial port, such as some [distance sensors](../sensor/rangefinders.md).
+
+- Run MAVLink on a different port, change the streamed messages, or switch a TELEM port to use ROS 2/XRCE-DDS.
+- Change the baud rate on a port or set the UDP port
+- Setup dual GPS.
+- Enable sensors that run on a serial port, such as some [distance sensors](../sensor/rangefinders.md).
 
 :::note
-Some ports cannot be configured because they are used for a very specific purpose like RC input or the system console (`SERIAL 5`).
+
+- Some ports cannot be configured because they are used for a very specific purpose such as the system console.
+- The mapping of specific devices to port names on the flight controller is explained in [Serial Port Mapping](../hardware/serial_port_mapping.md).
+  :::
+
+## Configuration Parameters
+
+The serial port configuration parameters allow you to assign a particular function or support for particular hardware to a particular port.
+These parameters follow the naming pattern `*_CONFIG` or `*_CFG`
+
+:::note
+_QGroundControl_ only displays the parameters for services/drivers that are present in firmware.
 :::
 
-<span id="default_port_mapping"></span>
-## Pre-configured Ports
+At time of writing the current set is:
 
-The following functions are typically mapped to the same specific serial ports on all boards, and are hence mapped by default:
+- GPS configuration: [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG), [GPS_2_CONFIG](../advanced_config/parameter_reference.md#GPS_2_CONFIG)
+- [Iridium Satellite radio](../advanced_features/satcom_roadblock.md): [ISBD_CONFIG](../advanced_config/parameter_reference.md#ISBD_CONFIG)
+- [MAVLink Ports](../peripherals/mavlink_peripherals.md): [MAV_0_CONFIG](../advanced_config/parameter_reference.md#MAV_0_CONFIG), [MAV_1_CONFIG](../advanced_config/parameter_reference.md#MAV_1_CONFIG), [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG)
+- Modal IO ESC: [MODAL_IO_CONFIG](../advanced_config/parameter_reference.md#MODAL_IO_CONFIG)
+- MSP OSD: [MSP_OSD_CONFIG](../advanced_config/parameter_reference.md#MSP_OSD_CONFIG)
+- RC Port: [RC_PORT_CONFIG](../advanced_config/parameter_reference.md#RC_PORT_CONFIG)
+- [FrSky Telemetry](../peripherals/frsky_telemetry.md): [TEL_FRSKY_CONFIG](../advanced_config/parameter_reference.md#TEL_FRSKY_CONFIG)
+- HoTT Telemetry: [TEL_HOTT_CONFIG](../advanced_config/parameter_reference.md#TEL_HOTT_CONFIG)
+- [uXRCE-DDS](../middleware/uxrce_dds.md) port: [UXRCE_DDS_CFG](../advanced_config/parameter_reference.md#UXRCE_DDS_CFG),
+- Sensors (optical flow, distance sensors): [SENS_CM8JL65_CFG](../advanced_config/parameter_reference.md#SENS_CM8JL65_CFG), [SENS_LEDDAR1_CFG](../advanced_config/parameter_reference.md#SENS_LEDDAR1_CFG), [SENS_SF0X_CFG](../advanced_config/parameter_reference.md#SENS_SF0X_CFG), [SENS_TFLOW_CFG](../advanced_config/parameter_reference.md#SENS_TFLOW_CFG), [SENS_TFMINI_CFG](../advanced_config/parameter_reference.md#SENS_TFMINI_CFG), [SENS_ULAND_CFG](../advanced_config/parameter_reference.md#SENS_ULAND_CFG), [SENS_VN_CFG](../advanced_config/parameter_reference.md#SENS_VN_CFG),
+- CRSF RC Input Driver: [RC_CRSF_PRT_CFG](../advanced_config/parameter_reference.md#RC_CRSF_PRT_CFG)
+- Sagetech MXS: [MXS_SER_CFG](../advanced_config/parameter_reference.md#MXS_SER_CFG)
+- Ultrawideband position sensor: [UWB_PORT_CFG](../advanced_config/parameter_reference.md#UWB_PORT_CFG)
+- DShot driver: [DSHOT_TEL_CFG](../advanced_config/parameter_reference.md#DSHOT_TEL_CFG)
 
-- MAVLink is mapped to the `TELEM 1` port with baudrate 57600 (for a [telemetry module](../telemetry/README.md)).
-- GPS 1 ([gps driver](../modules/modules_driver.md#gps)) is mapped to the `GPS 1` port with a baudrate *Auto* (with this setting a GPS will automatically detect the baudrate - except for the Trimble MB-Two, which requires 115200 baudrate).
-- MAVLink is mapped to the Ethernet port using `MAV_2_CONFIG` on Pixhawk devices that have an Ethernet port.
-
-All other ports have no assigned functions by default (are disabled).
-
-:::tip
-The port mappings above can be disabled by setting [MAV_0_CONFIG](../advanced_config/parameter_reference.md#MAV_0_CONFIG), [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG), and [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG) to *Disabled*, respectively.
-:::
-
+Some functions/features may define additional configuration parameters, which will follow a similar naming pattern to the port configuration prefix.
+For example, `MAV_0_CONFIG` enables MAVLink on a particular port, but you may also need to set [MAV_0_FLOW_CTRL](../advanced_config/parameter_reference.md#MAV_0_FLOW_CTRL), [MAV_0_FORWARD](../advanced_config/parameter_reference.md#MAV_0_FLOW_CTRL), [MAV_0_MODE](../advanced_config/parameter_reference.md#MAV_0_MODE) and so on.
 
 ## How to Configure a Port
 
 All the serial drivers/ports are configured in the same way:
-1. Set the configuration parameter for the service/peripheral to the port it will use.
 
-   :::note
-   Configuration parameter names follow the pattern `*_CONFIG` or `*_CFG` (*QGroundControl* only displays the parameters for services/drivers that are present in firmware).
-   
-   At time of writing the current set is: [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG), [GPS_2_CONFIG](../advanced_config/parameter_reference.md#GPS_2_CONFIG), [ISBD_CONFIG](../advanced_config/parameter_reference.md#ISBD_CONFIG), [MAV_0_CONFIG](../advanced_config/parameter_reference.md#MAV_0_CONFIG), [MAV_1_CONFIG](../advanced_config/parameter_reference.md#MAV_1_CONFIG), [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG), [MODAL_IO_CONFIG](../advanced_config/parameter_reference.md#MODAL_IO_CONFIG), [MSP_OSD_CONFIG](../advanced_config/parameter_reference.md#MSP_OSD_CONFIG), [RC_PORT_CONFIG](../advanced_config/parameter_reference.md#RC_PORT_CONFIG), [TEL_FRSKY_CONFIG](../advanced_config/parameter_reference.md#TEL_FRSKY_CONFIG), [TEL_HOTT_CONFIG](../advanced_config/parameter_reference.md#TEL_HOTT_CONFIG), [UXRCE_DDS_CFG](../advanced_config/parameter_reference.md#UXRCE_DDS_CFG), [SENS_CM8JL65_CFG](../advanced_config/parameter_reference.md#SENS_CM8JL65_CFG), [SENS_LEDDAR1_CFG](../advanced_config/parameter_reference.md#SENS_LEDDAR1_CFG), [SENS_SF0X_CFG](../advanced_config/parameter_reference.md#SENS_SF0X_CFG), [SENS_TFLOW_CFG](../advanced_config/parameter_reference.md#SENS_TFLOW_CFG), [SENS_TFMINI_CFG](../advanced_config/parameter_reference.md#SENS_TFMINI_CFG), [SENS_ULAND_CFG](../advanced_config/parameter_reference.md#SENS_ULAND_CFG), [SENS_VN_CFG](../advanced_config/parameter_reference.md#SENS_VN_CFG), [RC_CRSF_PRT_CFG](../advanced_config/parameter_reference.md#RC_CRSF_PRT_CFG), [MXS_SER_CFG](../advanced_config/parameter_reference.md#MXS_SER_CFG), [UWB_PORT_CFG](../advanced_config/parameter_reference.md#UWB_PORT_CFG), [DSHOT_TEL_CFG](../advanced_config/parameter_reference.md#DSHOT_TEL_CFG)
-   :::
+1. Set the configuration parameter for the service/peripheral to the port it will use.
 1. Reboot the vehicle in order to make the additional configuration parameters visible.
 1. Set the baud rate parameter for the selected port to the desired value.
 1. Configure module-specific parameters (i.e. MAVLink streams and data rate configuration).
 
-The [GPS/Compass > Secondary GPS](../gps_compass/README.md#dual_gps) section provides a practical example of how to configure a port in *QGroundControl* (it shows how to use `GPS_2_CONFIG` to run a secondary GPS on the `TELEM 2` port).
+The [GPS/Compass > Secondary GPS](../gps_compass/README.md#dual_gps) section provides a practical example of how to configure a port in _QGroundControl_ (it shows how to use `GPS_2_CONFIG` to run a secondary GPS on the `TELEM 2` port).
 
+Similarly [PX4 Ethernet Setup > PX4 MAVLink Serial Port Configuration](../advanced_config/ethernet_setup.md#px4-mavlink-serial-port-configuration) explains the setup for Ethernet serial ports, and [MAVLink Peripherals (OSD/GCS/Companion Computers/etc.)](../peripherals/mavlink_peripherals.md) explains the configuration for MAVLink serial ports.
 
 ## Deconflicting Ports
 
@@ -54,12 +69,45 @@ For example, it is not possible to start a MAVLink instance on a specific serial
 At time of writing there is no user feedback about conflicting ports.
 :::
 
+<a id="default_port_mapping"></a>
+
+## Default Serial Port Configuration
+
+:::tip
+These port mappings can be disabled by setting the associated configuration parameter to _Disabled_.
+:::
+
+The following ports are commonly mapped to specific functions on all boards:
+
+- `GPS 1` is configured as a GPS port (using [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG)).
+
+  This maps the [gps driver](../modules/modules_driver.md#gps) to the port with a baud rate of _Auto_ (with this setting a GPS will automatically detect the baudrate - except for the Trimble MB-Two, which requires 115200 baud rate).
+
+- `RC IN` is configured as an RC input (using [RC_PORT_CONFIG](../advanced_config/parameter_reference.md#RC_PORT_CONFIG)).
+- `TELEM 1` is configured as a MAVLink serial port suitable for connection to a GCS via a [telemetry module](../telemetry/README.md).
+
+  The configuration uses [MAV_0_CONFIG](../advanced_config/parameter_reference.md#MAV_0_CONFIG) to set the port, [MAV_0_RATE](../advanced_config/parameter_reference.md#MAV_0_RATE) to set the baud rate to 57600, and [MAV_0_MODE](../advanced_config/parameter_reference.md#MAV_1_MODE) to set the messages streamed to "Normal".
+  For more information see: [MAVLink Peripherals (OSD/GCS/Companion Computers/etc.)](../peripherals/mavlink_peripherals.md).
+
+- `TELEM 2` is configured by default as a MAVLink serial port suitable for connection to an Onboard/Companion computer via a wired connection.
+
+  The configuration uses [MAV_1_CONFIG](../advanced_config/parameter_reference.md#MAV_1_CONFIG) to set the port, [MAV_1_RATE](../advanced_config/parameter_reference.md#MAV_1_RATE) to set the baud rate, and [MAV_1_MODE](../advanced_config/parameter_reference.md#MAV_2_MODE) to set the messages streamed to "Onboard".
+  For more information see: [MAVLink Peripherals (OSD/GCS/Companion Computers/etc.)](../peripherals/mavlink_peripherals.md).
+
+- `Ethernet` is mapped as a MAVLink port on Pixhawk devices that have an Ethernet port.
+
+  The configuration uses [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG) and appropriate settings for the UDP port etc.
+  For more information see [PX4 Ethernet Setup > PX4 MAVLink Serial Port Configuration](../advanced_config/ethernet_setup.md#px4-mavlink-serial-port-configuration) and [MAVLink Peripherals (OSD/GCS/Companion Computers/etc.)](../peripherals/mavlink_peripherals.md).
+
+Other ports generally have no assigned functions by default (are disabled).
+
 ## Troubleshooting
 
 <a id="parameter_not_in_firmware"></a>
-### Configuration Parameter Missing from *QGroundControl*
 
-*QGroundControl* only displays the parameters for services/drivers that are present in firmware.
+### Configuration Parameter Missing from _QGroundControl_
+
+_QGroundControl_ only displays the parameters for services/drivers that are present in firmware.
 If a parameter is missing, then you may need to add it in firmware.
 
 :::note
@@ -67,17 +115,24 @@ PX4 firmware includes most drivers by default on [Pixhawk-series](../flight_cont
 Flash-limited boards may comment out/omit the driver (at time of writing this only affects boards based on FMUv2).
 :::
 
-You can include the missing driver in firmware by enabling the driver in the **default.px4board** config file that corresponds to the [board](https://github.com/PX4/PX4-Autopilot/tree/main/boards/px4) you want to build for. 
+You can include the missing driver in firmware by enabling the driver in the **default.px4board** config file that corresponds to the [board](https://github.com/PX4/PX4-Autopilot/tree/main/boards/px4) you want to build for.
 For example, to enable the SRF02 driver, you would a the following line to the px4board.
+
 ```
 CONFIG_DRIVERS_DISTANCE_SENSOR_SRF02=y
 ```
 
 An easier method would be using boardconfig which launches a GUI where you can easily search, disable and enable modules.
-To launch boardconfig type `make <vendor>_<board>_<label> boardconfig`
+To launch boardconfig type:
+
+```
+make <vendor>_<board>_<label> boardconfig
+```
 
 You will then need to build the firmware for your platform, as described in [Building PX4 Software](../dev_setup/building_px4.md).
 
 ## Further Information
 
-* [MAVLink Peripherals (OSD/GCS/Companion Computers/etc.)](../peripherals/mavlink_peripherals.md)
+- [MAVLink Peripherals (OSD/GCS/Companion Computers/etc.)](../peripherals/mavlink_peripherals.md)
+- [PX4 Ethernet Setup > PX4 MAVLink Serial Port Configuration](../advanced_config/ethernet_setup.md#px4-mavlink-serial-port-configuration)
+- [Serial Port Mapping](../hardware/serial_port_mapping.md)


### PR DESCRIPTION
Following on from confusion in https://discuss.px4.io/t/confusion-on-which-usart-ports-are-connected-to-which-telem-ports/33424 I wanted to make the relationship between serial port assignment to device, assignment of function, and MAVLink more clear.

THis updates the various docs - fixes a few errors and generally makes the structure easier to consume.