### PR TITLE
coding guide - note to use style guide for new code

### DIFF
--- a/en/contribute/code.md
+++ b/en/contribute/code.md
@@ -23,7 +23,6 @@ PX4 uses the [Google C++ style guide](https://google.github.io/styleguide/cppgui
 :::note
 Not all PX4 source code matches the style guide, but any _new code_ that you write should do so — in both new and existing files.
 If you update an existing file you are not required to make the whole file comply with the style guide, just the code you've modified.
-However if you do, we recommend that you use `clang-format` and add formatting changes as a separate commit.
 :::
 
 ### Tabs

--- a/en/contribute/code.md
+++ b/en/contribute/code.md
@@ -20,6 +20,12 @@ All code contributions have to be under the permissive [BSD 3-clause license](ht
 
 PX4 uses the [Google C++ style guide](https://google.github.io/styleguide/cppguide.html), with the following (minimal) modifications:
 
+:::note
+Not all PX4 source code matches the style guide, but any _new code_ that you write should do so — in both new and existing files.
+There is no requirement to update other code in changed files to match the guide.
+However if you do, we recommend that you use `clang-format` and add formatting changes as a separate commit.
+:::
+
 ### Tabs
 
 - Tabs are used for indentation (equivalent to 8 spaces).

--- a/en/contribute/code.md
+++ b/en/contribute/code.md
@@ -22,7 +22,7 @@ PX4 uses the [Google C++ style guide](https://google.github.io/styleguide/cppgui
 
 :::note
 Not all PX4 source code matches the style guide, but any _new code_ that you write should do so — in both new and existing files.
-There is no requirement to update other code in changed files to match the guide.
+If you update an existing file you are not required to make the whole file comply with the style guide, just the code you've modified.
 However if you do, we recommend that you use `clang-format` and add formatting changes as a separate commit.
 :::
 


### PR DESCRIPTION
PX4 source code should use google style guide, but parts of it are not compliant. In future we'll run clang-tidy, and clang-format, but in the meantime users should ensure that any new code in new or existing files should match the style guide.

This recommends following the guide for new code. 
It says you can also update existing files that you touch to match the style guide _if you want_. But if you do keep in a separate commit, and use clang-format. This makes sense to me because you can still differentiate the changes. Happy to argue/remove that bit.

@lvanasse Thoughts?

This falls out of discussion in https://discord.com/channels/1022170275984457759/1138541894620684388