### PR TITLE
Unhide depth camera docs

### DIFF
--- a/en/sim_gazebo_classic/README.md
+++ b/en/sim_gazebo_classic/README.md
@@ -387,10 +387,16 @@ This publishes depth images and camera information on the `/camera/depth/image_r
 To use these images, you will need to install ROS or ROS 2.
 Note the warning at the top of this page about how to "avoid installation conflicts" when installing ROS and Gazebo.
 
-You can simulate a quadrotor with a forward-facing depth camera using:
+You can simulate a quadrotor with a forward-facing depth camera:
 
 ```sh
 make px4_sitl gazebo-classic_iris_depth_camera
+```
+
+or a quadrotor with a downward-facing depth camera:
+
+```sh
+make px4_sitl gazebo-classic_iris_downward_depth_camera
 ```
 
 <a id="flight_termination"></a>

--- a/en/sim_gazebo_classic/README.md
+++ b/en/sim_gazebo_classic/README.md
@@ -378,10 +378,6 @@ The camera also supports/responds to the following MAVLink commands: [MAV_CMD_RE
 The simulated camera is implemented in [PX4/PX4-SITL_gazebo/main/src/gazebo_camera_manager_plugin.cpp](https://github.com/PX4/PX4-SITL_gazebo/blob/main/src/gazebo_camera_manager_plugin.cpp). 
 :::
 
-<!-- Simulated Depth Camera section removed 20230301.
-  Feature not yet available: https://github.com/PX4/PX4-user_guide/pull/2264#issuecomment-1441711189 
--->
-<!-- 
 ## Simulated Depth Camera
 
 The *Gazebo Classic* [depth camera model](https://github.com/PX4/PX4-SITL_gazebo-classic/blob/main/models/depth_camera/depth_camera.sdf.jinja) simulates an Intel® RealSense™ D455 stereo depth camera using the [Openni Kinect plugin](https://classic.gazebosim.org/tutorials?tut=ros_gzplugins#OpenniKinect).
@@ -396,8 +392,6 @@ You can simulate a quadrotor with a forward-facing depth camera using:
 ```sh
 make px4_sitl gazebo-classic_iris_depth_camera
 ```
-
--->
 
 <a id="flight_termination"></a>
 ## Simulated Parachute/Flight Termination


### PR DESCRIPTION
The depth camera simulation docs were hidden in #2315 since the required PX4 targets were not available.

If merged, https://github.com/PX4/PX4-Autopilot/pull/21972 will make these targets available and the simulation commands will work.

Fixes https://github.com/PX4/PX4-user_guide/issues/2283