### PR TITLE
add ulog_cpp library

### DIFF
--- a/en/dev_log/ulog_file_format.md
+++ b/en/dev_log/ulog_file_format.md
@@ -480,7 +480,8 @@ A valid ULog parser must fulfill the following requirements:
   - [logger module](https://github.com/PX4/PX4-Autopilot/tree/main/src/modules/logger)
   - [replay module](https://github.com/PX4/PX4-Autopilot/tree/main/src/modules/replay)
   - [hardfault_log module](https://github.com/PX4/PX4-Autopilot/tree/main/src/systemcmds/hardfault_log): append hardfault crash data.
-- [pyulog](https://github.com/PX4/pyulog): python, ULog parser library with CLI scripts.
+- [pyulog](https://github.com/PX4/pyulog): python, ULog reader and writer library with CLI scripts.
+- [ulog_cpp](https://github.com/PX4/ulog_cpp): C++, ULog reader and writer library.
 - [FlightPlot](https://github.com/PX4/FlightPlot): Java, log plotter.
 - [MAVLink](https://github.com/mavlink/mavlink): Messages for ULog streaming via MAVLink (note that appending data is not supported, at least not for cut off messages).
 - [QGroundControl](https://github.com/mavlink/qgroundcontrol): C++, ULog streaming via MAVLink and minimal parsing for GeoTagging.


### PR DESCRIPTION
Adds https://github.com/PX4/ulog_cpp to the list of ULog libraries.

I needed a C++ reader and writer library, so I'm making this generally available. For most use-cases the python library will probably still be the preferred solution.