### PR TITLE
Add link to Pixhawk 6X-RT doc page

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -168,7 +168,6 @@
       * [CUAV Pixhawk V6X (FMUv6X)](flight_controller/cuav_pixhawk_v6x.md)
       * [Holybro Pixhawk 6X-RT (FMUv6X-RT)](flight_controller/pixhawk6x-rt.md)
       * [Holybro Pixhawk 6X (FMUv6X)](flight_controller/pixhawk6x.md)
-      * [Holybro Pixhawk 6X-RT (FMUv6X-RT)](flight_controller/pixhawk6x-rt.md)
       * [Holybro Pixhawk 6C (FMUv6C)](flight_controller/pixhawk6c.md)
       * [Holybro Pixhawk 6C Mini(FMUv6C)](flight_controller/pixhawk6c_mini.md)
       * [Holybro Pix32 v6 (FMUv6C)](flight_controller/holybro_pix32_v6.md)

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -168,6 +168,7 @@
       * [CUAV Pixhawk V6X (FMUv6X)](flight_controller/cuav_pixhawk_v6x.md)
       * [Holybro Pixhawk 6X-RT (FMUv6X-RT)](flight_controller/pixhawk6x-rt.md)
       * [Holybro Pixhawk 6X (FMUv6X)](flight_controller/pixhawk6x.md)
+      * [Holybro Pixhawk 6X-RT (FMUv6X-RT)](flight_controller/pixhawk6x-rt.md)
       * [Holybro Pixhawk 6C (FMUv6C)](flight_controller/pixhawk6c.md)
       * [Holybro Pixhawk 6C Mini(FMUv6C)](flight_controller/pixhawk6c_mini.md)
       * [Holybro Pix32 v6 (FMUv6C)](flight_controller/holybro_pix32_v6.md)

--- a/en/flight_controller/pixhawk6x-rt.md
+++ b/en/flight_controller/pixhawk6x-rt.md
@@ -198,9 +198,11 @@ It is pre-built and automatically installed by _QGroundControl_ when appropriate
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
 ```
-make px4_fmu-v6x_default
+make nxp_fmurt1170-v1_default
 ```
-
+:::warning
+As of now PX4 SW enablement is done in px4 branch pr-imxrt1170-imxrt1062 only. Merge to PX4 main is expected soon.
+:::
 <a id="debug_port"></a>
 
 ## Debug Port

--- a/en/flight_controller/pixhawk6x-rt.md
+++ b/en/flight_controller/pixhawk6x-rt.md
@@ -11,7 +11,7 @@ It is based on the [Pixhawk​​® Autopilot FMUv6X Standard](https://github.co
 
 Equipped with a high performance NXP i.mx RT1176 dual core Processor, modular design, triple redundancy, temperature-controlled IMU board, isolated sensor domains, delivering incredible performance, reliability, and flexibility.
 
-<img src="../../assets/flight_controller/pixhawk6x-rt/pixhawk6x-rt.png" width="460px" title="Pixhawk6X-RT Upright Image" /> <img src="../../assets/flight_controller/pixhawk6x/pixhawk6x_exploded_diagram.png" width="400px" title="Pixhawk6X Exploded Image" />
+<img src="../../assets/flight_controller/pixhawk6x-rt/pixhawk6x-rt.png" width="350px" title="Pixhawk6X-RT Upright Image" /> <img src="../../assets/flight_controller/pixhawk6x/pixhawk6x_exploded_diagram.png" width="300px" title="Pixhawk6X Exploded Image" />
 
 :::tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.

--- a/en/flight_controller/pixhawk6x-rt.md
+++ b/en/flight_controller/pixhawk6x-rt.md
@@ -11,7 +11,7 @@ It is based on the [Pixhawk​​® Autopilot FMUv6X Standard](https://github.co
 
 Equipped with a high performance NXP i.mx RT1176 dual core Processor, modular design, triple redundancy, temperature-controlled IMU board, isolated sensor domains, delivering incredible performance, reliability, and flexibility.
 
-<img src="../../assets/flight_controller/pixhawk6x-rt/pixhawk6x-rt.png" width="230px" title="Pixhawk6X-RT Upright Image" /> <img src="../../assets/flight_controller/pixhawk6x/pixhawk6x_exploded_diagram.png" width="400px" title="Pixhawk6X Exploded Image" />
+<img src="../../assets/flight_controller/pixhawk6x-rt/pixhawk6x-rt.png" width="460px" title="Pixhawk6X-RT Upright Image" /> <img src="../../assets/flight_controller/pixhawk6x/pixhawk6x_exploded_diagram.png" width="400px" title="Pixhawk6X Exploded Image" />
 
 :::tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.

--- a/en/flight_controller/pixhawk6x-rt.md
+++ b/en/flight_controller/pixhawk6x-rt.md
@@ -11,7 +11,7 @@ It is based on the [Pixhawk​​® Autopilot FMUv6X Standard](https://github.co
 
 Equipped with a high performance NXP i.mx RT1176 dual core Processor, modular design, triple redundancy, temperature-controlled IMU board, isolated sensor domains, delivering incredible performance, reliability, and flexibility.
 
-[Pixhawk6X-RT Upright Image](../../assets/flight_controller/pixhawk6x-rt/pixhawk6x-rt.png)
+<img src="../../assets/flight_controller/pixhawk6x/pixhawk6x-rt.png" width="230px" title="Pixhawk6X-RT Upright Image" /> <img src="../../assets/flight_controller/pixhawk6x/pixhawk6x_exploded_diagram.png" width="400px" title="Pixhawk6X Exploded Image" />
 
 :::tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.

--- a/en/flight_controller/pixhawk6x-rt.md
+++ b/en/flight_controller/pixhawk6x-rt.md
@@ -11,7 +11,7 @@ It is based on the [Pixhawk​​® Autopilot FMUv6X Standard](https://github.co
 
 Equipped with a high performance NXP i.mx RT1176 dual core Processor, modular design, triple redundancy, temperature-controlled IMU board, isolated sensor domains, delivering incredible performance, reliability, and flexibility.
 
-<img src="../../assets/flight_controller/pixhawk6x/pixhawk6x-rt.png" width="230px" title="Pixhawk6X-RT Upright Image" /> <img src="../../assets/flight_controller/pixhawk6x/pixhawk6x_exploded_diagram.png" width="400px" title="Pixhawk6X Exploded Image" />
+<img src="../../assets/flight_controller/pixhawk6x-rt/pixhawk6x-rt.png" width="230px" title="Pixhawk6X-RT Upright Image" /> <img src="../../assets/flight_controller/pixhawk6x/pixhawk6x_exploded_diagram.png" width="400px" title="Pixhawk6X Exploded Image" />
 
 :::tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.


### PR DESCRIPTION
Add Pixhawk 6X-RT doc link to the list of Flight controllers.
@hamishwillee have forgotten adding the link in previous pull request.