### PR TITLE
Removing PX4_GZ_MODEL env variable

### DIFF
--- a/en/releases/main.md
+++ b/en/releases/main.md
@@ -39,7 +39,7 @@ TBD ...
 - [Gazebo] Support for [Advanced Plane](../sim_gazebo_gz/vehicles.md#advanced-plane), a simulated fixed-wing vehicle that provides better aerodynamic simulation than the regular plane.
   Added to PX4 in [PX4-Autopilot#22167](https://github.com/PX4/PX4-Autopilot/pull/22167) and [gz-sim#2185](https://github.com/gazebosim/gz-sim/pull/2185) (advanced lift drag plugin).
 
-- [Gazebo] Deprecation of the `PX4_GZ_MODEL` environmental variable in favor of `PX4_SIM_MODEL`.
+- [Gazebo] Deprecation of the `PX4_GZ_MODEL` environmental variable in favor of `PX4_SIM_MODEL`. Added to PX4 in [PX4-Autopilot#22400](https://github.com/PX4/PX4-Autopilot/pull/22400).
 
 ### uXRCE-DDS / ROS2
 

--- a/en/releases/main.md
+++ b/en/releases/main.md
@@ -39,6 +39,8 @@ TBD ...
 - [Gazebo] Support for [Advanced Plane](../sim_gazebo_gz/vehicles.md#advanced-plane), a simulated fixed-wing vehicle that provides better aerodynamic simulation than the regular plane.
   Added to PX4 in [PX4-Autopilot#22167](https://github.com/PX4/PX4-Autopilot/pull/22167) and [gz-sim#2185](https://github.com/gazebosim/gz-sim/pull/2185) (advanced lift drag plugin).
 
+- [Gazebo] Deprecation of the `PX4_GZ_MODEL` environmental variable in favor of `PX4_SIM_MODEL`.
+
 ### uXRCE-DDS / ROS2
 
 - [uXRCE-DDS] [DDS Topics YAML](../middleware/uxrce_dds.md#dds-topics-yaml) now allows the use of `subscription_multi` to specify that indicated ROS 2 topics are sent to a separate uORB topic instance reserved for ROS 2.

--- a/en/releases/main.md
+++ b/en/releases/main.md
@@ -38,8 +38,8 @@ TBD ...
 
 - [Gazebo] Support for [Advanced Plane](../sim_gazebo_gz/vehicles.md#advanced-plane), a simulated fixed-wing vehicle that provides better aerodynamic simulation than the regular plane.
   Added to PX4 in [PX4-Autopilot#22167](https://github.com/PX4/PX4-Autopilot/pull/22167) and [gz-sim#2185](https://github.com/gazebosim/gz-sim/pull/2185) (advanced lift drag plugin).
-
-- [Gazebo] Deprecation of the `PX4_GZ_MODEL` environmental variable in favor of `PX4_SIM_MODEL`.
+- [Gazebo] The environment variable `PX4_SIM_MODEL` can now be used to indicate the simulation model.
+  This supersedes `PX4_GZ_MODEL`, which is now deprecated.
   Added to PX4 in [PX4-Autopilot#22400](https://github.com/PX4/PX4-Autopilot/pull/22400).
 
 ### uXRCE-DDS / ROS2

--- a/en/releases/main.md
+++ b/en/releases/main.md
@@ -39,7 +39,8 @@ TBD ...
 - [Gazebo] Support for [Advanced Plane](../sim_gazebo_gz/vehicles.md#advanced-plane), a simulated fixed-wing vehicle that provides better aerodynamic simulation than the regular plane.
   Added to PX4 in [PX4-Autopilot#22167](https://github.com/PX4/PX4-Autopilot/pull/22167) and [gz-sim#2185](https://github.com/gazebosim/gz-sim/pull/2185) (advanced lift drag plugin).
 
-- [Gazebo] Deprecation of the `PX4_GZ_MODEL` environmental variable in favor of `PX4_SIM_MODEL`. Added to PX4 in [PX4-Autopilot#22400](https://github.com/PX4/PX4-Autopilot/pull/22400).
+- [Gazebo] Deprecation of the `PX4_GZ_MODEL` environmental variable in favor of `PX4_SIM_MODEL`.
+  Added to PX4 in [PX4-Autopilot#22400](https://github.com/PX4/PX4-Autopilot/pull/22400).
 
 ### uXRCE-DDS / ROS2
 

--- a/en/sim_gazebo_gz/README.md
+++ b/en/sim_gazebo_gz/README.md
@@ -132,26 +132,25 @@ where `ARGS` is a list of environment variables including:
   Sets the name of an _existing_ model in the gazebo simulation.
   If provided, the startup script tries to bind a new PX4 instance to the Gazebo resource matching exactly that name.
 
-  - The setting is mutually exclusive with `PX4_GZ_MODEL`.
+  - The setting is mutually exclusive with `PX4_SIM_MODEL`.
 
-- `PX4_GZ_MODEL`:
+- `PX4_SIM_MODEL`:
   Sets the name of a new Gazebo model to be spawned in the simulator.
   If provided, the startup script looks for a model in the Gazebo resource path that matches the given variable, spawns it and binds a new PX4 instance to it.
 
   - The setting is mutually exclusive with `PX4_GZ_MODEL_NAME`.
 
   :::note
-  If both `PX4_GZ_MODEL_NAME` and `PX4_GZ_MODEL` are not given, then PX4 looks for `PX4_SIM_MODEL` and uses it as an alias for `PX4_GZ_MODEL`.
-  However, this prevents the use of `PX4_GZ_MODEL_POSE`.
+  The environmental variable `PX4_GZ_MODEL` has been deprecated and its functionality merged into `PX4_SIM_MODEL`. 
   :::
 
 - `PX4_GZ_MODEL_POSE`:
-  Sets the spawning position and orientation of the model when `PX4_GZ_MODEL` is adopted.
+  Sets the spawning position and orientation of the model when `PX4_SIM_MODEL` is adopted.
   If provided, the startup script spawns the model at a pose following the syntax `"x,y,z,roll,pitch,yaw"`, where the positions are given in metres and the angles are in radians.
 
   - If omitted, the zero pose `[0,0,0,0,0,0]` is used.
   - If less then 6 values are provided, the missing ones are fixed to zero.
-  - This can only be used with `PX4_GZ_MODEL` (not `PX4_GZ_MODEL_NAME`).
+  - This can only be used with `PX4_SIM_MODEL` (not `PX4_GZ_MODEL_NAME`).
 
 - `PX4_GZ_WORLD`:
   Sets the Gazebo world file for a new simulation.
@@ -184,7 +183,7 @@ Here are some examples of the different scenarios covered above.
 2. **Start simulator + default world + spawn vehicle at custom pose (y=2m)**
 
    ```sh
-   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,2" PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4
+   PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,2" PX4_SIM_MODEL=gz_x500 ./build/px4_sitl_default/bin/px4
    ```
 
 3. **Start simulator + default world + link to existing vehicle**


### PR DESCRIPTION
This PR deprecates the `PX4_GZ_MODEL` env variable and merges its functionality with `PX4_SIM_MODEL`. 

Goes along with
- [x] https://github.com/PX4/PX4-Autopilot/pull/22400