### PR TITLE
PX4 1.14 Release Notes

### DIFF
--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -1,4 +1,10 @@
-## PX4-Autopilot v1.14 Release Notes
+# PX4-Autopilot v1.14 Release Notes
+
+## Upgrading Notes
+
+Below important notes when upgrading to v1.14 are listed:
+
+1. Default disarmed PWM was changed from 900us to 1000us. So make sure to check whether you were using default PWM disarmed values, and if it works with your setup. You can find related information in the [step 7 of ESC calibration](../advanced_config/esc_calibration.md#steps) document for details.
 
 ## Major Changes
 
@@ -64,6 +70,8 @@ For further details please refer to the [migration guide](../middleware/uxrce_dd
 * Improved preflight failure check reporting (requires QGC [v4.2.0](https://github.com/mavlink/qgroundcontrol/releases/tag/v4.2.0) or later): [PX4-Autopilot#20030](https://github.com/PX4/PX4-Autopilot/pull/20030) and [qgroundcontrol#10362](https://github.com/mavlink/qgroundcontrol/pull/10362)
 * [Package delivery in mission](../advanced/package_delivery.md): For package delivery applications, inital support for payload delivery in mission for gripper actuator was added
 * Manual control setpoint message redefinition: `manual_control_setpoint.x`, `y`, `z`, `w` -> `roll`, `pitch`, `yaw`, `throttle`; `throttle scale [0,1] -> [-1,1]` - [PX4-Autopilot#15949](https://github.com/PX4/PX4-Autopilot/pull/15949)
+* Default motor PWM configuration - [PX4-Autopilot#21800](https://github.com/PX4/PX4-Autopilot/pull/21800)
+* Fix PWM/Oneshot calibration - [PX4-Autopilot#21726](https://github.com/PX4/PX4-Autopilot/pull/21726)
 
 ### Control
 
@@ -129,6 +137,7 @@ For further details please refer to the [migration guide](../middleware/uxrce_dd
 * Add option to disable manual yaw inputs - [PX4-Autopilot#20647](https://github.com/PX4/PX4-Autopilot/pull/20647)
 * Disable airspeed rate input into TECS	airspeed rate estimation has shwon to be unreliable, so we decided to disable it for now - [PX4-Autopilot#21317](https://github.com/PX4/PX4-Autopilot/pull/21317)
 * Support flying at different airspeeds	Add airspeed to trim throttle mapping in TECS to support flying at different airspeeds - [PX4-Autopilot#21345](https://github.com/PX4/PX4-Autopilot/pull/21345)
+* FWPositionControl: navigateWaypoints: fix logic if already past waypo… - [PX4-Autopilot#21642](https://github.com/PX4/PX4-Autopilot/pull/21642)
 
 ### Hardware Support
 
@@ -136,3 +145,32 @@ For further details please refer to the [migration guide](../middleware/uxrce_dd
 * Unicore GPS: Support for Holybro Unicore UM982 GPS - [PX4-Autopilot#21214](https://github.com/PX4/PX4-Autopilot/pull/21214))
 * VOXL2 Improved support - [PX4-Autopilot#21426](https://github.com/PX4/PX4-Autopilot/pull/21426)
 * Cubepilot Cube Black detection: Fixed Cube Black vs. Pixhawk 2 detection with CAN1 connected - [PX4-Autopilot#21342](https://github.com/PX4/PX4-Autopilot/pull/21342)
+
+## Changes between beta releases
+
+### Release Candidate 1 - beta 2
+
+* FWPositionControl: navigateWaypoints: fix logic if already past waypo… - [PX4-Autopilot#21642](https://github.com/PX4/PX4-Autopilot/pull/21642)
+* Geofence: Disable pre-emptive geofence predictor by default - [PX4-Autopilot#21657](https://github.com/PX4/PX4-Autopilot/pull/21657)
+* VTOL mission item resets and QC rework - [PX4-Autopilot#21665](https://github.com/PX4/PX4-Autopilot/pull/21665)
+* RTCM Fixes - [PX4-Autopilot#21666](https://github.com/PX4/PX4-Autopilot/pull/21666)
+* FW/VTOL: open up a couple of param constraints - [PX4-Autopilot#21671](https://github.com/PX4/PX4-Autopilot/pull/21671)
+* netman: update module description (#21664) - [PX4-Autopilot#21673](https://github.com/PX4/PX4-Autopilot/pull/21673)
+* lights: Add LP5562 RGBLED driver - [PX4-Autopilot#21685](https://github.com/PX4/PX4-Autopilot/pull/21685)
+* rc_update: throttle trim centering fix for reverse channel - [PX4-Autopilot#21692](https://github.com/PX4/PX4-Autopilot/pull/21692)
+* Fix Rover Thrust Normalization - [PX4-Autopilot#21722](https://github.com/PX4/PX4-Autopilot/pull/21722)
+* FW Rate Controller: fix saturation logic for VTOLs with differential thrust enabled - [PX4-Autopilot#21725](https://github.com/PX4/PX4-Autopilot/pull/21725)
+* Fix PWM/Oneshot calibration - [PX4-Autopilot#21726](https://github.com/PX4/PX4-Autopilot/pull/21726)
+* icp201: increase startup delay (FMUv6X) - [PX4-Autopilot#21766](https://github.com/PX4/PX4-Autopilot/pull/21766)
+* SITL Tailsitter tuning fixes and add quadtailsitter  - [PX4-Autopilot#21773](https://github.com/PX4/PX4-Autopilot/pull/21773)
+* FMUv6X: Enable ADS1115 - [PX4-Autopilot#21794](https://github.com/PX4/PX4-Autopilot/pull/21794)
+* Navigator: Loiter: always establish new Loiter with center at current… - [PX4-Autopilot#21798](https://github.com/PX4/PX4-Autopilot/pull/21798)
+* Default motor PWM configuration - [PX4-Autopilot#21800](https://github.com/PX4/PX4-Autopilot/pull/21800)
+* rc_update: fix on-off-switch with negative threshold values - [PX4-Autopilot#21801](https://github.com/PX4/PX4-Autopilot/pull/21801)
+* ROMFS: auto try RGBLED is31fl3195 - [PX4-Autopilot#21804](https://github.com/PX4/PX4-Autopilot/pull/21804)
+* netman line too long - [PX4-Autopilot#21829](https://github.com/PX4/PX4-Autopilot/pull/21829)
+* icp201: increase startup delay (FMUv6X) - [PX4-Autopilot#21834](https://github.com/PX4/PX4-Autopilot/pull/21834)
+* mag_cal: fix mag bias estimate to mag cal - [PX4-Autopilot#21835](https://github.com/PX4/PX4-Autopilot/pull/21835)
+* airframes/x500_v2: move motors from AUX to MAIN - [PX4-Autopilot#21841](https://github.com/PX4/PX4-Autopilot/pull/21841)
+* Opt flow fixes - [PX4-Autopilot#21844](https://github.com/PX4/PX4-Autopilot/pull/21844)
+* Jenkinsfile-compile board updates - [PX4-Autopilot#21860](https://github.com/PX4/PX4-Autopilot/pull/21860)

--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -12,6 +12,8 @@ This section outlines the most important changes to consider when upgrading: tho
    This is critical if you are using a custom mixer file or the airframe you assigned in an earlier version is not present in PX4 v1.14.
    However it is still recommended even if you are using an airframe that precisely matches a specific vehicle in the [Airframe Reference](../airframes/airframe_reference.md) (such as the [Holybro X500 V2](#copter_quadrotor_x_holybro_x500_v2)) as your wiring and ESCs calibration may not match the defaults.
 1. Default disarmed PWM was changed from 900us to 1000us. So make sure to check whether you were using default PWM disarmed values, and if it works with your setup. You can find related information in the [step 7 of ESC calibration](../advanced_config/esc_calibration.md#steps) document for details.
+1. ROS 2/DDS users will need to modify their code to use uXRCE-DDS (instead of Fast-RTPS, which it replaces in PX4 v1.14).
+   For more information see [uXRCE-DDS > Fast-RTPS to uXRCE-DDS Migration Guidelines](../middleware/uxrce_dds.md#fast-rtps-to-uxrce-dds-migration-guidelines)
 
 ## Major Changes
 

--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -5,6 +5,12 @@
 PX4 v1.14 contains many new features, feature upgrades, and bug fixes.
 This section outlines the most important changes to consider when upgrading: those that could affect the stability of your vehicle, and their integration with other systems.
 
+1. When updating you should use the [Actuator Configuration UI](../config/actuators.md) to confirm that the geometry of the airframe matches your vehicle, and that the correct functions (motors and servos) are mapped to outputs as they are wired to the frame and with the correct ESC type specified: the test sliders in the UI an be used to confirm motor wiring.
+
+   If using PWM ESC for motors then running an [ESC Calibration](../advanced_config/esc_calibration.md) is highly recommended, and then setting appropriate disarmed, minimum and maximum values for the motors (in the actuator UI).
+
+   This is critical if you are using a custom mixer file or the airframe you assigned in an earlier version is not present in PX4 v1.14.
+   However it is still recommended even if you are using an airframe that precisely matches a specific vehicle in the [Airframe Reference](../airframes/airframe_reference.md) (such as the [Holybro X500 V2](#copter_quadrotor_x_holybro_x500_v2)) as your wiring and ESCs calibration may not match the defaults.
 1. Default disarmed PWM was changed from 900us to 1000us. So make sure to check whether you were using default PWM disarmed values, and if it works with your setup. You can find related information in the [step 7 of ESC calibration](../advanced_config/esc_calibration.md#steps) document for details.
 
 ## Major Changes

--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -1,8 +1,9 @@
 # PX4-Autopilot v1.14 Release Notes
 
-## Upgrading Notes
+## Upgrading to PX4 v1.14
 
-Below important notes when upgrading to v1.14 are listed:
+PX4 v1.14 contains many new features, feature upgrades, and bug fixes.
+This section outlines the most important changes to consider when upgrading: those that could affect the stability of your vehicle, and their integration with other systems.
 
 1. Default disarmed PWM was changed from 900us to 1000us. So make sure to check whether you were using default PWM disarmed values, and if it works with your setup. You can find related information in the [step 7 of ESC calibration](../advanced_config/esc_calibration.md#steps) document for details.
 

--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -1,77 +1,69 @@
 # PX4-Autopilot v1.14 Release Notes
 
-## Upgrading to PX4 v1.14
+## Read Before Upgrading
 
-PX4 v1.14 contains many new features, feature upgrades, and bug fixes.
-This section outlines the most important changes to consider when upgrading: those that could affect the stability of your vehicle, and their integration with other systems.
+The v1.14 release includes a few breaking changes for users upgrading from previous versions, in particular we are moving away from using mixer files to define the vehicle geometry, motor mappings and actuators.
 
-1. When updating you should use the [Actuator Configuration UI](../config/actuators.md) to confirm that the geometry of the airframe matches your vehicle, and that the correct functions (motors and servos) are mapped to outputs as they are wired to the frame and with the correct ESC type specified: the test sliders in the UI an be used to confirm motor wiring.
+Additionally, we deprecated the Fast-RTPS interface in favor of a much cleaner solution that doesn't require a custom build target, and goes away with the additional message generation step.
 
-   If using PWM ESC for motors then running an [ESC Calibration](../advanced_config/esc_calibration.md) is highly recommended, and then setting appropriate disarmed, minimum and maximum values for the motors (in the actuator UI).
-
-   This is critical if you are using a custom mixer file or the airframe you assigned in an earlier version is not present in PX4 v1.14.
-   However it is still recommended even if you are using an airframe that precisely matches a specific vehicle in the [Airframe Reference](../airframes/airframe_reference.md) (such as the [Holybro X500 V2](#copter_quadrotor_x_holybro_x500_v2)) as your wiring and ESCs calibration may not match the defaults.
-1. Default disarmed PWM was changed from 900us to 1000us. So make sure to check whether you were using default PWM disarmed values, and if it works with your setup. You can find related information in the [step 7 of ESC calibration](../advanced_config/esc_calibration.md#steps) document for details.
-1. ROS 2/DDS users will need to modify their code to use uXRCE-DDS (instead of Fast-RTPS, which it replaces in PX4 v1.14).
-   For more information see [uXRCE-DDS > Fast-RTPS to uXRCE-DDS Migration Guidelines](../middleware/uxrce_dds.md#fast-rtps-to-uxrce-dds-migration-guidelines)
+Please continue reading for upgrade instructions.
 
 ## Major Changes
 
-### Actuator Configuration UI
+* Dynamic Control Allocation
+* Default simulation is now New Gazebo
+* Improved ROS 2 Interface thanks to uXRCE-DDS
 
-The [Actuator Configuration UI](../config/actuators.md) replaces mixer files for defining vehicle geometry, mapping motors and other functions to specific flight control outputs, and testing actuator behaviour.
+### Dynamic Control Allocation
 
-:::warning
-This feature was an experimental option for v1.13, but is now enabled by default.
-Vehicles that used custom mixer files in v1.13 will need to replace them when upgrading to PX4 v1.14.
-Other vehicles may need to configure output mappings when updating.
-:::
-
-The mixer file approach effectively hard-coded the geometry, and outputs that you had to use for each motor and actuator on a frame.
-Using [dynamic control allocation](../concept/control_allocation.md) is much more flexible because the configuration can depend on the airframe that you select.
-For example, selecting a generic airframe will allow you to specify both the geometry and output mapping, while selecting a particular ready-to-fly vehicle only allows you to test the output mappings (because everything else is hard coded/wired).
-Selecting a frame like an S-500 is somewhere in between: the geometry is fixed but you can map the flight controller outputs to whatever motors you like.
+We are very excited to enable the new [dynamic control allocation](../concept/control_allocation.md) by default; it allows users to define vehicle configurations at runtime without needing a mixer file, thanks to the new [vehicle setup dashboard](../config/actuators.md) in QGroundControl.
 
 :::note
-To use the new actuator configuration UI, you must have a recent release version of QGroundControl (version 4.2.0 or later).
+The new actuator configuration UI is available on QGroundControl 4.2.0 or newer.
 :::
 
-### Gazebo Simulator Changes
+### New Gazebo
 
-Our [simulator](../simulation/README.md) naming convention has changed, because the [Open Source Robotics Foundation (OSRF)](https://www.openrobotics.org/) is in process of retiring the original Gazebo architecture:
+Given [the recent changes](https://discourse.ros.org/t/a-new-era-for-gazebo-cross-post/25012) by the Open Robotics simulation team, we are introducing name changes for our gazebo simulations, mirroring Open Robotics naming scheme, starting with v1.14:
 
-- The previous Gazebo architecture is now referred to as [Gazebo Classic](../sim_gazebo_classic/README.md#running-the-simulation), and the new architecture has taken the name [Gazebo](../sim_gazebo_gz/README.md) (the current release is "Gazebo Garden").
-- Gazebo Classic `make` targets are now prefixed with `gazebo-classic_` (e.g. `make px4_sitl gazebo-classic_cloudship`).
+- [Ignition Gazebo](https://docs.px4.io/v1.13/en/simulation/ignition_gazebo.html) to [Gazebo](../sim_gazebo_gz/README.md)
+- [Gazebo](https://docs.px4.io/v1.13/en/simulation/gazebo.html) to [Gazebo Classic](../sim_gazebo_classic/README.md).
+
+Most importantly this affects the PX4 build target names as well:
+
 - Gazebo targets are prefixed with `gz_` (e.g. `make px4_sitl gz_x500`).
+- Gazebo Classic `make` targets are now prefixed with `gazebo-classic_` (e.g., `make px4_sitl gazebo-classic_cloudship`).
 
-You can still use [Gazebo Classic](../sim_gazebo_classic/README.md#running-the-simulation) simulation in Ubuntu 20.04 or older.
-From Ubuntu 22.04 only Gazebo is supported and can be installed.
+### Improved ROS 2 Interface via uXRCE-DDS
 
-Gazebo supports a number of vehicles and can also be used for multivehicle simulation.
-However the set of vehicles is still less diverse than available in Gazebo classic, so we'd very much welcome the contribution of more simulation targets.
+We updated the ROS 2 interface, replacing [Fast-RTPS](https://docs.px4.io/v1.13/en/middleware/micrortps.html) with [uXRCE-DDS](../ros/ros2_comm.md), resulting in an improved experience across the board. The change also avoids the need for `_rtps` build targets, enabling the interface on even more targets by default.
 
-### ROS2 & XRCE-DDS Bridge
+## Upgrade Guide
 
-[ROS2 support with micro XRCE-DDS bridge](../ros/ros2_comm.md) was added, replacing the [MicroRTPS bridge](https://docs.px4.io/v1.13/en/middleware/micrortps.html) middleware used in PX4v1.13 with [uXRCE-DDS](../middleware/uxrce_dds.md).
+For users upgrading from previous versions, please take a moment to review the following:
 
-:::note
-XRCE-DDS was an experimental opt-in feature in v1.13.
-:::
+1. The actuator changes require you to verify vehicle geometry and motors/servos mappings match your vehicle. In QGC, find the [Actuator Configuration Dashboard](../config/actuators.md), and make sure to confirm the airframe geometry matches actuals from your vehicle, as well as update motor and ensure motors and servos are mapped to outputs as they are wired to the frame and with the correct ESC type specified. Note: take advantage of the sliders in the UI. They can be used to confirm motor wiring.
 
-The new architecture provides a more seemless integration with ROS 2, using the same message definition for both uORB and ROS2 topics, which are maintained in a single shared repository.
-It also provides a building block for microROS, which will allow ROS 2 nodes to be defined directly within PX4.
+   We highly recommend running an [ESC Calibration](../advanced_config/esc_calibration.md) if using PWM ESC motors and then setting appropriate disarmed minimum and maximum values for the motors (in the actuator UI).
 
-ROS 2 users from PX4 v1.13 will need to use the new XRCE_DDS agent, and build their applications using the new message definitions.
-Application code should only require minor modifications.
-These will include (minimally):
+   The calibration is critical if you are using a custom mixer file or the airframe you assigned in an earlier version is not present in PX4 v1.14.
 
-1. Modifying topic names to match the new naming pattern, which changed from `fmu/<topic_name>/out` to `fmu/out/<topic_name>`
-1. [Adusting the QoS settings](../ros/ros2_comm.md#ros-2-subscriber-qos-settings)
+   However, an ESC Calibration is still recommended **even if** you are using an airframe that precisely matches a specific vehicle in the [Airframe Reference](../airframes/airframe_reference.md) (such as the [Holybro X500 V2](#copter_quadrotor_x_holybro_x500_v2)) as your wiring and ESCs calibration may not match the defaults.
+1. Default disarmed PWM was changed from 900us to 1000us. Verify if you previously used the default PWM disarmed values and if the changes impact your setup. For details, you can find related information in the [step 7 of ESC calibration](../advanced_config/esc_calibration.md#steps) document.
+1. Fast-RTPS users must port their code to the new uXRCE-DDS interface. Application code should only require minor modifications. These include (minimally):
 
-For further details please refer to the [migration guide](../middleware/uxrce_dds.md#fast-rtps-to-uxrce-dds-migration-guidelines).
+Modifying topic names to match the new naming pattern, which changed from `fmu/<topic_name>/out` to `fmu/out/<topic_name>`, and [Adusting the QoS settings](../ros/ros2_comm.md#ros-2-subscriber-qos-settings).
 
+For more information see [Fast-RTPS to uXRCE-DDS Migration Guidelines](../middleware/uxrce_dds.md#fast-rtps-to-uxrce-dds-migration-guidelines)
 
-## Minor Changes
+## Other changes
+
+### Hardware Support
+
+* Cubepilot Cube Orange+ - [PX4-Autopilot#20304](https://github.com/PX4/PX4-Autopilot/pull/20304)
+* Unicore GPS: Support for Holybro Unicore UM982 GPS - [PX4-Autopilot#21214](https://github.com/PX4/PX4-Autopilot/pull/21214))
+* VOXL2 Improved support - [PX4-Autopilot#21426](https://github.com/PX4/PX4-Autopilot/pull/21426)
+* Cubepilot Cube Black detection: Fixed Cube Black vs. Pixhawk 2 detection with CAN1 connected - [PX4-Autopilot#21342](https://github.com/PX4/PX4-Autopilot/pull/21342)
 
 ### Common
 
@@ -118,7 +110,7 @@ For further details please refer to the [migration guide](../middleware/uxrce_dd
 
 * MAVLink forwarding over USB: Forward MAVLink traffic to/from USB by default - [PX4-Autopilot#20745](https://github.com/PX4/PX4-Autopilot/pull/20745)
 
-### Multirotor
+### Multi-Rotor
 
 * Improved Follow-Me flight mode: Follow-me mode was improved for better user experience - [PX4-Autopilot#18026](https://github.com/PX4/PX4-Autopilot/pull/18026) | [PX4 Dev Summit presentation](https://www.youtube.com/watch?v=rYYso87cmxA)
 * Improved Helicopter Support: [Helicopter Configuration](../config_heli/README.md)
@@ -147,39 +139,3 @@ For further details please refer to the [migration guide](../middleware/uxrce_dd
 * Disable airspeed rate input into TECS	airspeed rate estimation has shwon to be unreliable, so we decided to disable it for now - [PX4-Autopilot#21317](https://github.com/PX4/PX4-Autopilot/pull/21317)
 * Support flying at different airspeeds	Add airspeed to trim throttle mapping in TECS to support flying at different airspeeds - [PX4-Autopilot#21345](https://github.com/PX4/PX4-Autopilot/pull/21345)
 * FWPositionControl: navigateWaypoints: fix logic if already past waypo… - [PX4-Autopilot#21642](https://github.com/PX4/PX4-Autopilot/pull/21642)
-
-### Hardware Support
-
-* Cubepilot Cube Orange+ - [PX4-Autopilot#20304](https://github.com/PX4/PX4-Autopilot/pull/20304)
-* Unicore GPS: Support for Holybro Unicore UM982 GPS - [PX4-Autopilot#21214](https://github.com/PX4/PX4-Autopilot/pull/21214))
-* VOXL2 Improved support - [PX4-Autopilot#21426](https://github.com/PX4/PX4-Autopilot/pull/21426)
-* Cubepilot Cube Black detection: Fixed Cube Black vs. Pixhawk 2 detection with CAN1 connected - [PX4-Autopilot#21342](https://github.com/PX4/PX4-Autopilot/pull/21342)
-
-## Changes between beta releases
-
-### Release Candidate 1 - beta 2
-
-* FWPositionControl: navigateWaypoints: fix logic if already past waypo… - [PX4-Autopilot#21642](https://github.com/PX4/PX4-Autopilot/pull/21642)
-* Geofence: Disable pre-emptive geofence predictor by default - [PX4-Autopilot#21657](https://github.com/PX4/PX4-Autopilot/pull/21657)
-* VTOL mission item resets and QC rework - [PX4-Autopilot#21665](https://github.com/PX4/PX4-Autopilot/pull/21665)
-* RTCM Fixes - [PX4-Autopilot#21666](https://github.com/PX4/PX4-Autopilot/pull/21666)
-* FW/VTOL: open up a couple of param constraints - [PX4-Autopilot#21671](https://github.com/PX4/PX4-Autopilot/pull/21671)
-* netman: update module description (#21664) - [PX4-Autopilot#21673](https://github.com/PX4/PX4-Autopilot/pull/21673)
-* lights: Add LP5562 RGBLED driver - [PX4-Autopilot#21685](https://github.com/PX4/PX4-Autopilot/pull/21685)
-* rc_update: throttle trim centering fix for reverse channel - [PX4-Autopilot#21692](https://github.com/PX4/PX4-Autopilot/pull/21692)
-* Fix Rover Thrust Normalization - [PX4-Autopilot#21722](https://github.com/PX4/PX4-Autopilot/pull/21722)
-* FW Rate Controller: fix saturation logic for VTOLs with differential thrust enabled - [PX4-Autopilot#21725](https://github.com/PX4/PX4-Autopilot/pull/21725)
-* Fix PWM/Oneshot calibration - [PX4-Autopilot#21726](https://github.com/PX4/PX4-Autopilot/pull/21726)
-* icp201: increase startup delay (FMUv6X) - [PX4-Autopilot#21766](https://github.com/PX4/PX4-Autopilot/pull/21766)
-* SITL Tailsitter tuning fixes and add quadtailsitter  - [PX4-Autopilot#21773](https://github.com/PX4/PX4-Autopilot/pull/21773)
-* FMUv6X: Enable ADS1115 - [PX4-Autopilot#21794](https://github.com/PX4/PX4-Autopilot/pull/21794)
-* Navigator: Loiter: always establish new Loiter with center at current… - [PX4-Autopilot#21798](https://github.com/PX4/PX4-Autopilot/pull/21798)
-* Default motor PWM configuration - [PX4-Autopilot#21800](https://github.com/PX4/PX4-Autopilot/pull/21800)
-* rc_update: fix on-off-switch with negative threshold values - [PX4-Autopilot#21801](https://github.com/PX4/PX4-Autopilot/pull/21801)
-* ROMFS: auto try RGBLED is31fl3195 - [PX4-Autopilot#21804](https://github.com/PX4/PX4-Autopilot/pull/21804)
-* netman line too long - [PX4-Autopilot#21829](https://github.com/PX4/PX4-Autopilot/pull/21829)
-* icp201: increase startup delay (FMUv6X) - [PX4-Autopilot#21834](https://github.com/PX4/PX4-Autopilot/pull/21834)
-* mag_cal: fix mag bias estimate to mag cal - [PX4-Autopilot#21835](https://github.com/PX4/PX4-Autopilot/pull/21835)
-* airframes/x500_v2: move motors from AUX to MAIN - [PX4-Autopilot#21841](https://github.com/PX4/PX4-Autopilot/pull/21841)
-* Opt flow fixes - [PX4-Autopilot#21844](https://github.com/PX4/PX4-Autopilot/pull/21844)
-* Jenkinsfile-compile board updates - [PX4-Autopilot#21860](https://github.com/PX4/PX4-Autopilot/pull/21860)


### PR DESCRIPTION
built on top of https://github.com/PX4/PX4-user_guide/pull/2645

I took the liberty to update the wording and moved a few things around, and I think the migration guide is looking good.