### PR TITLE
Fix up image and build instruction 6x-rt

### DIFF
--- a/en/flight_controller/pixhawk6x-rt.md
+++ b/en/flight_controller/pixhawk6x-rt.md
@@ -11,7 +11,7 @@ It is based on the [Pixhawk​​® Autopilot FMUv6X Standard](https://github.co
 
 Equipped with a high performance NXP i.mx RT1176 dual core Processor, modular design, triple redundancy, temperature-controlled IMU board, isolated sensor domains, delivering incredible performance, reliability, and flexibility.
 
-[Pixhawk6X-RT Upright Image](../../assets/flight_controller/pixhawk6x-rt/pixhawk6x-rt.png)
+<img src="../../assets/flight_controller/pixhawk6x-rt/pixhawk6x-rt.png" width="350px" title="Pixhawk6X-RT Upright Image" /> <img src="../../assets/flight_controller/pixhawk6x/pixhawk6x_exploded_diagram.png" width="300px" title="Pixhawk6X Exploded Image" />
 
 :::tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
@@ -132,6 +132,7 @@ The [Pixhawk 6X Wiring Quick Start](../assembly/quick_start_pixhawk6x.md) provid
 ## Connections
 
 Sample Wiring Diagram
+
 ![Pixhawk 6X Wiring Overview](../../assets/flight_controller/pixhawk6x/pixhawk6x_wiring_diagram.png)
 
 ## Pinouts
@@ -145,16 +146,16 @@ Notes:
 
 ## Serial Port Mapping
 
-| UART   | Device     | Port          |
-| ------ | ---------- | ------------- |
-| UART1  | /dev/ttyS0 | Debug         |
-| UART3  | /dev/ttyS1 | GPS           |
-| UART4  | /dev/ttyS2 | TELEM1        |
-| UART5  | /dev/ttyS3 | GPS2          |
-| UART6  | /dev/ttyS4 | PX4IO         |
-| UART8  | /dev/ttyS5 | TELEM2        |
-| UART10 | /dev/ttyS6 | TELEM3        |
-| UART11 | /dev/ttyS7 | External      |
+| UART   | Device     | Port     |
+| ------ | ---------- | -------- |
+| UART1  | /dev/ttyS0 | Debug    |
+| UART3  | /dev/ttyS1 | GPS      |
+| UART4  | /dev/ttyS2 | TELEM1   |
+| UART5  | /dev/ttyS3 | GPS2     |
+| UART6  | /dev/ttyS4 | PX4IO    |
+| UART8  | /dev/ttyS5 | TELEM2   |
+| UART10 | /dev/ttyS6 | TELEM3   |
+| UART11 | /dev/ttyS7 | External |
 
 ## Dimensions
 
@@ -198,7 +199,7 @@ It is pre-built and automatically installed by _QGroundControl_ when appropriate
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
 ```
-make px4_fmu-v6x_default
+make px4_fmu-v6xrt
 ```
 
 <a id="debug_port"></a>


### PR DESCRIPTION
Replaces #2812 which I am unable to edit.

Note that it doesn't update summary because that wasn't needed - this already appears in sidebar. It does fix up the images and the make command.

FYI @dk7xe 