### PR TITLE
Update docs on using auto modes with local estimate

### DIFF
--- a/en/flight_modes/land.md
+++ b/en/flight_modes/land.md
@@ -6,7 +6,8 @@ The *Land* flight mode causes the vehicle to land at the position where the mode
 After landing, vehicles will disarm after a short timeout (by default).
 
 :::note
-* This mode requires a valid position estimate unless the mode is entered due to a failsafe, in which case only altitude is required (typically a barometer is built into the flight controller).
+* This mode requires a valid global position estimate (from GPS or inferred from a [local position](../ros/external_position_estimation.md#enabling-auto-modes-with-a-local-position)).
+* In a failsafe the mode only requires altitude (typically a barometer is built into the flight controller).
 * This mode is automatic - no user intervention is *required* to control the vehicle.
 * RC control switches can be used to change flight modes on any vehicle.
 * RC stick movement in a multicopter (or VTOL in multicopter mode) will [by default](#COM_RC_OVERRIDE) change the vehicle to [Position mode](../flight_modes/position_mc.md) unless handling a critical battery failsafe.

--- a/en/flight_modes/mission.md
+++ b/en/flight_modes/mission.md
@@ -6,7 +6,7 @@
 The mission is typically created and uploaded with a Ground Control Station (GCS) application like [QGroundControl](https://docs.qgroundcontrol.com/master/en/) (QGC).
 
 :::note
-- This mode requires a global 3d position estimate (from GPS or a [local position](#missions-using-a-local-position-estimate)).
+- This mode requires a global 3d position estimate (from GPS or inferred from a [local position](../ros/external_position_estimation.md#enabling-auto-modes-with-a-local-position)).
 - The vehicle must be armed before this mode can be engaged.
 - This mode is automatic - no user intervention is *required* to control the vehicle.
 - RC control switches can be used to change flight modes on any vehicle.
@@ -380,11 +380,3 @@ After transitioning the vehicle heads towards the 3D position defined in the mis
 
 A VTOL mission requires a `VTOL Takeoff` mission item to takeoff; if however the vehicle is already flying when the mission is started the takeoff item will be treated as a normal waypoint.
 
-## Missions using a Local Position Estimate
-
-[Mission mode](../flight_modes/mission.md) requires a _global_ position estimate, which would normally come from a GPS/GNSS positioning system.
-
-Vehicles that only have a _local_ position estimate (say, from [Motion Capture (MOCAP)](../advanced/computer_vision.md#motion-capture) or [Visual Inertial Odometry (VIO)](../advanced/computer_vision.md#visual-inertial-odometry-vio)) can still plan and execute missions, by setting the GPS origin.
-This forces EKF to provide a global position estimate based on the origin and the local position estimate.
-
-The global origin may be set using the [SET_GPS_GLOBAL_ORIGIN](https://mavlink.io/en/messages/common.html#SET_GPS_GLOBAL_ORIGIN) MAVLink message.

--- a/en/flight_modes/orbit.md
+++ b/en/flight_modes/orbit.md
@@ -2,7 +2,16 @@
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](../getting_started/flight_modes.md#key_difficulty)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
 
-The *Orbit* guided flight mode allows you to command a multicopter (or VTOL in multicopter mode) to fly in a circle, by [default](https://mavlink.io/en/messages/common.html#ORBIT_YAW_BEHAVIOUR) yawing so that it always faces towards the center.
+The *Orbit* guided flight mode allows you to command a multicopter (or VTOL in multicopter mode) to fly in a circle at a particular location, by [default](https://mavlink.io/en/messages/common.html#ORBIT_YAW_BEHAVIOUR) yawing so that it always faces towards the center.
+
+:::note
+* This mode requires a valid global position estimate (from GPS or inferred from a [local position](../ros/external_position_estimation.md#enabling-auto-modes-with-a-local-position)).
+* This mode is automatic - no user intervention is *required* to control the vehicle.
+* RC stick movement can control ascent/descent and orbit speed and direction.
+* The mode can be triggered using the [MAV_CMD_DO_ORBIT](https://mavlink.io/en/messages/common.html#MMAV_CMD_DO_ORBIT) MAVLink command.
+:::
+
+## Overview
 
 ![Orbit Mode - MC](../../assets/flying/orbit.jpg)
 

--- a/en/flight_modes/return.md
+++ b/en/flight_modes/return.md
@@ -10,7 +10,7 @@ The following sections explain how to configure the [return type](#return_types)
 At the end there are sections explaining the *default* (preconfigured) behaviour for each [vehicle type](#default_configuration).
 
 :::note
-* This mode requires GPS.
+* This mode requires a global 3d position estimate (from GPS or inferred from a [local position](../ros/external_position_estimation.md#enabling-auto-modes-with-a-local-position)).
 * This mode is automatic - no user intervention is *required* to control the vehicle.
 * RC control switches can be used to change flight modes on any vehicle.
 * RC stick movement in a multicopter (or VTOL in multicopter mode) will [by default](#COM_RC_OVERRIDE) change the vehicle to [Position mode](../flight_modes/position_mc.md) unless handling a critical battery failsafe.

--- a/en/getting_started/flight_modes.md
+++ b/en/getting_started/flight_modes.md
@@ -69,7 +69,7 @@ The icons below are used within the document:
 Icon | Description
 --- | ---
 <a id="key_manual"></a>[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual) | Manual mode. Remote control required.
-<a id="key_automatic"></a>[<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic) | Automatic mode. RC control is disabled by default except to change modes.
+<a id="key_automatic"></a>[<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic) | Automatic mode. RC control is disabled by default except to change modes. Global position estimate required.
 <a id="key_position_fixed"></a>[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed) | Position fix required (e.g. GPS, VIO, or some other positioning system).
 <a id="altitude_only"></a><img src="../../assets/site/altitude_icon.svg" title="Altitude fix required (e.g. barometer, rangefinder)" width="30px" /> | Altitude required (e.g. from barometer, rangefinder).
 <a id="key_difficulty"></a>[<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />&nbsp;<img src="../../assets/site/difficulty_medium.png" title="Medium difficulty to fly" width="30px" />&nbsp;<img src="../../assets/site/difficulty_hard.png" title="Hard to fly" width="30px" />](#key_difficulty) | Flight mode difficulty (Easy to Hard)

--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -151,12 +151,14 @@ If performance is still poor, try increasing the [LPE_PN_V](../advanced_config/p
 This will cause the estimator to trust measurements more during velocity estimation.
 :::
 
-## Planning/Executing Missions
+## Enabling Auto Modes with a Local Position
 
-[Mission mode](../flight_modes/mission.md) _requires_ a global position estimate.
+All PX4 automatic flight modes ([Mission](../flight_modes/mission.md), [Return](../flight_modes/return.md), [Land](../flight_modes/land.md), [Hold](../flight_modes/land.md), [Orbit](../flight_modes/orbit.md))) require a _global_ position estimate, which would normally come from a GPS/GNSS system.
 
-Systems that only have a local position estimate (from MOCAP, VIO, or similar) can use the [SET_GPS_GLOBAL_ORIGIN](https://mavlink.io/en/messages/common.html#SET_GPS_GLOBAL_ORIGIN) MAVLink message to set the origin of the EKF to a particular GPS location.
-EKF will then provide a global position estimate (based on origin and local frame position), which can be used to plan and execute missions.
+Systems that only have a _local_ position estimate (from MOCAP, VIO, or similar) can use the [SET_GPS_GLOBAL_ORIGIN](https://mavlink.io/en/messages/common.html#SET_GPS_GLOBAL_ORIGIN) MAVLink message to set the origin of the EKF to a particular global location.
+EKF will then provide a global position estimate based on origin and local frame position.
+
+This can then be used when planning and executing indoor missions, or to set a local return point, and so on.
 
 ## Working with ROS
 


### PR DESCRIPTION
This docs from #2689 to account for the fact that all automatic modes require a position estimate - not just mission mode.

To do this, the topic in the external position topic changed from "Planning/Executing Missions" to "Enabling Auto Modes with a Local Position". I thought about "Global Position from Local Position" (or similar) but I think people are more likely to find this.

Then in all the auto modes I linked back from the high level description box:
![image](https://github.com/PX4/PX4-user_guide/assets/5368500/fc137018-abdc-4713-afc8-0b3e77a2dc84)

So if you are interested in local positions you can find out about this from either the flight modes or external_position_estimation topic

@beniaminopozzan Note that as discussed, this being in "external_position_estimation" is OK, but the topic should not be living under ROS as such. It's a placeholder :-).

This OK for you @bresch 