### PR TITLE
[ros2] Improve ROS-Gazebo-PX4 time sync description

### DIFF
--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -450,14 +450,18 @@ No further action is required by the user.
 
 In this scenario, ROS2 also uses the Gazebo `/clock` topic as time source.
 This approach makes sense if the Gazebo simulation is running with real time factor different from one, or if ROS2 needs to directly interact with Gazebo.
-The procedure requires you to:
+On the ROS2 side, direct interaction with Gazebo is achieved by the [ros_gz_bridge](https://github.com/gazebosim/ros_gz) package of the [ros_gz](https://github.com/gazebosim/ros_gz) repository.
+Read through the [repo](https://github.com/gazebosim/ros_gz#readme) and [package](https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_bridge#readme) READMEs to find out the right version that has to be installed depending on your ROS2 and Gazebo versions.
 
-- Directly bridge ROS and Gazebo using [ros_gz](https://github.com/gazebosim/ros_gz) and the [ros_gz_bridge](https://github.com/gazebosim/ros_gz) package.
-- Bridge the Gazebo `/clock` topic over ROS:
+Once the package is installed and sourced, the node `parameter_bridge` provides the bridging capabilities and can be used to create an unidirectional `/clock` bridge:
+```sh
+ros2 run ros_gz_bridge parameter_bridge /clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock
+```
 
-  ```sh
-  ros2 run ros_gz_bridge parameter_bridge /clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock
+At this point, every ROS2 node must be instructed to use the newly bridged `/clock` topic as time source instead of the OS one, this is done by setting the parameter `use_sim_time` (of _each_ node) to `true` (see [ROS clock and Time design](https://design.ros2.org/articles/clock_and_time.html)).
 
+This concludes the modifications required on the ROS2 side. On the PX4 side, you are only required to stop the uXRCE-DDS time synchronization, setting the parameter [UXRCE_DDS_SYNCT](../advanced_config/parameter_reference.md#UXRCE_DDS_SYNCT) to `false`.
+By doing so, Gazebo will act as main and only time source for both ROS2 and PX4.
 ## ROS 2 Example Applications
 
 ### ROS 2 Listener

--- a/en/ros/ros2_comm.md
+++ b/en/ros/ros2_comm.md
@@ -454,6 +454,7 @@ On the ROS2 side, direct interaction with Gazebo is achieved by the [ros_gz_brid
 Read through the [repo](https://github.com/gazebosim/ros_gz#readme) and [package](https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_bridge#readme) READMEs to find out the right version that has to be installed depending on your ROS2 and Gazebo versions.
 
 Once the package is installed and sourced, the node `parameter_bridge` provides the bridging capabilities and can be used to create an unidirectional `/clock` bridge:
+
 ```sh
 ros2 run ros_gz_bridge parameter_bridge /clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock
 ```
@@ -462,6 +463,7 @@ At this point, every ROS2 node must be instructed to use the newly bridged `/clo
 
 This concludes the modifications required on the ROS2 side. On the PX4 side, you are only required to stop the uXRCE-DDS time synchronization, setting the parameter [UXRCE_DDS_SYNCT](../advanced_config/parameter_reference.md#UXRCE_DDS_SYNCT) to `false`.
 By doing so, Gazebo will act as main and only time source for both ROS2 and PX4.
+
 ## ROS 2 Example Applications
 
 ### ROS 2 Listener


### PR DESCRIPTION
FIX https://github.com/PX4/PX4-user_guide/pull/2594#discussion_r1359841037 and improve instructions to use Gazebo clock as ROS2 time source.