### PR TITLE
mission with local position estimate

### DIFF
--- a/en/flight_modes/mission.md
+++ b/en/flight_modes/mission.md
@@ -1,12 +1,12 @@
 # Mission Mode
 
-[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
+[<img src="../../assets/site/position_fixed.svg" title="Global position fix required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
 
 *Mission mode* causes the vehicle to execute a predefined autonomous [mission](../flying/missions.md) (flight plan) that has been uploaded to the flight controller. 
 The mission is typically created and uploaded with a Ground Control Station (GCS) application like [QGroundControl](https://docs.qgroundcontrol.com/master/en/) (QGC).
 
 :::note
-- This mode requires 3d position information (e.g. GPS).
+- This mode requires a global 3d position estimate (from GPS or a [local position](#missions-using-a-local-position-estimate)).
 - The vehicle must be armed before this mode can be engaged.
 - This mode is automatic - no user intervention is *required* to control the vehicle.
 - RC control switches can be used to change flight modes on any vehicle.
@@ -379,3 +379,12 @@ During mission execution the vehicle will ascend vertically to the minimum takeo
 After transitioning the vehicle heads towards the 3D position defined in the mission item.
 
 A VTOL mission requires a `VTOL Takeoff` mission item to takeoff; if however the vehicle is already flying when the mission is started the takeoff item will be treated as a normal waypoint.
+
+## Missions using a Local Position Estimate
+
+[Mission mode](../flight_modes/mission.md) requires a _global_ position estimate, which would normally come from a GPS/GNSS positioning system.
+
+Vehicles that only have a _local_ position estimate (say, from [Motion Capture (MOCAP)](../advanced/computer_vision.md#motion-capture) or [Visual Inertial Odometry (VIO)](../advanced/computer_vision.md#visual-inertial-odometry-vio)) can still plan and execute missions, by setting the GPS origin.
+This forces EKF to provide a global position estimate based on the origin and the local position estimate.
+
+The global origin may be set using the [SET_GPS_GLOBAL_ORIGIN](https://mavlink.io/en/messages/common.html#SET_GPS_GLOBAL_ORIGIN) MAVLink message.

--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -151,6 +151,13 @@ If performance is still poor, try increasing the [LPE_PN_V](../advanced_config/p
 This will cause the estimator to trust measurements more during velocity estimation.
 :::
 
+## Planning/Executing Missions
+
+[Mission mode](../flight_modes/mission.md) _requires_ a global position estimate.
+
+Systems that only have a local position estimate (from MOCAP, VIO, or similar) can use the [SET_GPS_GLOBAL_ORIGIN](https://mavlink.io/en/messages/common.html#SET_GPS_GLOBAL_ORIGIN) MAVLink message to set the origin of the EKF to a particular GPS location.
+EKF will then provide a global position estimate (based on origin and local frame position), which can be used to plan and execute missions.
+
 ## Working with ROS
 
 ROS is not *required* for supplying external pose information, but is highly recommended as it already comes with good integrations with VIO and MoCap systems.


### PR DESCRIPTION
This comes from the discussion [here](https://discord.com/channels/1022170275984457759/1134467913324187769) about planning missions with only a local estimate.

I have updated in two places - mission mode and ros/external_position_estimation.html, which are the two places you might try find out about it.

@bresch Is the global position generated by EFK from local position and global position origin used in **all auto modes**, or just mission? I.e. can I use hold mode if I set this? What about orbit and so on?

FYI @beniaminopozzan having this in the ROS topic isn't strictly needed, but when we create our "master" topic on VIO/MOCAP I want this information to be included, and this is a good way to make that more likely).