### PR TITLE
Airspeed config fixes

### DIFF
--- a/en/config_vtol/vtol_without_airspeed_sensor.md
+++ b/en/config_vtol/vtol_without_airspeed_sensor.md
@@ -7,7 +7,7 @@ Support for VTOLs without an airspeed sensor is considered experimental and shou
 The use of an airspeed sensor is recommended.
 :::
 
-Fixed-wing vehicles use airspeed sensors to determine the speed at which the airplane is moving through the air.
+Fixed-wing vehicles use [airspeed sensors](../sensor/airspeed.md) to determine the speed at which the airplane is moving through the air.
 Depending on wind this could vary from groundspeed.
 Every airplane has a minimum airspeed below which the airplane will stall.
 In mild weather conditions and with settings significantly above stall speed a VTOL can operate without the use of an airspeed sensor.

--- a/en/sensor/airspeed.md
+++ b/en/sensor/airspeed.md
@@ -53,8 +53,9 @@ If you have multiple airspeed sensors then you can select which sensor is _prefe
 
 The airspeed selector validates the indicated sensor _first_ and only falls back to other sensors if the indicated sensor fails airspeed checks ([ASPD_DO_CHECKS](../advanced_config/parameter_reference.md#ASPD_DO_CHECKS) is used to configure the checks).
 
-The selected sensor is then used to supply data to the estimator (EKF2).
+The selected sensor is then used to supply data to the estimator (EKF2) and the controlllers.
 The EKF fuses the airspeed data if it's above [EKF2_ARSP_THR](../advanced_config/parameter_reference.md#EKF2_ARSP_THR) and has a low innovation compared to groundspeed minus windspeed.
+The useage of the airspeed data in the controllers (fixed-wing rate, attitude and position controllers) can be disabled by setting [FW_USE_AIRSPD](../advanced_config/parameter_reference.md#FW_USE_AIRSPD) to False.
 
 ### Sensor-specific Configuration
 

--- a/en/sensor/airspeed.md
+++ b/en/sensor/airspeed.md
@@ -46,7 +46,6 @@ You should also check [ASPD_PRIMARY](../advanced_config/parameter_reference.md#A
 
 If you have multiple airspeed sensors then you can select which sensor is _preferred_ as the primary source using [ASPD_PRIMARY](../advanced_config/parameter_reference.md#ASPD_PRIMARY), where `1`, `2` and `3` reflect the order in which the airspeed sensors were started:
 
-- `-1`: Disabled (no airspeed information used).
 - `0`: Synthetic airspeed estimation (groundspeed minus windspeed)
 - `1`: First airspeed sensor started (default)
 - `2`: Second airspeed sensor started

--- a/en/sensor/airspeed.md
+++ b/en/sensor/airspeed.md
@@ -57,9 +57,7 @@ If you have multiple airspeed sensors then you can select which sensor is _prefe
 
 The airspeed selector validates the indicated sensor _first_ and only falls back to other sensors if the indicated sensor fails airspeed checks ([ASPD_DO_CHECKS](../advanced_config/parameter_reference.md#ASPD_DO_CHECKS) is used to configure the checks).
 
-The selected sensor is then used to supply data to the estimator (EKF2) and the controlllers.
-The EKF fuses the airspeed data if it's above [EKF2_ARSP_THR](../advanced_config/parameter_reference.md#EKF2_ARSP_THR) and has a low innovation compared to groundspeed minus windspeed.
-The useage of the airspeed data in the controllers (fixed-wing rate, attitude and position controllers) can be disabled by setting [FW_USE_AIRSPD](../advanced_config/parameter_reference.md#FW_USE_AIRSPD) to False.
+The selected sensor is then used to supply data to the estimator (EKF2) and the controllers.
 
 ### Sensor-specific Configuration
 

--- a/en/sensor/airspeed.md
+++ b/en/sensor/airspeed.md
@@ -2,7 +2,7 @@
 
 Airspeed sensors are _highly recommended_ for fixed-wing and VTOL frames.
 They are so important because the autopilot does not have other means to detect stall.
-For fixed-wing flight it is the airspeed that guarantees lift not ground speed!
+For fixed-wing flight it is the airspeed that guarantees lift — not ground speed!
 
 ![Digital airspeed sensor](../../assets/hardware/sensors/airspeed/digital_airspeed_sensor.jpg)
 
@@ -57,7 +57,7 @@ If you have multiple airspeed sensors then you can select which sensor is _prefe
 
 The airspeed selector validates the indicated sensor _first_ and only falls back to other sensors if the indicated sensor fails airspeed checks ([ASPD_DO_CHECKS](../advanced_config/parameter_reference.md#ASPD_DO_CHECKS) is used to configure the checks).
 
-The selected sensor is then used to supply data to the estimator (EKF2) and the controllers.
+The selected sensor is then used to [supply data to the estimator (EKF2)](../advanced_config/tuning_the_ecl_ekf.md#airspeed) and the controllers.
 
 ### Sensor-specific Configuration
 
@@ -72,6 +72,8 @@ The specific configuration for sensors that do not have a separate page is liste
 
 Airspeed sensors should be calibrated by following the instructions: [Basic Configuration > Airspeed](../config/airspeed.md).
 
-## Developer Information
+## See Also
 
+- [Using the ECL EKF > Airspeed](../advanced_config/tuning_the_ecl_ekf.md#airspeed)
 - [Airspeed drivers](https://github.com/PX4/PX4-Autopilot/tree/main/src/drivers/differential_pressure) (source code)
+- [VTOL Without an Airspeed Sensor](../config_vtol/vtol_without_airspeed_sensor.md)

--- a/en/sensor/airspeed.md
+++ b/en/sensor/airspeed.md
@@ -44,6 +44,10 @@ You should also check [ASPD_PRIMARY](../advanced_config/parameter_reference.md#A
 
 ### Multiple Airspeed Sensors
 
+:::warning Experimental
+Using multiple airspeed sensors is experimental.
+:::
+
 If you have multiple airspeed sensors then you can select which sensor is _preferred_ as the primary source using [ASPD_PRIMARY](../advanced_config/parameter_reference.md#ASPD_PRIMARY), where `1`, `2` and `3` reflect the order in which the airspeed sensors were started:
 
 - `0`: Synthetic airspeed estimation (groundspeed minus windspeed)


### PR DESCRIPTION
Further fixes/improvements after https://github.com/PX4/PX4-user_guide/pull/3000.

We need to further thing about how to split it up between this sensor/airspeed page and a configuration helper like https://docs.px4.io/main/en/config_vtol/vtol_without_airspeed_sensor.html.