### PR TITLE
FW_USE_AIRSPD not AIRSPEED

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -444,6 +444,7 @@
       * [DebugKeyValue](msg_docs/DebugKeyValue.md)
       * [DebugValue](msg_docs/DebugValue.md)
       * [DebugVect](msg_docs/DebugVect.md)
+      * [DifferentialDriveSetpoint](msg_docs/DifferentialDriveSetpoint.md)
       * [DifferentialPressure](msg_docs/DifferentialPressure.md)
       * [DistanceSensor](msg_docs/DistanceSensor.md)
       * [Ekf2Timestamps](msg_docs/Ekf2Timestamps.md)

--- a/en/config_vtol/vtol_without_airspeed_sensor.md
+++ b/en/config_vtol/vtol_without_airspeed_sensor.md
@@ -48,7 +48,7 @@ This can be used to tune your throttle setting after the first flight without an
 
 To bypass the airspeed preflight check you need to set [SYS_HAS_NUM_ASPD](../advanced_config/parameter_reference.md#SYS_HAS_NUM_ASPD) to 0.
 
-To prevent an installed airspeed sensor being used for feedback control set [FW_USE_AIRSPEED](../advanced_config/parameter_reference.md#FW_USE_AIRSPEED) to `False`.
+To prevent an installed airspeed sensor being used for feedback control set [FW_USE_AIRSPD](../advanced_config/parameter_reference.md#FW_USE_AIRSPD) to `False`.
 This allows you to test the system's behavior in the airspeed-less setting while still having the actual airspeed reading available to check the safety margin to stall speed etc.
 
 Set the trim throttle ([FW_THR_TRIM](../advanced_config/parameter_reference.md#FW_THR_TRIM)) to the percentage as determined from the log of the reference flight.


### PR DESCRIPTION
This fixes incorrect param name that should be FW_USE_AIRSPD and also missing uorb message link.

