### PR TITLE
Update pixhawk6x-rt.md

### DIFF
--- a/en/flight_controller/pixhawk6x-rt.md
+++ b/en/flight_controller/pixhawk6x-rt.md
@@ -199,7 +199,7 @@ It is pre-built and automatically installed by _QGroundControl_ when appropriate
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
 ```
-make px4_fmu-v6xrt
+make px4_fmu-v6xrt_default
 ```
 
 <a id="debug_port"></a>


### PR DESCRIPTION
Support for Pixhawk 6X-RT is in PX4 main since today. Corrected the build target name.