### PR TITLE
crowdin - update as unapproved

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,4 @@
 files:
   - source: /en/**/*.md
     translation: /%two_letters_code%/**/%original_file_name%
+    update_option: update_as_unapproved


### PR DESCRIPTION
We're not really using approvals, but this does give an option for using approval as a way of invalidating strings if we want.

https://developer.crowdin.com/configuration-file/#translations-upload