### PR TITLE
Update vtol_without_airspeed_sensor.md

### DIFF
--- a/en/config_vtol/vtol_without_airspeed_sensor.md
+++ b/en/config_vtol/vtol_without_airspeed_sensor.md
@@ -11,9 +11,13 @@ Fixed-wing vehicles use airspeed sensors to determine the speed at which the air
 Depending on wind this could vary from groundspeed.
 Every airplane has a minimum airspeed below which the airplane will stall.
 In mild weather conditions and with settings significantly above stall speed a VTOL can operate without the use of an airspeed sensor.
-The settings should also be applicable to non-VTOL fixed-wings but this is currently untested.
 
 This guide will outline the parameter settings required to bypass the airspeed sensor for VTOL planes.
+
+::: note
+Most settings described here should also be applicable to fixed-wing vehicles that are not VTOL, but this is currently untested.
+Transition turning and quad-chute are VTOL-specific.
+:::
 
 ## Preparation
 


### PR DESCRIPTION
As discussed in https://github.com/PX4/PX4-user_guide/pull/3000#issuecomment-1880781937  "Most of that page is as applicable to FW as it is to VTOL"

I think we need to leave it as VTOL until it gets tested. But what I've done is pulled out the fact that it should work into a note.
If this gets tested we'd rename/restructure it a bit.

FYI only @sfuhrer 