### PR TITLE
Add experimental and discontinued badging plus a linked badge

### DIFF
--- a/.vuepress/components/LinkedBadge.vue
+++ b/.vuepress/components/LinkedBadge.vue
@@ -1,0 +1,26 @@
+<template>
+  <a :href="url">
+    <Badge :text="text" :type="type" />
+  </a>
+</template>
+
+<script>
+import Badge from '@vuepress/theme-default/global-components/Badge.vue';
+import markdownIt from 'markdown-it';
+
+const md = markdownIt();
+
+export default {
+  components: {
+    Badge,
+  },
+  props: {
+    url: String,
+    text: String,
+    type: String,
+  },
+  mounted() {
+    this.url = md.renderInline(this.url).toString();
+  },
+};
+</script>

--- a/en/advanced/package_delivery.md
+++ b/en/advanced/package_delivery.md
@@ -1,4 +1,6 @@
-# Package Delivery in Missions <Badge type="tip" text="v1.14" vertical="top" />
+# Package Delivery in Missions
+
+<Badge type="tip" text="PX4 v1.14" />
 
 A package delivery mission is an extension of a waypoint mission, where a user can plan delivering a package as a waypoint.
 

--- a/en/airframes/README.md
+++ b/en/airframes/README.md
@@ -18,6 +18,14 @@ The frame types that have a maintainer and are well tested and supported are:
 
 ## Experimental Vehicles
 
+Experimental frames are those vehicle types that:
+
+- Do not have a maintainer.
+- Are not regularly tested by the core development team.
+- May not be tested in CI.
+- May lack features required for production-ready vehicles.
+- May not support some common vehicle configurations for the vehicle type.
+
 The following vehicle types are considered experimental:
 
 - [Airships](../frames_airship/README.md)
@@ -28,13 +36,6 @@ The following vehicle types are considered experimental:
 - [Submarines](../frames_sub/README.md)
 
 :::note
-Experimental frames are those vehicle types that:
-
-- Do not have a maintainer.
-- Are not regularly tested by the core development team.
-- May lack features required for production-ready vehicles.
-- May not support some common vehicle configurations for the vehicle type.
-
 Maintainer volunteers, [contribution](../contribute/README.md) of new features, new frame configurations, or other improvements would all be very welcome!
 :::
 

--- a/en/complete_vehicles/betafpv_beta75x.md
+++ b/en/complete_vehicles/betafpv_beta75x.md
@@ -1,5 +1,7 @@
 # BetaFPV Beta75X 2S Brushless Whoop
 
+<Badge type="error" text="Discontinued" />
+
 :::warning
 This frame has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::

--- a/en/complete_vehicles/crazyflie2.md
+++ b/en/complete_vehicles/crazyflie2.md
@@ -1,5 +1,7 @@
 # Crazyflie 2.0 (Discontinued)
 
+<Badge type="error" text="Discontinued" />
+
 :::warning
 _Crazyflie 2.0_ has been [discontinued/superseded](../flight_controller/autopilot_experimental.md).
 Try [Bitcraze Crazyflie 2.1](../complete_vehicles/crazyflie21.md) instead!

--- a/en/complete_vehicles/crazyflie21.md
+++ b/en/complete_vehicles/crazyflie21.md
@@ -1,12 +1,10 @@
 # Crazyflie 2.1
 
+<LinkedBadge type="warning" text="Experimental" url="../flight_controller/autopilot_experimental.html"/>
+
 :::warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://www.bitcraze.io/) for hardware support or compliance issues.
-:::
-
-:::warning
-PX4 support for this flight controller is [experimental](../flight_controller/autopilot_experimental.md).
 :::
 
 :::warning

--- a/en/complete_vehicles/intel_aero.md
+++ b/en/complete_vehicles/intel_aero.md
@@ -1,5 +1,7 @@
 # Intel Aero Ready to Fly Drone
 
+<Badge type="error" text="Discontinued" />
+
 :::warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 

--- a/en/config/actuators.md
+++ b/en/config/actuators.md
@@ -1,4 +1,6 @@
-# Actuator Configuration and Testing <Badge type="tip" text="v1.14" vertical="top" />
+# Actuator Configuration and Testing
+
+<Badge type="tip" text="PX4 v1.14" />
 
 The _Actuators Setup_ view is used to customize the specific geometry of the vehicle, assign actuators and motors to flight controller outputs, and test the actuator and motor response.
 

--- a/en/config/safety_simulation.md
+++ b/en/config/safety_simulation.md
@@ -1,4 +1,6 @@
-# Failsafe State Machine Simulation <Badge type="tip" text="v1.14" vertical="top" />
+# Failsafe State Machine Simulation
+
+<Badge type="tip" text="PX4 v1.14" />
 
 This page can be used to simulate the actions of the PX4 failsafe state machine under all possible configurations and conditions.
 

--- a/en/flight_controller/auav_x2.md
+++ b/en/flight_controller/auav_x2.md
@@ -1,5 +1,7 @@
 # AUAV-X2 Autopilot (Discontinued)
 
+<Badge type="error" text="Discontinued" />
+
 :::warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::

--- a/en/flight_controller/beaglebone_blue.md
+++ b/en/flight_controller/beaglebone_blue.md
@@ -1,12 +1,10 @@
 # BeagleBone Blue
 
+<LinkedBadge type="warning" text="Experimental" url="../flight_controller/autopilot_experimental.md"/>
+
 :::warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://beagleboard.org/blue) for hardware support or compliance issues.
-:::
-
-:::warning
-PX4 support for this flight controller is [experimental](../flight_controller/autopilot_experimental.md).
 :::
 
 [BeagleBone Blue](https://beagleboard.org/blue) is an all-in-one Linux-based computer.

--- a/en/flight_controller/cuav_v5.md
+++ b/en/flight_controller/cuav_v5.md
@@ -1,5 +1,7 @@
 # CUAV v5 (Discontinued)
 
+<Badge type="error" text="Discontinued" />
+
 :::warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::

--- a/en/flight_controller/kakutef7.md
+++ b/en/flight_controller/kakutef7.md
@@ -1,5 +1,7 @@
 # Holybro Kakute F7 (Discontinued)
 
+<Badge type="error" text="Discontinued" />
+
 :::warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.

--- a/en/flight_controller/ocpoc_zynq.md
+++ b/en/flight_controller/ocpoc_zynq.md
@@ -1,5 +1,7 @@
 # Aerotenna OcPoC-Zynq Mini Flight Controller (Discontinued)
 
+<Badge type="error" text="Discontinued" />
+
 :::warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 

--- a/en/flight_controller/pixfalcon.md
+++ b/en/flight_controller/pixfalcon.md
@@ -1,5 +1,7 @@
 # Pixfalcon Flight Controller (Discontinued)
 
+<Badge type="error" text="Discontinued" />
+
 :::warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::

--- a/en/flight_controller/raspberry_pi_navio2.md
+++ b/en/flight_controller/raspberry_pi_navio2.md
@@ -1,12 +1,10 @@
 # Raspberry Pi 2/3/4 Navio2 Autopilot
 
+<LinkedBadge type="warning" text="Experimental" url="../flight_controller/autopilot_experimental.html"/>
+
 :::warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://emlid.com/) for hardware support or compliance issues.
-:::
-
-:::warning
-PX4 support for this flight controller is [experimental](../flight_controller/autopilot_experimental.md).
 :::
 
 This is the developer "quickstart" for Raspberry Pi 2/3/4 Navio2 autopilots.

--- a/en/flight_controller/raspberry_pi_pilotpi.md
+++ b/en/flight_controller/raspberry_pi_pilotpi.md
@@ -1,12 +1,10 @@
 # RPi PilotPi Shield
 
+<LinkedBadge type="warning" text="Experimental" url="../flight_controller/autopilot_experimental.html"/>
+
 :::warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](mailto:lhf2613@gmail.com) for hardware support or compliance issues.
-:::
-
-:::warning
-PX4 support for this flight controller is [experimental](../flight_controller/autopilot_experimental.md).
 :::
 
 The _PilotPi_ shield is a fully functional solution to run PX4 autopilot directly on Raspberry Pi.

--- a/en/flight_modes_mc/position_slow.md
+++ b/en/flight_modes_mc/position_slow.md
@@ -1,4 +1,6 @@
-# Position Slow Mode (Multicopter) <Badge type="warning" text="main (v1.15+)" vertical="top" />
+# Position Slow Mode (Multicopter)
+
+<Badge type="warning" text="main (PX4 v1.15)" />
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](../getting_started/flight_modes.md#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](../getting_started/flight_modes.md#key_manual)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
 

--- a/en/flight_modes_mc/throw_launch.md
+++ b/en/flight_modes_mc/throw_launch.md
@@ -1,4 +1,6 @@
-# Throw Launch (Multicopter) <Badge type="warning" text="main (v1.15+)" vertical="top" />
+# Throw Launch (Multicopter)
+
+ <Badge type="warning" text="main (PX4 v1.15)" /> <Badge type="warning" text="Experimental" />
 
 :::warning Experimental
 This feature was introduced after PX4 v1.14.

--- a/en/frames_airship/README.md
+++ b/en/frames_airship/README.md
@@ -1,12 +1,9 @@
 # Airships
 
+<LinkedBadge type="warning" text="Experimental" url="../airframes/#experimental-vehicles"/>
+
 :::warning
 Support for airships is [experimental](../airframes/README.md#experimental-vehicles).
-
-- Does not have a maintainer.
-- Not regularly tested by the core development team.
-- Limited support for different types of vehicles.
-
 Maintainer volunteers, [contribution](../contribute/README.md) of new features, new frame configurations, or other improvements would all be very welcome!
 :::
 

--- a/en/frames_autogyro/README.md
+++ b/en/frames_autogyro/README.md
@@ -1,12 +1,11 @@
 # Autogyro Frames
 
+<LinkedBadge type="warning" text="Experimental" url="../airframes/#experimental-vehicles"/>
+
 :::warning
 Support for autogyro frames is [experimental](../airframes/README.md#experimental-vehicles).
-
-- Does not have a maintainer.
-- Not regularly tested by the core development team.
-- May not support all features needed in a product-quality UUV (feature support not known/documented).
-  :::
+Maintainer volunteers, [contribution](../contribute/README.md) of new features, new frame configurations, or other improvements would all be very welcome!
+:::
 
 An [Autogyro](https://en.wikipedia.org/wiki/Autogyro) is a type of [rotorary-wing](https://en.wikipedia.org/wiki/Rotorcraft).
 Compared to other designs it possesses following advantages:

--- a/en/frames_balloon/README.md
+++ b/en/frames_balloon/README.md
@@ -1,14 +1,11 @@
 # Balloons
 
+<LinkedBadge type="warning" text="Experimental" url="../airframes/#experimental-vehicles"/>
+
 :::warning
 Support for balloons is [experimental](../airframes/README.md#experimental-vehicles).
-
-- Does not have a maintainer.
-- Not regularly tested by the core development team.
-- Limited support for different types of vehicles.
-
 Maintainer volunteers, [contribution](../contribute/README.md) of new features, new frame configurations, or other improvements would all be very welcome!
 :::
 
-PX4 supports a single baloon geometry with no fligth controls.
-The frame configuration is shown in [Airframes Reference > Balloon](../airframes/airframe_reference.md#balloon). 
+PX4 supports a single balloon geometry with no flight controls.
+The frame configuration is shown in [Airframes Reference > Balloon](../airframes/airframe_reference.md#balloon).

--- a/en/frames_helicopter/README.md
+++ b/en/frames_helicopter/README.md
@@ -1,14 +1,16 @@
 # Helicopters
 
+<LinkedBadge type="warning" text="Experimental" url="../airframes/#experimental-vehicles"/>
+
 :::warning
 Support for helicopters is [experimental](../airframes/README.md#experimental-vehicles).
+Maintainer volunteers, [contribution](../contribute/README.md) of new features, new frame configurations, or other improvements would all be very welcome!
 
-- Does not have a maintainer.
-- Not regularly tested by the core development team.
+Issues include:
+
 - Limited support for different types of helicopters.
   For example, PX4 does not support helicopters with coaxial or dual rotor types, and features such as RPM governor and autorotation.
 
-Maintainer volunteers, [contribution](../contribute/README.md) of new features, new frame configurations, or other improvements would all be very welcome!
 :::
 
 <!-- image here please of PX4 helicopter -->

--- a/en/frames_rover/README.md
+++ b/en/frames_rover/README.md
@@ -1,12 +1,9 @@
 # Rovers (UGVs)
 
+<LinkedBadge type="warning" text="Experimental" url="../airframes/#experimental-vehicles"/>
+
 :::warning
 Support for rover is [experimental](../airframes/README.md#experimental-vehicles).
-
-- Does not have a maintainer.
-- Not regularly tested by the core development team.
-- Limited support for different types of vehicles.
-
 Maintainer volunteers, [contribution](../contribute/README.md) of new features, new frame configurations, or other improvements would all be very welcome!
 :::
 

--- a/en/frames_sub/README.md
+++ b/en/frames_sub/README.md
@@ -1,15 +1,18 @@
 # Submarines (Unmanned Underwater Vehicles - UUV)
 
+<LinkedBadge type="warning" text="Experimental" url="../airframes/#experimental-vehicles"/>
+
 :::warning
-Support for UUVs is _experimental_.
-The platform does not support all features needed in a product-quality UUV, and the platform is not regularly tested by the core development team.
+Support for UUVs is [experimental](../airframes/README.md#experimental-vehicles).
+Maintainer volunteers, [contribution](../contribute/README.md) of new features, new frame configurations, or other improvements would all be very welcome!
 
 At time of writing it has only been tested using ROS in offboard mode.
 The following features have not been implemented:
 
 - Modes like missions, depth hold, stabilised manual control, etc.
 - BlueRobotics gripper support.
-  :::
+
+:::
 
 PX4 enables a number of unmanned underwater vehicle (UUV) frames:
 

--- a/en/gps_compass/gps_cuav_neo_3.md
+++ b/en/gps_compass/gps_cuav_neo_3.md
@@ -1,6 +1,6 @@
 # CUAV NEO 3 GPS
 
-<Badge type="tip" text="PX4 v1.13+" />
+<Badge type="tip" text="PX4 v1.13" />
 
 This NEO 3 GPS is manufactured by CUAV.
 It integrates Ublox M9N, IST8310, three-color LED lights and safety switches, and is compatible with CUAV and Pixhawk standard controllers.

--- a/en/gps_compass/gps_cuav_neo_3pro.md
+++ b/en/gps_compass/gps_cuav_neo_3pro.md
@@ -1,6 +1,6 @@
 # CUAV NEO 3 Pro
 
-<Badge type="tip" text="PX4 v1.13+" />
+<Badge type="tip" text="PX4 v1.13" />
 
 NEO 3Pro is a DroneCan GPS receiver produced by CUAV.
 It integrates UBLOX M9N, STM32F4 MCU, RM3100 compass, three-color LED light and safety switch.

--- a/en/gps_compass/gps_cuav_neo_3x.md
+++ b/en/gps_compass/gps_cuav_neo_3x.md
@@ -1,6 +1,6 @@
 # CUAV NEO 3X GPS
 
-<Badge type="tip" text="PX4 v1.13+" />
+<Badge type="tip" text="PX4 v1.13" />
 
 CUAV Neo 3X is a GNSS receiver that is waterproof and dustproof.
 It has IP66 protection capability and integrates UBLOX M9N module, RM3100 compass, color LED light and safety switch.

--- a/en/middleware/uxrce_dds.md
+++ b/en/middleware/uxrce_dds.md
@@ -1,4 +1,6 @@
-# uXRCE-DDS (PX4-ROS 2/DDS Bridge) <Badge type="tip" text="v1.14" vertical="top" />
+# uXRCE-DDS (PX4-ROS 2/DDS Bridge)
+
+<Badge type="tip" text="PX4 v1.14" />
 
 :::note
 uXRCE-DDS replaces the [Fast-RTPS Bridge](https://docs.px4.io/v1.13/en/middleware/micrortps.html#rtps-dds-interface-px4-fast-rtps-dds-bridge) used in PX4 v1.13.

--- a/en/ros2/px4_ros2_control_interface.md
+++ b/en/ros2/px4_ros2_control_interface.md
@@ -1,4 +1,6 @@
-# PX4 ROS 2 Control Interface <Badge type="warning" text="main (v1.15+)" vertical="top" />
+# PX4 ROS 2 Control Interface
+
+<Badge type="warning" text="main (PX4 v1.15)" /> <Badge type="warning" text="Experimental" />
 
 :::warning Experimental
 At the time of writing, parts of the PX4 ROS 2 Control Interface are experimental, and hence subject to change:

--- a/en/ros2/px4_ros2_interface_lib.md
+++ b/en/ros2/px4_ros2_interface_lib.md
@@ -1,4 +1,6 @@
-# PX4 ROS 2 Interface Library <Badge type="warning" text="main (v1.15+)" vertical="top" />
+# PX4 ROS 2 Interface Library
+
+<Badge type="warning" text="main (PX4 v1.15)" /> <Badge type="warning" text="Experimental" />
 
 :::warning Experimental
 At the time of writing, parts of the PX4 ROS 2 Interface Library are experimental, and hence subject to change.

--- a/en/ros2/px4_ros2_navigation_interface.md
+++ b/en/ros2/px4_ros2_navigation_interface.md
@@ -1,4 +1,6 @@
-# PX4 ROS 2 Navigation Interface <Badge type="warning" text="main (v1.15+)" vertical="top" />
+# PX4 ROS 2 Navigation Interface
+
+<Badge type="warning" text="main (PX4 v1.15)" /> <Badge type="warning" text="Experimental" />
 
 :::warning Experimental
 At the time of writing, parts of the PX4 ROS 2 Interface Library are experimental, and hence subject to change.


### PR DESCRIPTION
This improves badging in two ways:
1. Remove badges from headings. Easier to stack them in own line below heading.
2. Adds a linked badge so we can link to more information. Not fully utilized, but done in a few laces.
3. Adds a bunch more badges. The confusing one for me is "Discontinued". Not clear if this is helpful, say, compared to just keeping our badging.
4. Used the linked badge for experimental frames - linking to definition. Then reduced the amount of text, where possible, explaining what is missing in them.