### PR TITLE
update default interaction to use name alias

### DIFF
--- a/en/sim_gazebo_gz/README.md
+++ b/en/sim_gazebo_gz/README.md
@@ -128,7 +128,7 @@ Here are some examples of the different scenarios covered above.
 1. **Start simulator + default world + spawn vehicle at default pose**
 
    ```sh
-   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4
+   PX4_SYS_AUTOSTART=4001 PX4_SIM_MODEL=gz_x500 ./build/px4_sitl_default/bin/px4
    ```
 
 2. **Start simulator + default world + spawn vehicle at custom pose (y=2m)**

--- a/en/sim_gazebo_gz/README.md
+++ b/en/sim_gazebo_gz/README.md
@@ -134,13 +134,13 @@ Here are some examples of the different scenarios covered above.
 2. **Start simulator + default world + spawn vehicle at custom pose (y=2m)**
 
    ```sh
-   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,2" PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4
+   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,2" PX4_GZ_MODEL=gz_x500 ./build/px4_sitl_default/bin/px4
    ```
 
 3. **Start simulator + default world + link to existing vehicle**
 
    ```sh
-   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_NAME=x500 ./build/px4_sitl_default/bin/px4
+   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_NAME=gz_x500 ./build/px4_sitl_default/bin/px4
    ```
 
 ## Adding New Worlds and Models


### PR DESCRIPTION
With the old default example, vehicles were set half in the ground. Using `PX4_SIM_MODEL` rather than `PX4_GZ_MODEL` the model takes the default pose defined in its sdf file, rather than the default pose 0,0,0,0,0,0. 

Related to issue: https://github.com/PX4/PX4-Autopilot/issues/22214