### PR TITLE
pmw3901.md - fix typo pin mapping

### DIFF
--- a/en/sensor/pmw3901.md
+++ b/en/sensor/pmw3901.md
@@ -103,8 +103,8 @@ Pixhawk SPI Port (from left to right) | Bitcraze flow board
 2 (SCK) | CLK
 3 (MISO) | MISO
 4 (MOSI) | MOSI
-5 (CS1) | Do not connect
-6 (CS2) | CS
+5 (CS1) | CS
+6 (CS2) | Do not connect
 7 (GND) | GND
 
 To connect the bitcraze flow board to the Pixhawk, you will need to solder the wires of the Pixhawk SPI cable to the flow board.


### PR DESCRIPTION
pmw3901 [SPI wiring here](https://docs.px4.io/main/en/sensor/pmw3901.html#bitcraze-flow-breakout) says 

<html>
<body>
<!--StartFragment-->

5 (CS1) | Do not connect
-- | --
6 (CS2) | CS

<!--EndFragment-->
</body>
</html>

However that disagrees with the wiring diagram in same section and the text, which has them the other way around. 
IN addition the other way around was tested by Karthic here and worked https://discord.com/channels/1022170275984457759/1022185721450213396/1158374616268554300

So I am inverting the table to match all other sources of information.