### PR TITLE
Add Land mode docs for none-Mission FW landing

### DIFF
--- a/en/flight_modes/land.md
+++ b/en/flight_modes/land.md
@@ -11,7 +11,7 @@ After landing, vehicles will disarm after a short timeout (by default).
 * This mode is automatic - no user intervention is *required* to control the vehicle.
 * RC control switches can be used to change flight modes on any vehicle.
 * RC stick movement in a multicopter (or VTOL in multicopter mode) will [by default](#COM_RC_OVERRIDE) change the vehicle to [Position mode](../flight_modes_mc/position.md) unless handling a critical battery failsafe.
-* The mode can be triggered using the [MAV_CMD_DO_LAND_START](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_LAND_START) MAVLink command, or by explicitly switching to Land mode.
+* The mode can be triggered using the [MAV_CMD_NAV_LAND](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND) MAVLink command, or by explicitly switching to Land mode.
 :::
 
 The specific behaviour for each vehicle type is described below.

--- a/en/flight_modes/land.md
+++ b/en/flight_modes/land.md
@@ -36,13 +36,27 @@ Parameter | Description
 
 ## Fixed-wing (FW)
 
-:::warning
-Fixed-wing _Land mode_ is currently broken: [PX4-Autopilot/pull/21036](https://github.com/PX4/PX4-Autopilot/pull/21036).
-(Specifically, switching to Land mode causes a fly-away.)
+Fixed-wing _land mode_ performs a circular landing at the current vehicle position.
+As opposed to the configurable landing approach settings in mission mode, the _land mode_ cannot be adapted to the local terrain, and should
+thus only be considered as an emergency option to bring a vehicle to the ground.
 
-Automated landing in missions is supported: [Mission mode > Fixed-wing mission landing](../flight_modes/mission.md#fw-mission-landing).
+When the mode is engaged, the vehicle starts to loiter around the current vehicle position with loiter radius [NAV_LOITER_RAD](#NAV_LOITER_RAD) and begins to descend with a constant descent speed.
+The descent speed is calculated using [FW_LND_ANG](#FW_LND_ANG) and the set landing airspeed [FW_LND_AIRSPD](#FW_LND_AIRSPD).
+The vehicle will flare if configured to do so (see [Flaring](../flight_modes/mission.md#flaring-roll-out)), and otherwise proceed circling with the constant descent rate until landing is detected.
+[Manual nudging](../flight_modes/mission.md#automatic-abort) and [automatic land abort](../flight_modes/mission.md#nudging) are not available in the landing mode.
+
+
+:::warning
+It is highly recommended to only engage this mode in case of emergency, as the exact touch down point cannot be configured and it will
+touch down while tracking a circle.
+Auto landings should whenever possible be executed through the mission interface: [Mission mode > Fixed-wing mission landing](../flight_modes/mission.md#fw-mission-landing).
 :::
 
+Parameter | Description
+--- | ---
+<a id="NAV_LOITER_RAD"></a>[NAV_LOITER_RAD](../advanced_config/parameter_reference.md#NAV_LOITER_RAD) | The loiter radius that the controller tracks for the whole landing sequence.
+<a id="FW_LND_ANG"></a>[FW_LND_ANG](../advanced_config/parameter_reference.md#FW_LND_ANG) | The flight path angle setpoint.
+<a id="FW_LND_AIRSPD"></a>[FW_LND_AIRSPD](../advanced_config/parameter_reference.md#FW_LND_AIRSPD) | The airspeed setpoint.
 
 ## VTOL
 

--- a/en/flight_modes/land.md
+++ b/en/flight_modes/land.md
@@ -37,20 +37,19 @@ Parameter | Description
 ## Fixed-wing (FW)
 
 Fixed-wing _land mode_ performs a circular landing at the current vehicle position.
-As opposed to the configurable landing approach settings in mission mode, the _land mode_ cannot be adapted to the local terrain, and should
-thus only be considered as an emergency option to bring a vehicle to the ground.
+
+:::warning
+Fixed-wing _land mode_ should only be used in an **emergency**!
+The vehicle will descend around the current location irrespective of the suitability of the underlying terrain, and touch down while following a circlular flight path.
+
+Where possible, instead use the configurable landing approach in [Mission mode > Fixed-wing mission landing](../flight_modes/mission.md#fw-mission-landing).
+:::
 
 When the mode is engaged, the vehicle starts to loiter around the current vehicle position with loiter radius [NAV_LOITER_RAD](#NAV_LOITER_RAD) and begins to descend with a constant descent speed.
 The descent speed is calculated using [FW_LND_ANG](#FW_LND_ANG) and the set landing airspeed [FW_LND_AIRSPD](#FW_LND_AIRSPD).
 The vehicle will flare if configured to do so (see [Flaring](../flight_modes/mission.md#flaring-roll-out)), and otherwise proceed circling with the constant descent rate until landing is detected.
-[Manual nudging](../flight_modes/mission.md#automatic-abort) and [automatic land abort](../flight_modes/mission.md#nudging) are not available in the landing mode.
 
-
-:::warning
-It is highly recommended to only engage this mode in case of emergency, as the exact touch down point cannot be configured and it will
-touch down while tracking a circle.
-Auto landings should whenever possible be executed through the mission interface: [Mission mode > Fixed-wing mission landing](../flight_modes/mission.md#fw-mission-landing).
-:::
+[Manual nudging](../flight_modes/mission.md#automatic-abort) and [automatic land abort](../flight_modes/mission.md#nudging) are not available in land mode.
 
 Parameter | Description
 --- | ---

--- a/en/flight_modes/mission.md
+++ b/en/flight_modes/mission.md
@@ -241,10 +241,6 @@ This can be planned in *QGroundControl* using [fixed-wing landing pattern](https
 
 If possible, always plan the landing such that it does the approach into the wind.
 
-:::note
-Note fixed-wing landing using [Land mode](../flight_modes/land.md#fixed-wing-fw) is currently broken, so mission landing is the _only_ way to autonomously land a plane.
-:::
-
 The following sections describe the landing sequence, land abort and nudging, safety considerations, and configuration. 
 
 ### Landing Sequence


### PR DESCRIPTION
As promised in https://github.com/PX4/PX4-Autopilot/pull/21036#issuecomment-1698538960.

Should get ported to the v1.14 docs.