### PR TITLE
Add introduced-in badges for features

### DIFF
--- a/en/advanced/package_delivery.md
+++ b/en/advanced/package_delivery.md
@@ -1,4 +1,4 @@
-# Package Delivery in Missions (Development)
+# Package Delivery in Missions <Badge type="tip" text="v1.14" vertical="top" />
 
 A package delivery mission is an extension of a waypoint mission, where a user can plan delivering a package as a waypoint.
 

--- a/en/config/actuators.md
+++ b/en/config/actuators.md
@@ -1,4 +1,4 @@
-# Actuator Configuration and Testing
+# Actuator Configuration and Testing <Badge type="tip" text="v1.14" vertical="top" />
 
 The _Actuators Setup_ view is used to customize the specific geometry of the vehicle, assign actuators and motors to flight controller outputs, and test the actuator and motor response.
 

--- a/en/config/safety_simulation.md
+++ b/en/config/safety_simulation.md
@@ -1,4 +1,4 @@
-# Failsafe State Machine Simulation
+# Failsafe State Machine Simulation <Badge type="tip" text="v1.14" vertical="top" />
 
 This page can be used to simulate the actions of the PX4 failsafe state machine under all possible configurations and conditions.
 

--- a/en/getting_started/flight_modes.md
+++ b/en/getting_started/flight_modes.md
@@ -99,7 +99,7 @@ Unlike [Altitude](#altitude-mode-mc) and [Manual/Stabilized](#manual_stabilized_
 [Position Slow mode](../flight_modes_mc/position_slow.md) is a velocity and yaw rate limited version of the regular [Position mode](#position-mode-mc).
 
 The mode works in exactly the same way as _Position mode_ but with the controller stick deflection re-scaled to lower maximum velocities (and proportionally lower acceleration).
-You can use it to quickly slow down the vehicle to a safe speed (if it is moving faster than the maximum velocity in the limited axis).
+You can use it to quickly slow down the vehicle to a safe speed.
 You can also use it to get more precision from stick input, in particular when flying close to obstacles, or to comply with regulations such as [EASA's low-speed mode/function](https://www.easa.europa.eu/en/light/topics/flying-drones-close-people).
 
 ### Altitude Mode (MC)

--- a/en/middleware/uxrce_dds.md
+++ b/en/middleware/uxrce_dds.md
@@ -1,4 +1,4 @@
-# uXRCE-DDS (PX4-ROS 2/DDS Bridge)
+# uXRCE-DDS (PX4-ROS 2/DDS Bridge) <Badge type="tip" text="v1.14" vertical="top" />
 
 :::note
 uXRCE-DDS replaces the [Fast-RTPS Bridge](https://docs.px4.io/v1.13/en/middleware/micrortps.html#rtps-dds-interface-px4-fast-rtps-dds-bridge) used in PX4 v1.13.


### PR DESCRIPTION
This adds version badges to some new features in v1.14 - actuators and xrce-dds. This uses the green "tip" badge, because that is appropriate for something that is "OK". I'm using "warning" badges for new features.

The main thing here is to make some of these new features more obviously new and clear that just because you see actuators in the top level doesn't mean it is in your version of PX4.