### PR TITLE
Update ros2_offboard_control.md

### DIFF
--- a/en/ros/ros2_offboard_control.md
+++ b/en/ros/ros2_offboard_control.md
@@ -146,6 +146,8 @@ void OffboardControl::publish_offboard_control_mode()
 	msg.acceleration = false;
 	msg.attitude = false;
 	msg.body_rate = false;
+	msg.thrust_and_torque = false;
+	msg.direct_actuator = false;
 	msg.timestamp = this->get_clock()->now().nanoseconds() / 1000;
 	offboard_control_mode_publisher_->publish(msg);
 }


### PR DESCRIPTION
I made a little update in the function called publish_offboard_control_mode.  I added thrust_and_torque and direct_actuator variables of the OffboardControlMode message, in this way the message is aligned with its new version.