### PR TITLE
Rebrand contribution to community

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -683,7 +683,7 @@
       * [ROS/MAVROS Installation on RPi](ros/raspberrypi_installation.md)
       * [External Position Estimation (Vision/Motion based)](ros/external_position_estimation.md)
   * [DroneKit](robotics/dronekit.md)
-* [Contribution (&Dev Call)](contribute/README.md)
+* [Community](contribute/README.md)
   * [Dev Call](contribute/dev_call.md)
   * [Support](contribute/support.md)
   * [Source Code Management](contribute/code.md)

--- a/en/contribute/README.md
+++ b/en/contribute/README.md
@@ -1,23 +1,24 @@
-# Contributing
+# Community
 
 <div v-if="$themeConfig.px4_version != 'main'">
   <div class="custom-block danger"><p class="custom-block-title">This page may be out of date</p>. <p>The latest version <a href="https://docs.px4.io/main/en/contribute/">can be found here</a>.</p>
   </div>
 </div>
 
+Welcome to the PX4 Community!
+
 :::tip
-We pledge to adhere to the [PX4 code of conduct](https://github.com/PX4/PX4-Autopilot/blob/main/CODE_OF_CONDUCT.md). 
-This code aims to foster an open and welcoming environment.
+We pledge to adhere to the [PX4 code of conduct](https://github.com/PX4/PX4-Autopilot/blob/main/CODE_OF_CONDUCT.md), which aims to foster an open and welcoming environment.
 :::
 
-This section contains information about contributing to PX4, including the source code, documentation, and translations, and their relevant licenses.
-* [Dev Call](../contribute/dev_call.md) - Discuss architecture, pull requests, impacting issues with the dev team
-* [Codeline Management](../contribute/code.md) - Work with PX4 code
-* [Documentation](../contribute/docs.md) - Improve the docs
-* [Translation](../contribute/translation.md) - Translate using Crowdin
-* [Terminology/Notation](../contribute/notation.md)
-* [Licenses](../contribute/licenses.md)
 
-Contributors will also find these sections/topics useful:
-* [Support](../contribute/support.md) - Get help and raise issues
-* [Test Flights](../test_and_ci/test_flights.md) - Get your pull requests flight-tested.
+This section contains information about how you can meet with the community and contribute to PX4:
+
+- [Dev Call](../contribute/dev_call.md) - Discuss architecture, pull requests, impacting issues with the dev team
+- [Support](../contribute/support.md) - Get help and raise issues
+- [Source Code Management](../contribute/code.md) - Work with PX4 code
+- [Documentation](../contribute/docs.md) - Improve the docs
+- [Translation](../contribute/translation.md) - Translate using Crowdin
+- [Terminology/Notation](../contribute/notation.md) - Terms and symbols used in the docs
+- [Licenses](../contribute/licenses.md) - PX4 and Pixhawk licensing
+

--- a/en/contribute/docs.md
+++ b/en/contribute/docs.md
@@ -3,41 +3,43 @@
 Contributions to the PX4 User Guide are very welcome; from simple fixes to spelling and grammar, through to the creation of whole new sections.
 
 This topic explains how to make and test changes.
-Towards the end there is a basic style guide. 
+Towards the end there is a basic style guide.
 
 :::tip Note
 You will need a (free) [Github](https://github.com/) account to contribute to the guides.
 :::
 
 <a id="github_changes" ></a>
+
 ## Quick Changes in Github
 
-Simple changes to *existing content* can be made by clicking the **Edit this page on GitHub** link that appears at the bottom of every page (this opens the page on Github for editing).
+Simple changes to _existing content_ can be made by clicking the **Edit this page on GitHub** link that appears at the bottom of every page (this opens the page on Github for editing).
 
 ![Vuepress: Edit Page button](../../assets/vuepress/vuepress_edit_page_on_github_link.png)
 
 To edit an existing page:
+
 1. Open the page.
 1. Click the **Edit this page on GitHub** link below the page content.
 1. Make the desired change.
-1. Below the Github page editor you'll be prompted to create a separate branch and then 
-   guided to submit a *pull request*.
-   
+1. Below the Github page editor you'll be prompted to create a separate branch and then
+   guided to submit a _pull request_.
+
 The documentation team will review the request and either merge it or work with you to update it.
 
-
 <a id="big_changes" ></a>
+
 ## Changes using Git (New Pages and Images)
 
 More substantial changes, including adding new pages or adding/modifying images, aren't as easy to make (or properly test) on Github.
-For these kinds of changes we suggest using the same approach as for *code*: 
-1. Use the *git* toolchain to get the documentation source code onto your local computer.
+For these kinds of changes we suggest using the same approach as for _code_:
+
+1. Use the _git_ toolchain to get the documentation source code onto your local computer.
 1. Modify the documentation as needed (add, change, delete).
-1. *Test* that it builds properly using Vuepress.  
-1. Create a branch for your changes and create a pull request (PR) to pull it back into the documentation. 
+1. _Test_ that it builds properly using Vuepress.
+1. Create a branch for your changes and create a pull request (PR) to pull it back into the documentation.
 
 The following explain how to get the source code, build locally (to test), and modify the code.
-
 
 ### Get/Push Documentation Source Code
 
@@ -58,18 +60,20 @@ The instructions below explain how to get git and use it on your local computer.
    ```
 1. Navigate to your local repository:
    ```sh
-   cd ~/wherever/PX4-user_guide   
+   cd ~/wherever/PX4-user_guide
    ```
-1. Add a *remote* called "upstream" to point to the PX4 version of the library:
+1. Add a _remote_ called "upstream" to point to the PX4 version of the library:
+
    ```sh
    git remote add upstream https://github.com/PX4/PX4-user_guide.git
    ```
-   
+
    :::tip
    A "remote" is a handle to a particular repository.
-   The remote named *origin* is created by default when you clone the repository, and points to *your fork* of the guide.
-   Above you create a new remote *upstream* that points to the PX4 project version of the documents.
+   The remote named _origin_ is created by default when you clone the repository, and points to _your fork_ of the guide.
+   Above you create a new remote _upstream_ that points to the PX4 project version of the documents.
    :::
+
 1. Create a branch for your changes:
    ```sh
    git checkout -b <your_feature_branch_name>
@@ -81,64 +85,74 @@ The instructions below explain how to get git and use it on your local computer.
    git add <file name>
    git commit -m "<your commit message>"
    ```
-   For a good commit message, please refer to [Contributing](../contribute/README.md) section.
+   For a good commit message, please refer to the [Source Code Management](../contribute//code.md#commits-and-commit-messages) section.
 1. Push your local branch (including commits added to it) to your forked repository on Github.
    ```sh
    git push origin your_feature_branch_name
    ```
 1. Go to your forked repository on Github in a web browser, e.g.: `https://github.com/<your git name>/PX4-user_guide.git`.
-  There you should see the message that a new branch has been pushed to your forked repository.
+   There you should see the message that a new branch has been pushed to your forked repository.
 1. Create a pull request (PR):
    - On the right hand side of the "new branch message" (see one step before), you should see a green button saying "Compare & Create Pull Request".
      Press it.
    - A pull request template will be created.
      It will list your commits and you can (must) add a meaningful title (in case of a one commit PR, it's usually the commit message) and message (<span style="color:orange">explain what you did for what reason</span>.
-	 Check [other pull requests](https://github.com/PX4/PX4-user_guide/pulls) for comparison)
+     Check [other pull requests](https://github.com/PX4/PX4-user_guide/pulls) for comparison)
 1. You're done!
    Maintainers for the PX4 User Guide will now have a look at your contribution and decide if they want to integrate it.
    Check if they have questions on your changes every once in a while.
 
-
 ### Building the Library Locally
 
 Build the library locally to test that any changes you have made have rendered properly:
+
 1. Install the [Vuepress prerequiresites](https://vuepress.vuejs.org/guide/getting-started.html#prerequisites):
+
    - [Nodejs 10+](https://nodejs.org/en)
 
      :::note
      For recent nodejs versions (after v16.15.0) you need to enable the node legacy OpenSSL provider.
      On Ubuntu you can do this by running the terminal command:
-     
+
      ```bash
      export NODE_OPTIONS=--openssl-legacy-provider
      ```
 
    - [Yarn classic](https://classic.yarnpkg.com/en/docs/install)
+
 1. Navigate to your local repository:
+
    ```sh
    cd ~/wherever/PX4-user_guide
    ```
+
 1. Install dependencies (including Vuepress):
+
    ```sh
    yarn install
    ```
+
 1. Preview and serve the library:
+
    ```sh
    yarn docs:dev
    ```
-   * Now you can browse the guide on http://localhost:8080/px4_user_guide/
-   * Stop serving using **CTRL+C** in the terminal prompt.
+
+   - Now you can browse the guide on http://localhost:8080/px4_user_guide/
+   - Stop serving using **CTRL+C** in the terminal prompt.
+
 1. Build the library using:
+
    ```sh
    # Ubuntu
    yarn docs:build
-   
+
    # Windows
    yarn docs:buildwin
    ```
 
-:::tip 
-Use `yarn docs:dev` to preview changes *as you make them* (documents are updated and served very quickly).
+:::tip
+Use `yarn docs:dev` to preview changes _as you make them_ (documents are updated and served very quickly).
 Before submitting a PR you should also build it using `docs:build`, as this can highlight issues that are not visible when using `docs:dev`.
 :::
 
@@ -149,28 +163,30 @@ The PX4 User Guide has some minor differences, mostly related to configuration a
 
 In overview:
 
-* Pages are written in separate files using markdown.
+- Pages are written in separate files using markdown.
   - The syntax is almost the same as that used by the Github wiki.
   - Vuepress also supports some [markdown extensions](https://vuepress.vuejs.org/guide/markdown.html).
     We try and avoid using these, except for [tips, warning, etc.](https://vuepress.vuejs.org/guide/markdown.html#custom-containers).
-* This is a [multilingual](https://vuepress.vuejs.org/guide/i18n.html#default-theme-i18n-config) book:
+- This is a [multilingual](https://vuepress.vuejs.org/guide/i18n.html#default-theme-i18n-config) book:
   - Pages for each language are stored in the folder named for the associated language code (e.g. "zh" for Chinese, "ko" for Korean).
   - Only edit the ENGLISH (**/en**) version of files.
     We use [Crowdin](../contribute/translation.md) to manage the translations.
-* All pages must be in an appropriately named sub-folder of **/en** (e.g. this page is in folder **en/contribute/**).
+- All pages must be in an appropriately named sub-folder of **/en** (e.g. this page is in folder **en/contribute/**).
   - This makes linking easier because other pages and images are always as the same relative levels
-* The _structure_ of the book is defined in **SUMMARY.md**
+- The _structure_ of the book is defined in **SUMMARY.md**
   - If you add a new page to the guide you must also add an entry to this file!
     :::tip
-    This is not "standard vuepress" way to define the sidebar (the summary file is imported by [.vuepress/get_sidebar.js](https://github.com/PX4/PX4-user_guide/blob/main/.vuepress/get_sidebar.js)). 
+    This is not "standard vuepress" way to define the sidebar (the summary file is imported by [.vuepress/get_sidebar.js](https://github.com/PX4/PX4-user_guide/blob/main/.vuepress/get_sidebar.js)).
     :::
-* Images must be stored in a sub folder of **/assets**.
+- Images must be stored in a sub folder of **/assets**.
   This is two folders down from content folders, so if you add an image you will reference it like:
-  ```
+
+  ```plain
   ![Image Description](../../assets/path_to_file/filename.jpg)
   ```
-* A file named **package.json** defines any dependencies of the build.
-* A web hook is used to track whenever files are merged into the master branch on this repository, causing the book to rebuild.
+
+- A file named **package.json** defines any dependencies of the build.
+- A web hook is used to track whenever files are merged into the master branch on this repository, causing the book to rebuild.
 
 ### Adding New Pages
 
@@ -180,37 +196,36 @@ When you add a new page you must also add it to **en/SUMMARY.md**!
 
 1. Files/file names
 
-   * Put new files in an appropriate sub-folder of **/en/**.
+   - Put new files in an appropriate sub-folder of **/en/**.
      Do not further nest folders.
-   * Use descriptive names.
+   - Use descriptive names.
      In particular, image filenames should describe what they contain.
-   * Use lower case filenames and separate words using underscores "\_"
+   - Use lower case filenames and separate words using underscores "\_"
 
 2. Images
 
-   * Use the smallest size and lowest resolution that makes the image still useful (this reduces download cost for users with poor bandwidth).
-   * New images should be created in a sub-folder of **/assets/** by default 
+   - Use the smallest size and lowest resolution that makes the image still useful (this reduces download cost for users with poor bandwidth).
+   - New images should be created in a sub-folder of **/assets/** by default
      (so they can be shared between translations).
 
 3. Content:
 
-   * Use "style" \(bold, emphasis, etc\) consistently.
-     - **Bold** for button presses and menu definitions. 
-     - _Emphasis_ for tool names.
-	 - Otherwise use as little as possible.
-   * Headings and page titles should use "First Letter Capitalisation"
-   * The page title should be a first level heading \(\#\).
+   - Use "style" \(bold, emphasis, etc\) consistently.
+     - **Bold** for button presses and menu definitions.
+     - _Emphasis_ for tool names. - Otherwise use as little as possible.
+   - Headings and page titles should use "First Letter Capitalisation"
+   - The page title should be a first level heading \(\#\).
      All other headings should be h2 \(\#\#\) or lower.
-   * Don't add any style to headings.
-   * Don't translate the *first part* of a note, tip or warning declaration (e.g. `::: tip`) 
+   - Don't add any style to headings.
+   - Don't translate the _first part_ of a note, tip or warning declaration (e.g. `::: tip`)
      as this precise text is required to render the note properly.
-
 
 ## Where Do I Add Changes?
 
 Add new documentation in-line with the existing structure!
 
 Some of the main categories are:
+
 - Development: content related to:
   - Evolving the platform (new modes, modules, flight modes, hardware, software and hardware architecture and porting).
   - "Experimental" work that requires developer expertise to reproduce.
@@ -222,12 +237,11 @@ Some of the main categories are:
 - Basic Assembly: Assembly of an autopilot and its main peripherals
 - Airframe Builds: Examples of how to build a whole system.
 
-
 ## Translations
 
 For information about translation see: [Translation](../contribute/translation.md).
 
 ## Licence
 
-All PX4/Dronecode documentation is free to use and modify under terms of the permissive 
+All PX4/Dronecode documentation is free to use and modify under terms of the permissive
 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) licence.

--- a/en/contribute/git_examples.md
+++ b/en/contribute/git_examples.md
@@ -1,52 +1,61 @@
 # GIT Examples
 
 <a id="contributing_code"></a>
+
 ## Contributing Code to PX4
 
 Adding a feature to PX4 follows a defined workflow. In order to share your contributions on PX4, you can follow this example.
 
-* [Sign up](https://github.com/join) for github if you haven't already
-* Fork the PX4-Autopilot repo (see [here](https://docs.github.com/en/get-started/quickstart/fork-a-repo))
-* Clone your forked repository to your local computer
+- [Sign up](https://github.com/join) for github if you haven't already
+- Fork the PX4-Autopilot repo (see [here](https://docs.github.com/en/get-started/quickstart/fork-a-repo))
+- Clone your forked repository to your local computer
 
   ```sh
   cd ~/wherever/
   git clone https://github.com/<your git name>/PX4-Autopilot.git
   ```
-* Go into the new directory, initialize and update the submodules, and add the original upstream PX4-Autopilot
+
+- Go into the new directory, initialize and update the submodules, and add the original upstream PX4-Autopilot
 
   ```sh
   cd PX4-Autopilot
   git submodule update --init --recursive
   git remote add upstream https://github.com/PX4/PX4-Autopilot.git
   ```
-* You should have now two remote repositories: One repository is called `upstream` that points to PX4/PX4-Autopilot, and one repository `origin` that points to your forked copy of the PX4 repository.
-* This can be checked with the following command:
+
+- You should have now two remote repositories: One repository is called `upstream` that points to PX4/PX4-Autopilot, and one repository `origin` that points to your forked copy of the PX4 repository.
+- This can be checked with the following command:
+
   ```sh
   git remote -v
   ```
-* Make the changes that you want to add to the current main.
-* Create a new branch with a meaningful name that represents your feature
+
+- Make the changes that you want to add to the current main.
+- Create a new branch with a meaningful name that represents your feature
 
   ```sh
   git checkout -b <your feature branch name>
   ```
 
   you can use the command `git branch` to make sure you're on the right branch.
-* Add your changes that you want to be part of the commit by adding the respective files
+
+- Add your changes that you want to be part of the commit by adding the respective files
 
   ```sh
   git add <file name>
   ```
+
   If you prefer having a GUI to add your files see [Gitk](https://git-scm.com/book/en/v2/Git-in-Other-Environments-Graphical-Interfaces) or [`git add -p`](http://nuclearsquid.com/writings/git-add/).
-* Commit the added files with a meaningful message explaining your changes
+
+- Commit the added files with a meaningful message explaining your changes
 
   ```sh
   git commit -m "<your commit message>"
   ```
 
-  For a good commit message, please refer to [Contributing](../contribute/README.md) section.
-* Some time might have passed and the [upstream main](https://github.com/PX4/PX4-Autopilot.git) has changed.
+  For a good commit message, please refer to the [Source Code Management](../contribute//code.md#commits-and-commit-messages) section.
+
+- Some time might have passed and the [upstream main](https://github.com/PX4/PX4-Autopilot.git) has changed.
   PX4 prefers a linear commit history and uses [git rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).
   To include the newest changes from upstream in your local branch, switch to your main branch
 
@@ -59,6 +68,7 @@ Adding a feature to PX4 follows a defined workflow. In order to share your contr
   ```sh
   git pull upstream main
   ```
+
   Now your local main is up to date.
   Switch back to your feature branch and rebase on your updated main
 
@@ -66,22 +76,24 @@ Adding a feature to PX4 follows a defined workflow. In order to share your contr
   git checkout <your feature branch name>
   git rebase main
   ```
-* Now you can push your local commits to your forked repository
+
+- Now you can push your local commits to your forked repository
 
   ```sh
   git push origin <your feature branch name>
   ```
-* You can verify that the push was successful by going to your forked repository in your browser: `https://github.com/<your git name>/PX4-Autopilot.git`
+
+- You can verify that the push was successful by going to your forked repository in your browser: `https://github.com/<your git name>/PX4-Autopilot.git`
 
   There you should see the message that a new branch has been pushed to your forked repository.
-* Now it's time to create a pull request (PR).
+
+- Now it's time to create a pull request (PR).
   On the right hand side of the "new branch message" (see one step before), you should see a green button saying "Compare & Create Pull Request".
   Then it should list your changes and you can (must) add a meaningful title (in case of a one commit PR, it's usually the commit message) and message (<span style="color:orange">explain what you did for what reason</span>.
   Check [other pull requests](https://github.com/PX4/PX4-Autopilot/pulls) for comparison)
-* You're done! 
+- You're done!
   Responsible members of PX4 will now have a look at your contribution and decide if they want to integrate it.
   Check if they have questions on your changes every once in a while.
-
 
 ## Changing Source Trees
 
@@ -96,12 +108,14 @@ To switch between branches:
    make clean
    make distclean
    ```
+
 1. Switch to a new branch or tag (here we first fetch the fictional branch "PR_test_branch" from the `upstream` remote):
 
    ```sh
    git fetch upstream PR_test_branch
    git checkout PR_test_branch
    ```
+
 1. Get the submodules for the new branch:
 
    ```sh
@@ -110,13 +124,12 @@ To switch between branches:
 
 <!-- FYI: Cleaning commands in https://github.com/PX4/PX4-Autopilot/blob/main/Makefile#L494 -->
 
-
 ## Get a Specific Release
 
 Specific PX4 point releases are made as tags of the [release branches](#get-a-release-branch), and are named using the format `v<release>`.
 These are [listed on Github here](https://github.com/PX4/PX4-Autopilot/releases?q=release&expanded=true) (or you can query all tags using `git tag -l`).
 
-To get the source code for a *specific older release* (tag):
+To get the source code for a _specific older release_ (tag):
 
 1. Clone the PX4-Autopilot repo and navigate into _PX4-Autopilot_ directory:
 
@@ -124,15 +137,16 @@ To get the source code for a *specific older release* (tag):
    git clone https://github.com/PX4/PX4-Autopilot.git
    cd PX4-Autopilot
    ```
-   
+
    :::note
    You can reuse an existing repo rather than cloning a new one.
    In this case clean the build environment (see [changing source trees](#changing-source-trees)):
-   
+
    ```sh
    make clean
    make distclean
    ```
+
    :::
 
 1. Checkout code for particular tag (e.g. for tag v1.13.0-beta2)
@@ -161,6 +175,7 @@ To get a release branch:
   git clone https://github.com/PX4/PX4-Autopilot.git
   cd PX4-Autopilot
   ```
+
   :::note
   You can reuse an existing repo rather than cloning a new one.
   In this case clean the build environment (see [changing source trees](#changing-source-trees)):
@@ -169,9 +184,9 @@ To get a release branch:
   make clean
   make distclean
   ```
+
   :::
-  
-  
+
 - Fetch the desired release branch.
   For example, assuming you want the source for PX4 v1.13:
 
@@ -199,23 +214,25 @@ Either you clone the repository or you go in the submodule directory and follow 
 ## Do a PR for a submodule update
 
 This is required after you have done a PR for a submodule X repository and the bug-fix / feature-add is in the current main of submodule X. Since the Firmware still points to a commit before your update, a submodule pull request is required such that the submodule used by the Firmware points to the newest commit.
+
 ```sh
 cd Firmware
 ```
-* Make a new branch that describes the fix / feature for the submodule update:
+
+- Make a new branch that describes the fix / feature for the submodule update:
   ```sh
   git checkout -b pr-some-fix
   ```
-* Go to submodule subdirectory
+- Go to submodule subdirectory
   ```sh
   cd <path to submodule>
   ```
-* PX4 submodule might not necessarily point to the newest commit. Therefore, first checkout main and pull the newest upstream code.
+- PX4 submodule might not necessarily point to the newest commit. Therefore, first checkout main and pull the newest upstream code.
   ```sh
   git checkout main
   git pull upstream main
   ```
-* Go back to Firmware directory, and as usual add, commit and push the changes.
+- Go back to Firmware directory, and as usual add, commit and push the changes.
   ```sh
   cd -
   git add <path to submodule>
@@ -226,14 +243,19 @@ cd Firmware
 ## Checkout pull requests
 
 You can test someone's pull request (changes are not yet merged) even if the branch to merge only exists on the fork from that person. Do the following:
+
 ```sh
 git fetch upstream  pull/<PR ID>/head:<branch name>
 ```
+
 `PR ID` is the number right next to the PR's title (without the #) and the `<branch name>` can also be found right below the `PR ID`, e.g. `<the other persons git name>:<branch name>`. After that you can see the newly created branch locally with
+
 ```sh
 git branch
 ```
+
 Then switch to that branch
+
 ```sh
 git checkout <branch name>
 ```
@@ -243,6 +265,7 @@ git checkout <branch name>
 ### Force push to forked repository
 
 After having done the first PR, people from the PX4 community will review your changes. In most cases this means that you have to fix your local branch according to the review. After changing the files locally, the feature branch needs to be rebased again with the most recent upstream/main. However, after the rebase, it is no longer possible to push the feature branch to your forked repository directly, but instead you need to use a force push:
+
 ```sh
 git push --force-with-lease origin <your feature branch name>
 ```
@@ -260,7 +283,7 @@ If a conflict occurs during a `git pull`, please refer to [this guide](https://h
 The build error `Error: PX4 version too low, expected at least vx.x.x` occurs if git tags are out of date.
 
 This can be solved by fetching the upstream repository tags:
+
 ```sh
 git fetch upstream --tags
 ```
-

--- a/en/contribute/notation.md
+++ b/en/contribute/notation.md
@@ -18,7 +18,7 @@ Acronym | Expansion
 AOA | Angle Of Attack. Also named *alpha*.
 AOS | Angle Of Sideslip. Also named *beta*.
 FRD | Coordinate system where the X-axis is pointing towards the Front of the vehicle, the Y-axis is pointing Right and the Z-axis is pointing Down, completing the right-hand rule.
-FW | Fixed-Wing.
+FW | Fixed-wing (planes).
 MC | MultiCopter.
 MPC or MCPC | MultiCopter Position Controller. MPC is also used for Model Predictive Control.
 NED | Coordinate system where the X-axis is pointing towards the true North, the Y-axis is pointing East and the Z-axis is pointing Down, completing the right-hand rule.


### PR DESCRIPTION
This rebrands contribution as community as per @sfuhrer proposed restructure. I have updated the page and the SUMMARY.md.
I also prettified some affected docs - so it is hard to review. I'll tag the specific parts worth looking at.

@sfuhrer @MaEtUgR One question though - should Source Code management be here or in development?
Of course you could argue that is also true for licences, but I think the argument is stronger for source code.
