### PR TITLE
Update airframe.md - modify so no longer states airframe results in t…

### DIFF
--- a/en/config/airframe.md
+++ b/en/config/airframe.md
@@ -1,11 +1,10 @@
 # Vehicle (Frame) Selection
 
 After installing firmware you need to select the [vehicle type and specific frame configuration](../airframes/airframe_reference.md) that best matches your vehicle frame.
-This configures appropriate default parameter values for the vehicle type.
+This applies appropriate default parameter values for the selected frame, such as the vehicle type, number of motors, relative motor position, and so on.
 
 :::note
-Select the configuration for your vehicle brand and model, if one exists, as this should be tuned well enough to fly following standard configuration.
-Otherwise select the closest "Generic" frame option. 
+Choose the frame that matches your vehicle brand and model if one exists, and otherwise select the closest "Generic" frame option matching your vehicle.
 :::
 
 ## Set the Frame
@@ -16,18 +15,21 @@ To set the airframe:
 1. Select **"Q" icon > Vehicle Setup > Airframe** (sidebar) to open *Airframe Setup*.
 1. Select the broad vehicle group/type that matches your airframe and then use the dropdown within the group to choose the airframe that best matches your vehicle.
    
-   ![](../../assets/qgc/setup/airframe/airframe_px4.jpg)
+   ![Selecting generic hexarotor X frame in QGroundControl](../../assets/qgc/setup/airframe/airframe_px4.jpg)
 
    The example above shows *Generic Hexarotor X geometry* selected from the *Hexarotor X* group.
-
 
 1. Click **Apply and Restart**.
    Click **Apply** in the following prompt to save the settings and restart the vehicle.
 
    <img src="../../assets/qgc/setup/airframe/airframe_px4_apply_prompt.jpg" width="300px" title="Apply airframe selection prompt" />
 
+## Next Steps
+
+[Actuator Configuration & Testing](../config/actuators.md) shows how to set the precise geometry of the vehicle motors and actuators, and their mapping to flight controller outputs.
+After mapping actuators to outputs you should perform [ESC Calibration](../advanced_config/esc_calibration.md) if using PWM or OneShot ESCs.
 
 ## Further Information
 
-* [QGroundControl User Guide > Airframe](https://docs.qgroundcontrol.com/master/en/SetupView/Airframe.html)
-* [PX4 Setup Video - @37s](https://youtu.be/91VGmdSlbo4?t=35s) (Youtube)
+- [QGroundControl User Guide > Airframe](https://docs.qgroundcontrol.com/master/en/SetupView/Airframe.html)
+- [PX4 Setup Video - @37s](https://youtu.be/91VGmdSlbo4?t=35s) (Youtube)


### PR DESCRIPTION
The problem that this fixes is the text:

> Select the configuration for your vehicle brand and model, if one exists, as this should be tuned well enough to fly following standard configuration.

This is not the case, and in any case not desirable. Actually it just apply a default configuration of vehicle type, motor number. Then if you selected your particular model it might include correct motor geometry - but otherwise if you select "generic" you will have to that too.

Anyway, that is removed and I've added next steps pointing to actuator config for next steps. The idea being to infer that this airframe config us only the first step.

I would like to explain why you don't select a closely matching frame that isn't your frame. Mostly this is because it _might_ have params set you would not expect. Better to start clean from generic. Hard to fit in and still keep simple. 