### PR TITLE
Update land.md - remove unhelpful reference to failsafe

### DIFF
--- a/en/flight_modes_mc/land.md
+++ b/en/flight_modes_mc/land.md
@@ -8,7 +8,6 @@ The vehicle will disarm shortly after landing (by default).
 :::note
 
 - This mode requires a valid global position estimate (from GPS or inferred from a [local position](../ros/external_position_estimation.md#enabling-auto-modes-with-a-local-position)).
-- In a failsafe the mode only requires altitude (typically a barometer is built into the flight controller).
 - This mode is automatic - no user intervention is _required_ to control the vehicle.
 - RC control switches can be used to change flight modes on any vehicle.
 - RC stick movement in a multicopter (or VTOL in multicopter mode) will [by default](#COM_RC_OVERRIDE) change the vehicle to [Position mode](../flight_modes_mc/position.md) unless handling a critical battery failsafe.


### PR DESCRIPTION
The failsafe mode for any Auto mode is Descend, where the vehicle descends vertically without holding position. It's though not "Land" mode anymore. 
COM_POSCTL_NAVL allows you to set the failsafe action.

This was raised in https://discuss.px4.io/t/do-really-all-autonomous-modes-require-global-position/34890/10. We better keep all the failsafe docs in one place.