### PR TITLE
Reversing simulation instructions 

### DIFF
--- a/en/sim_gazebo_gz/README.md
+++ b/en/sim_gazebo_gz/README.md
@@ -138,7 +138,7 @@ Here are some examples of the different scenarios covered above.
 2. **Start simulator + default world + spawn vehicle at custom pose (y=2m)**
 
    ```sh
-   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,2" PX4_SIM_MODEL=gz_x500 ./build/px4_sitl_default/bin/px4
+   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,2" PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4
    ```
 
 3. **Start simulator + default world + link to existing vehicle**

--- a/en/sim_gazebo_gz/README.md
+++ b/en/sim_gazebo_gz/README.md
@@ -138,13 +138,13 @@ Here are some examples of the different scenarios covered above.
 2. **Start simulator + default world + spawn vehicle at custom pose (y=2m)**
 
    ```sh
-   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,2" PX4_GZ_MODEL=gz_x500 ./build/px4_sitl_default/bin/px4
+   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,2" PX4_SIM_MODEL=gz_x500 ./build/px4_sitl_default/bin/px4
    ```
 
 3. **Start simulator + default world + link to existing vehicle**
 
    ```sh
-   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_NAME=gz_x500 ./build/px4_sitl_default/bin/px4
+   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_NAME=x500 ./build/px4_sitl_default/bin/px4
    ```
 
 ## Adding New Worlds and Models


### PR DESCRIPTION
Reversing the simulation instructions for the second and third gazebo instruction in the README. This was incorrectly amended in #2801, commit 7a80d380af750ad489724663240e8b09b06661d0. 