### PR TITLE
Docs update state estimators - lpe deprecated

### DIFF
--- a/en/advanced/switching_state_estimators.md
+++ b/en/advanced/switching_state_estimators.md
@@ -3,16 +3,25 @@
 This page shows you which state estimators are available and how you can switch between them.
 
 :::tip
-EKF2 is highly recommended for all purposes (LPE is no longer supported/maintained).
+EKF2 is highly recommended on vehicles with a GNSS/GPS.
+The Q-Estimator is recommended if you don't have GPS, and is commonly used in [multicopter racers](../config_mc/racer_setup.md).
 :::
 
 ## Available Estimators
 
 The available estimators are:
 
-- **EKF2 attitude, position and wind states estimator** - EKF2 is an extended Kalman filter estimating attitude, 3D position / velocity and wind states.
-- **LPE position estimator** - The LPE position estimator is an extended Kalman filter for 3D position and velocity states.
-- **Q attitude estimator** - The attitude Q estimator is a very simple, quaternion based complementary filter for attitude.
+- **EKF2 attitude, position and wind states estimator** (_recommended_) - An extended Kalman filter estimating attitude, 3D position / velocity and wind states.
+- **LPE position estimator** (_deprecated_) - An extended Kalman filter for 3D position and velocity states.
+
+  :::warning
+  LPE is deprecated.
+  It works (at time of writing, in PX4 v1.14) but is no longer supported or maintained.
+  :::
+
+- **Q attitude estimator** - A very simple, quaternion based complementary filter for attitude.
+  It does not require a GPS, magnetometer, or barometer.
+  <!-- Q estimator is supported (at time of writing in PX4 v1.14). Test added in PX4-Autopilot/pull/21922 -->
 
 ## How to Enable Different Estimators
 
@@ -20,9 +29,9 @@ For multirotors and VTOL use the parameter [SYS_MC_EST_GROUP](../advanced_config
 
 | SYS_MC_EST_GROUP | Q Estimator | LPE     | EKF2    |
 | ---------------- | ----------- | ------- | ------- |
-| 1                | enabled     | enabled |
+| 1                | enabled     | enabled |         |
 | 2                |             |         | enabled |
-| 3                | enabled     |         |
+| 3                | enabled     |         |         |
 
 :::note
 For FMU-v2 (only) you will also need to build PX4 to specifically include required estimator (e.g. EKF2: `make px4_fmu-v2`, LPE: `make px4_fmu-v2_lpe`).

--- a/en/tutorials/motion-capture.md
+++ b/en/tutorials/motion-capture.md
@@ -1,9 +1,9 @@
 # Flying with Motion Capture (VICON, NOKOV, Optitrack)
 
 :::warning
-**WORK IN PROGRESS**. 
+**WORK IN PROGRESS**
 
-This topic shares significant overlap with [External Position Estimation (ROS)](../ros/external_position_estimation.md). 
+This topic shares significant overlap with [External Position Estimation (ROS)](../ros/external_position_estimation.md).
 :::
 
 Indoor motion capture systems like VICON, NOKOV and Optitrack can be used to provide position and attitude data for vehicle state estimation, orto serve as ground-truth for analysis.
@@ -19,29 +19,32 @@ Most standard telemetry links like 3DR/SiK radios are **not** suitable for high-
 
 ## Coordinate Frames
 
-This section shows how to setup the system with the proper reference frames. There are various representations but we will use two of them: ENU and NED. 
+This section shows how to setup the system with the proper reference frames. There are various representations but we will use two of them: ENU and NED.
 
-* ENU is a ground-fixed frame where **X** axis points East, **Y** points North and **Z** up. The robot/vehicle body frame is **X** towards the front, **Z** up and **Y** towards the left.
-* NED has **X** towards North, **Y** East and **Z** down. The robot/vehicle body frame has **X** towards the front, **Z** down and **Y** accordingly.
+- ENU is a ground-fixed frame where **X** axis points East, **Y** points North and **Z** up. The robot/vehicle body frame is **X** towards the front, **Z** up and **Y** towards the left.
+- NED has **X** towards North, **Y** East and **Z** down. The robot/vehicle body frame has **X** towards the front, **Z** down and **Y** accordingly.
 
 Frames are shown in the image below. NED on the left, ENU on the right:
+
 ![Reference frames](../../assets/lpe/ref_frames.png)
 
-With the external heading estimation, however, magnetic North is ignored and faked with a vector corresponding to world *x* axis (which can be placed freely at mocap calibration); yaw angle will be given respect to local *x*.
+With the external heading estimation, however, magnetic North is ignored and faked with a vector corresponding to world _x_ axis (which can be placed freely at mocap calibration); yaw angle will be given respect to local _x_.
 
 :::warning
 When creating the rigid body in the motion capture software, remember to first align the robot with the world **X** axis otherwise yaw estimation will have an initial offset.
 :::
 
-## Estimator choice
+## Estimator Choice
 
-### LPE and Attitude Estimator Q
+EKF2 is recommended for GPS-enabled systems (LPE is deprecated, and hence no longer supported or maintained).
+The Q-Estimator is recommended if you don't have GPS, as it works without a magnetometer or barometer.
+
+See [Switching State Estimators](../advanced/switching_state_estimators.md) for more information.
 
 ### EKF2
 
-
-The ROS topic for motion cap `mocap_pose_estimate` for mocap systems and `vision_pose_estimate` for vision. Check [mavros_extras](http://wiki.ros.org/mavros_extras) for further info.
-
+The ROS topic for motion cap `mocap_pose_estimate` for mocap systems and `vision_pose_estimate` for vision.
+Check [mavros_extras](http://wiki.ros.org/mavros_extras) for further info.
 
 ## Testing
 


### PR DESCRIPTION
Explicitly marks LPE as deprecated in the main place we talk about it "Switching state estimators". Q Estimator still supported - added note about where it is used (non-GPS systems). Also added a little info to MOCAP systems. Ran prettier on the affected docs.

Note this follows on from test being added for Q Estimator https://github.com/PX4/PX4-Autopilot/pull/21922 and discussion about deprecation in https://discord.com/channels/1022170275984457759/1128542715106316368
