### PR TITLE
Mavlink custom messages update

### DIFF
--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -134,12 +134,12 @@ Add the headers for the MAVLink and uORB messages to the top of the file:
 
 ```cpp
 #include <uORB/topics/battery_status.h>
-#include <v2.0/common/mavlink.h>
+#include <v2.0/development/mavlink.h>
 ```
 
 :::note
 The uORB topic's snake-case header file is generated from the CamelCase uORB filename at build time.
-The `common/mavlink.h` header is also generated at build time (where "common" in the path comes from the XML file name).
+The `development/mavlink.h` header is also generated at build time (where "development" in the path comes from the XML definition file name).
 :::
 
 Then copy the streaming class definition below into the file:
@@ -346,13 +346,14 @@ A particular message can be requested just once using [MAV_CMD_REQUEST_MESSAGE](
 
 This section explains how to receive a message over MAVLink and publish it to uORB.
 
-It assumes that we are receiving the `BATTERY_STATUS_DEMO` message, which is perhaps published by a MAVLink battery, and we want to update the (existing) [BatteryStatus uORB message](../msg_docs/BatteryStatus.md) with the contained information.
+It assumes that we are receiving the `BATTERY_STATUS_DEMO` message and we want to update the (existing) [BatteryStatus uORB message](../msg_docs/BatteryStatus.md) with the contained information.
+This is the kind of implementation that you would provide to support a MAVLink battery integration with PX4.
 
 Add the headers for the incoming MAVLink message and the uORB topic to publish to in [mavlink_receiver.h](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_receiver.h#L77):
 
 ```cpp
 #include <uORB/topics/battery_status.h>
-#include <v2.0/common/mavlink.h>
+#include <v2.0/development/mavlink.h>
 ```
 
 Add a function signature for a function that handles the incoming MAVLink message in the `MavlinkReceiver` class in

--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -328,7 +328,7 @@ QGC uses a pre-built C library that must be located at [/qgroundcontrol/libs/mav
 
 By default this is pre-included as a submodule from <https://github.com/mavlink/c_library_v2> but you can [generate your own MAVLink Libraries](https://mavlink.io/en/getting_started/generate_libraries.html).
 
-QGC uses the ArduPilotMega.xml dialect by default, which includes **common.xml**.
+QGC uses the all.xml dialect by default, which includes **common.xml**.
 You can include your messages in either file or in your own dialect.
 However if you use your own dialect then it should include ArduPilotMega.xml (or it will miss all the existing messages), and you will need to change the dialect used by setting it in [`MAVLINK_CONF`](https://github.com/mavlink/qgroundcontrol/blob/master/QGCExternalLibs.pri#L52) when running _qmake_.
 

--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -2,7 +2,7 @@
 
 [MAVLink](https://mavlink.io/en/) is a very lightweight messaging protocol that has been designed for the drone ecosystem.
 
-PX4 uses *MAVLink* to communicate with *QGroundControl* (and other ground stations), and as the integration mechanism for connecting to drone components outside of the flight controller: companion computers, MAVLink enabled cameras etc.
+PX4 uses _MAVLink_ to communicate with _QGroundControl_ (and other ground stations), and as the integration mechanism for connecting to drone components outside of the flight controller: companion computers, MAVLink enabled cameras etc.
 
 The protocol defines a number of standard [messages](https://mavlink.io/en/messages/) and [microservices](https://mavlink.io/en/services/) for exchanging data (many, but not all, messages/services have been implemented in PX4).
 
@@ -35,7 +35,6 @@ Inspect the build log for information.
 :::note
 The [MAVLink Developer guide](https://mavlink.io/en/getting_started/) has more information about using the MAVLink toolchain.
 :::
-
 
 ## Sending Custom MAVLink Messages
 
@@ -105,7 +104,7 @@ protected:
             _msg_ca_trajectory.seq_id = _ca_trajectory.seq_id;
 
             mavlink_msg_ca_trajectory_send_struct(_mavlink->get_channel(), &_msg_ca_trajectory);
-            
+
             return true;
         }
 
@@ -131,10 +130,10 @@ mavlink stream -r 50 -s CA_TRAJECTORY -u 14556
 ```
 
 :::tip
-You can use the `uorb top [<message_name>]` command to verify in real-time that your message is published and the rate (see [uORB Messaging](../middleware/uorb.md#uorb-top-command)). 
+You can use the `uorb top [<message_name>]` command to verify in real-time that your message is published and the rate (see [uORB Messaging](../middleware/uorb.md#uorb-top-command)).
 This approach can also be used to test incoming messages that publish a uORB topic (for other messages you might use `printf` in your code and test in SITL).
 
-To see the message on *QGroundControl* you will need to [build it with your MAVLink library](https://dev.qgroundcontrol.com/en/getting_started/), and then verify that the message is received using [MAVLink Inspector Widget](https://docs.qgroundcontrol.com/master/en/app_menu/mavlink_inspector.html) (or some other MAVLink tool).
+To see the message on _QGroundControl_ you will need to [build it with your MAVLink library](https://dev.qgroundcontrol.com/en/getting_started/), and then verify that the message is received using [MAVLink Inspector Widget](https://docs.qgroundcontrol.com/master/en/app_menu/mavlink_inspector.html) (or some other MAVLink tool).
 :::
 
 ## Receiving Custom MAVLink Messages
@@ -155,6 +154,7 @@ Add a function that handles the incoming MAVLink message in the `MavlinkReceiver
 ```C
 void handle_message_ca_trajectory_msg(mavlink_message_t *msg);
 ```
+
 Add an uORB publisher in the `MavlinkReceiver` class in
 [mavlink_receiver.h](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_receiver.h#L195)
 
@@ -179,7 +179,7 @@ void MavlinkReceiver::handle_message_ca_trajectory_msg(mavlink_message_t *msg)
     f.time_stop_usec = traj.time_stop_usec;
     for(int i=0;i<28;i++)
         f.coefficients[i] = traj.coefficients[i];
-        
+
     _ca_traj_msg_pub.publish(f);
 }
 ```
@@ -205,7 +205,7 @@ Sometimes there is the need for a custom MAVLink message with content that is no
 For example when using MAVLink to interface PX4 with an embedded device, the messages that are exchanged between the autopilot and the device may go through several iterations before they are stabilized.
 In this case, it can be time-consuming and error-prone to regenerate the MAVLink headers, and make sure both devices use the same version of the protocol.
 
-An alternative - and temporary - solution is to re-purpose debug messages. 
+An alternative - and temporary - solution is to re-purpose debug messages.
 Instead of creating a custom MAVLink message `CA_TRAJECTORY`, you can send a message `DEBUG_VECT` with the string key `CA_TRAJ` and data in the `x`, `y` and `z` fields.
 See [this tutorial](../debug/debug_values.md). for an example usage of debug messages.
 
@@ -220,8 +220,9 @@ Ultimately you'll want to test your new MAVLink interface is working by providin
 As a first step, and while debugging, commonly you'll just want to confirm that any messages you've created are being sent/received as you expect.
 
 There are several approaches you can use to view traffic:
+
 - Create a [Wireshark MAVLink plugin](https://mavlink.io/en/guide/wireshark.html) for your dialect.
-  This allows you to inspect MAVLink traffic on an IP interface - for example between *QGroundControl* or MAVSDK and your real or simulated version of PX4. 
+  This allows you to inspect MAVLink traffic on an IP interface - for example between _QGroundControl_ or MAVSDK and your real or simulated version of PX4.
 - [Log uORB topics](../dev_log/logging.md) associate with your MAVLink message.
 - View received messages in the QGroundControl [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_inspector.html).
   For the messages to appear you will need to [Build QGroundControl](https://dev.qgroundcontrol.com/master/en/getting_started/) including a pre-built C library that contains your custom messages.
@@ -229,20 +230,22 @@ There are several approaches you can use to view traffic:
     By default this is pre-included as a submodule from https://github.com/mavlink/c_library_v2 but you can [generate your own MAVLink Libraries](https://mavlink.io/en/getting_started/generate_libraries.html)
   - QGC uses the ArduPilotMega.xml dialect by default, which includes **common.xml**.
     You can include your messages in either file or in your own dialect.
-    However if you use your own dialect then it should include ArduPilotMega.xml (or it will miss all the existing messages), and you will need to change the dialect used by setting it in [`MAVLINK_CONF`](https://github.com/mavlink/qgroundcontrol/blob/master/QGCExternalLibs.pri#L52) when running *qmake*.
-
+    However if you use your own dialect then it should include ArduPilotMega.xml (or it will miss all the existing messages), and you will need to change the dialect used by setting it in [`MAVLINK_CONF`](https://github.com/mavlink/qgroundcontrol/blob/master/QGCExternalLibs.pri#L52) when running _qmake_.
 
 ## General
 
 ### Set streaming rate
 
-Sometimes it is useful to increase the streaming rate of individual topics (e.g. for inspection in QGC). 
+Sometimes it is useful to increase the streaming rate of individual topics (e.g. for inspection in QGC).
 This can be achieved by typing the following line in the shell:
+
 ```sh
 mavlink stream -u <port number> -s <mavlink topic name> -r <rate>
 ```
-You can get the port number with `mavlink status` which will output (amongst others) `transport protocol: UDP (<port number>)`. 
+
+You can get the port number with `mavlink status` which will output (amongst others) `transport protocol: UDP (<port number>)`.
 An example would be:
+
 ```sh
 mavlink stream -u 14556 -s OPTICAL_FLOW_RAD -r 300
 ```

--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -162,14 +162,14 @@ If you search in the file you'll find groups of messages defined in a switch sta
 
 - `MAVLINK_MODE_NORMAL`: Streamed to a GCS.
 - `MAVLINK_MODE_ONBOARD`: Streamed to a companion computer on a fast link, such as Ethernet
-- `MAVLINK_MODE_ONBOARD_LOW_BANDWIDTH`: Streamed to a companion computer on slower link
+- `MAVLINK_MODE_ONBOARD_LOW_BANDWIDTH`: Streamed to a companion computer for re-routing to a reduced-traffic link, such as a GCS.
 - `MAVLINK_MODE_GIMBAL`: Streamed to a gimbal
 - `MAVLINK_MODE_EXTVISION`: Streamed to an external vision system
 - `MAVLINK_MODE_EXTVISIONMIN`: Streamed to an external vision system on a slower link
 - `MAVLINK_MODE_OSD`: Streamed to an OSD, such as an FPV headset.
 - `MAVLINK_MODE_CUSTOM`: Stream nothing by default. Used when configuring streaming using MAVLink.
 - `MAVLINK_MODE_MAGIC`: Same as `MAVLINK_MODE_CUSTOM`
-- `MAVLINK_MODE_CONFIG`: ?
+- `MAVLINK_MODE_CONFIG`: Streaming over USB with higher rates than `MAVLINK_MODE_NORMAL`.
 - `MAVLINK_MODE_MINIMAL`: Stream a minimal set of messages. Normally used for poor telemetry links.
 - `MAVLINK_MODE_IRIDIUM`: Streamed to an iridium satellite phone
 

--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -225,7 +225,7 @@ protected:
 
 Most streaming classes are very similar (see examples in [/src/modules/mavlink/streams](https://github.com/PX4/PX4-Autopilot/tree/main/src/modules/mavlink/streams)):
 
-- The streaming class derives from [`MavlinkStream`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_stream.h) and is named using the pattern `MavlinkStream``CamelCaseMessageName>`.
+- The streaming class derives from [`MavlinkStream`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_stream.h) and is named using the pattern `MavlinkStream``<CamelCaseMessageName>`.
 - The `public` definitions are "near-boilerplate", allowing PX4 to get an instance of the class (`new_instance()`), and then to use it to fetch the name, id, and size of the message from the MAVLink headers (`get_name()`, `get_name_static()`, `get_id_static()`, `get_id()`, `get_size()`).
   For your own streaming classes these can just be copied and modified to match the values for your MAVLink message.
 - The `private` definitions subscribe to the uORB topics that need to be published.

--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -225,7 +225,7 @@ protected:
 
 Most streaming classes are very similar (see examples in [/src/modules/mavlink/streams](https://github.com/PX4/PX4-Autopilot/tree/main/src/modules/mavlink/streams)):
 
-- The streaming class derives from [`MavlinkStream`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_stream.h).
+- The streaming class derives from [`MavlinkStream`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_stream.h) and is named using the pattern `MavlinkStream``CamelCaseMessageName>`.
 - The `public` definitions are "near-boilerplate", allowing PX4 to get an instance of the class (`new_instance()`), and then to use it to fetch the name, id, and size of the message from the MAVLink headers (`get_name()`, `get_name_static()`, `get_id_static()`, `get_id()`, `get_size()`).
   For your own streaming classes these can just be copied and modified to match the values for your MAVLink message.
 - The `private` definitions subscribe to the uORB topics that need to be published.


### PR DESCRIPTION
This is a significant update to the MAVLink custom message doc. This did not match the current way of doing things, which is to have a separate file for the streaming class and include it. Also somewhat confusing for readers who don't understand they have to create their own CA_TRAJECTORY message and Uorb topic.

There are several main parts to the change
1. Explains the streaming class file and how it is included
2. Changes correct way for streaming message to be updating the groups in mavlink_main.cpp (not using startup file, though that is mentioned).
3. Explains how you can use MAVLink to set streaming rates. The old "set streaming rates" uses the shell, and I have made that part of testing
4. Adds a section on updating MAVSDK/QGC. Cross links to this from testing.

I've added a few notes, where I'd quite like help.

@julianoes @bkueng Would you be able to review?