### PR TITLE
Prearm checks - more info in the extended guide

### DIFF
--- a/en/advanced_config/prearm_arm_disarm.md
+++ b/en/advanced_config/prearm_arm_disarm.md
@@ -1,4 +1,4 @@
-# Prearm, Arm, Disarm Configuration
+# Arm, Disarm, Prearm Configuration
 
 Vehicles may have moving parts, some of which are potentially dangerous when powered (in particular motors and propellers)!
 
@@ -56,8 +56,8 @@ RC controllers will have different gestures [based on their mode](../getting_sta
 
 The required hold time can be configured using [COM_RC_ARM_HYST](#COM_RC_ARM_HYST).
 
-| Parameter                                                                                                      | Description                                                                                                |
-| -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Parameter                                                                                                | Description                                                                                                |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | <a id="COM_RC_ARM_HYST"></a>[COM_RC_ARM_HYST](../advanced_config/parameter_reference.md#COM_RC_ARM_HYST) | Time that RC stick must be held in arm/disarm position before arming/disarming occurs (default: 1 second). |
 
 <a id="arm_disarm_switch"></a>
@@ -93,6 +93,37 @@ The feature is configured using the following timeouts.
 | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | <a id="COM_DISARM_LAND"></a>[COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND)    | Time-out for auto disarm after landing. Default: 2s (-1 to disable).            |
 | <a id="COM_DISARM_PRFLT"></a>[COM_DISARM_PRFLT](../advanced_config/parameter_reference.md#COM_DISARM_PRFLT) | Time-out for auto disarm if too slow to takeoff. Default: 10s (<=0 to disable). |
+
+## Pre-Arm Checks
+
+To reduce accidents, vehicles are only allowed to arm certain conditions are met.
+Arming is prevented if:
+
+- The vehicle is not in a "healthy" state.
+  For example it is not calibrated, or is reporting sensor errors.
+- The vehicle has a [safety switch](../getting_started/px4_basic_concepts.md#safety-switch) that has not been engaged.
+- The vehicle has a [remote ID](../peripherals/remote_id.md) that is unhealthy or otherwise not ready
+- A VTOL vehicle is in fixed-wing mode ([by default](../advanced_config/parameter_reference.md#CBRK_VTOLARMING)).
+- The current mode requires an adequate global position estimate but the vehicle does not have GPS lock.
+- Many more ...
+
+The current failed checks can be viewed in QGroundControl (v4.2.0 and later): [Fly View > Arming and Preflight Checks](https://docs.qgroundcontrol.com/master/en/FlyView/FlyView.html#arm).
+
+Note that internally PX4 runs arming checks at 10Hz.
+A list of the failed checks is kept, and if the list changes PX4 emits the current list using the [Events interface](../concept/events_interface.md).
+The list is also sent out when the GCS connects.
+Effectively the GCS knows the status of prearm checks immediately, both when disarmed and armed.
+
+:::details Implementation notes for developers
+The client implementation is in [libevents](https://github.com/mavlink/libevents):
+
+- [libevents > Event groups](https://github.com/mavlink/libevents#event-groups)
+- [health_and_arming_checks.h](https://github.com/mavlink/libevents/blob/main/libs/cpp/parse/health_and_arming_checks.h)
+
+QGC implementation: [HealthAndArmingCheckReport.cc](https://github.com/mavlink/qgroundcontrol/blob/master/src/Vehicle/HealthAndArmingCheckReport.cc).
+:::
+
+PX4 also emits a subset of the arming check information in the [SYS_STATUS](https://mavlink.io/en/messages/common.html#SYS_STATUS) message (see [MAV_SYS_STATUS_SENSOR](https://mavlink.io/en/messages/common.html#MAV_SYS_STATUS_SENSOR)).
 
 ## Arming Sequence: Pre Arm Mode & Safety Button
 

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -185,19 +185,17 @@ Flight controllers that do not include an SD Card slot may:
 
 ## Arming and Disarming
 
-Vehicles may have moving parts, some of which are dangerous when powered (in particular motors and propellers)!
+A vehicle is said to be _armed_ when all motors and actuators are powered, and _disarmed_ when nothing is powered.
+There is also a _prearmed_ state when only actuators are powered.
 
-To reduce accidents, vehicles should be armed (motors and actuators powered) as little as possible when the vehicle is on the ground.
-
-Arming is triggered by default (Mode 2 transmitters) by holding the RC throttle/yaw stick on the _bottom right_ for one second (to disarm, hold stick on bottom left).
-It is alternatively possible to configure PX4 to arm using an RC switch or button (and arming MAVLink commands can also be sent from a ground station).
-
-:::tip
-Sometimes a vehicle will not arm for reasons that are not obvious.
-QGC v4.2.0 (Daily build at time of writing) and later provide an arming check report in [Fly View > Arming and Preflight Checks](https://docs.qgroundcontrol.com/master/en/FlyView/FlyView.html#arm).
-From PX4 v1.14 this provides comprehensive information about arming problems along with possible solutions.
+:::warning
+Armed vehicles can be dangerous as propellors will be spinning.
 :::
 
+Arming is triggered by default (on Mode 2 transmitters) by holding the RC throttle/yaw stick on the _bottom right_ for one second (to disarm, hold stick on bottom left).
+It is alternatively possible to configure PX4 to arm using an RC switch or button (and arming MAVLink commands can also be sent from a ground station).
+
+To reduce accidents, vehicles should be armed as little as possible when the vehicle is on the ground.
 By default, vehicles are:
 
 - _Disarmed_ or _Prearmed_ (motors unpowered) when not in use, and must be explicitly _armed_ before taking off.
@@ -210,6 +208,11 @@ By default, vehicles are:
 When prearmed you can still use actuators, while disarming unpowers everything.
 Prearmed and disarmed should both safe, and a particular vehicle may support either or both.
 
+:::tip
+Sometimes a vehicle will not arm for reasons that are not obvious.
+QGC v4.2.0 (Daily build at time of writing) and later provide an arming check report in [Fly View > Arming and Preflight Checks](https://docs.qgroundcontrol.com/master/en/FlyView/FlyView.html#arm).
+From PX4 v1.14 this provides comprehensive information about arming problems along with possible solutions.
+:::
 
 
 A detailed overview of arming and disarming configuration can be found here: [Prearm, Arm, Disarm Configuration](../advanced_config/prearm_arm_disarm.md).


### PR DESCRIPTION
This is follow on to the docs in  https://github.com/PX4/PX4-user_guide/pull/2682 for for https://github.com/PX4/PX4-Autopilot/pull/20030#issuecomment-1670821728

Essentially the basic concepts doc covers the default behaviour for a new user and the "Arm, Disarm, Prearm Configuration" topic is the full detail for people who want to configure stuff. This updates that second topic with a new section on prearming. This new section explains a bit about what prearming is, and links to the right places to find out more for developers. 

FYI only @bkueng 