### PR TITLE
Fix location of `rootfs` in SITL

### DIFF
--- a/en/debug/system_wide_replay.md
+++ b/en/debug/system_wide_replay.md
@@ -29,7 +29,7 @@ Reasons for this are given below.
   ```
   This will create the output in a separate build directory `build/px4_sitl_default_replay` (so that the parameters don't interfere with normal builds).
   It's possible to choose any posix SITL build target for replay, the build system knows through the `replay` environment variable that it's in replay mode.
-- Add ORB publisher rules file in `build/px4_sitl_default_replay/tmp/rootfs/orb_publisher.rules`.
+- Add ORB publisher rules file in `build/px4_sitl_default_replay/rootfs/orb_publisher.rules`.
   This file defines which module is allowed to publish which messages.
   It has the following format:
   ```
@@ -52,7 +52,7 @@ Reasons for this are given below.
   
   This allows that the modules, which usually publish these topics, don't need to be disabled for replay.
 
-- Optional: setup parameter overrides in the file `build/px4_sitl_default_replay/tmp/rootfs/replay_params.txt`.
+- Optional: setup parameter overrides in the file `build/px4_sitl_default_replay/rootfs/replay_params.txt`.
   This file should contain a list of `<param_name> <value>`, like:
   
   ```
@@ -122,7 +122,7 @@ The parameters can be adjusted as well.
 They can be extracted from the log with the following \(install pyulog with `pip install --user pyulog` first\):
 
 ```
-ulog_params -i "$replay" -d ' ' | grep -e '^EKF2' > build/px4_sitl_default_replay/tmp/rootfs/replay_params.txt
+ulog_params -i "$replay" -d ' ' | grep -e '^EKF2' > build/px4_sitl_default_replay/rootfs/replay_params.txt
 ```
 
 Then edit the parameters in the file as needed and restart the replay process with `make px4_sitl none`. 

--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -53,7 +53,7 @@ This allows, for example, logging of your own uORB topics.
 ### SD Card Configuration
 
 Separately, the list of logged topics can also be customized with a file on the SD card.
-Create a file `etc/logging/logger_topics.txt` on the card with a list of topics (For SITL, it's `build/px4_sitl_default/tmp/rootfs/fs/microsd/etc/logging/logger_topics.txt`):
+Create a file `etc/logging/logger_topics.txt` on the card with a list of topics (For SITL, it's `build/px4_sitl_default/rootfs/fs/microsd/etc/logging/logger_topics.txt`):
 ```
 <topic_name> <interval> <instance>
 ```

--- a/en/simulation/jmavsim.md
+++ b/en/simulation/jmavsim.md
@@ -160,7 +160,7 @@ The simulation can be [interfaced to ROS](../simulation/ros_interface.md) the sa
 ## Important Files
 
 * The startup scripts are discussed in [System Startup](../concept/system_startup.md).
-* The simulated root file system ("`/`" directory) is created inside the build directory here: `build/px4_sitl_default/tmp/rootfs`.
+* The simulated root file system ("`/`" directory) is created inside the build directory here: `build/px4_sitl_default/rootfs`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
The `rootfs` directory for SITL builds is no longer in `build/px4_sitl_[target]/tmp/`, but rather directly under `build/px4_sitl_[target]`.

- Changed in https://github.com/PX4/PX4-Autopilot/pull/20090