### PR TITLE
Fixes broken docs.qgroundcontrol links

### DIFF
--- a/en/advanced_config/ethernet_setup.md
+++ b/en/advanced_config/ethernet_setup.md
@@ -174,7 +174,7 @@ To connect QGroundControl to PX4 over Ethernet:
 
 1. [Set up the Ethernet Network](#setting-up-the-ethernet-network) so your ground station computer and PX4 run on the same network.
 1. Connect the ground station computer and PX4 using an Ethernet cable.
-1. Start QGroundControl and [define a comm link](https://docs.qgroundcontrol.com/master/en/SettingsView/SettingsView.html) (**Application Settings > Comm Links**) specifying the _server address_ and port as the IP address and port assigned in PX4, respectively.
+1. Start QGroundControl and [define a comm link](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/settings_view/settings_view.html) (**Application Settings > Comm Links**) specifying the _server address_ and port as the IP address and port assigned in PX4, respectively.
 
    Assuming that the values are set as described in the rest of this topic the setup will look like this:
 

--- a/en/advanced_config/imu_factory_calibration.md
+++ b/en/advanced_config/imu_factory_calibration.md
@@ -27,4 +27,4 @@ Subsequent user calibrations will then take effect as usual (factory calibration
 
 ## Further Information
 
-- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/SetupView/sensors_px4.html)
+- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/sensors_px4.html)

--- a/en/advanced_config/prearm_arm_disarm.md
+++ b/en/advanced_config/prearm_arm_disarm.md
@@ -107,7 +107,7 @@ Arming is prevented if:
 - The current mode requires an adequate global position estimate but the vehicle does not have GPS lock.
 - Many more ...
 
-The current failed checks can be viewed in QGroundControl (v4.2.0 and later): [Fly View > Arming and Preflight Checks](https://docs.qgroundcontrol.com/master/en/FlyView/FlyView.html#arm).
+The current failed checks can be viewed in QGroundControl (v4.2.0 and later): [Fly View > Arming and Preflight Checks](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/fly_view/fly_view.html#arm).
 
 Note that internally PX4 runs arming checks at 10Hz.
 A list of the failed checks is kept, and if the list changes PX4 emits the current list using the [Events interface](../concept/events_interface.md).

--- a/en/advanced_config/tuning_the_ecl_ekf.md
+++ b/en/advanced_config/tuning_the_ecl_ekf.md
@@ -201,7 +201,7 @@ The EKF2 module models the error as a body fixed ellipsoid that specifies the fr
 A good tuning is obtained as follows:
 
 1. Fly once in [Position mode](../flight_modes_mc/position.md) repeatedly forwards/backwards/left/right/up/down between rest and maximum speed (best results are obtained when this testing is conducted in still conditions).
-2. Extract the `.ulg` log file using, for example, [QGroundControl: Analyze > Log Download](https://docs.qgroundcontrol.com/master/en/analyze_view/log_download.html)
+2. Extract the `.ulg` log file using, for example, [QGroundControl: Analyze > Log Download](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/log_download.html)
 
    :::note
    The same log file can be used to tune the [multirotor wind estimator](#mc_wind_estimation_using_drag).
@@ -418,7 +418,7 @@ The amount of specific force observation noise is set by the [EKF2_DRAG_NOISE](.
 A good tuning is obtained as follows:
 
 1. Fly once in [Position mode](../flight_modes_mc/position.md) repeatedly forwards/backwards/left/right/up/down between rest and maximum speed (best results are obtained when this testing is conducted in still conditions).
-2. Extract the **.ulg** log file using, for example, [QGroundControl: Analyze > Log Download](https://docs.qgroundcontrol.com/master/en/analyze_view/log_download.html)
+2. Extract the **.ulg** log file using, for example, [QGroundControl: Analyze > Log Download](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/log_download.html)
    :::note
    The same **.ulg** log file can also be used to tune the [static pressure position error coefficients](#correction-for-static-pressure-position-error).
    :::

--- a/en/advanced_features/satcom_roadblock.md
+++ b/en/advanced_features/satcom_roadblock.md
@@ -187,7 +187,7 @@ To setup the ground station:
    ```
 
 1. Edit the **udp2rabbit.cfg** configuration file to reflect your settings.
-1. [Install _QGroundControl_](https://docs.qgroundcontrol.com/master/en/getting_started/download_and_install.html) (daily build).
+1. [Install _QGroundControl_](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/getting_started/download_and_install.html) (daily build).
 1. Add a UDP connection in QGC with the parameters:
 
    - Listening port: 10000

--- a/en/assembly/quick_start_pixhawk4.md
+++ b/en/assembly/quick_start_pixhawk4.md
@@ -115,7 +115,7 @@ A lower voltage of 5V is still acceptable, but discouraged.
 | 6(black) | GND     | GND   |
 
 :::note
-Using the Power Module that comes with the kit you will need to configure the _Number of Cells_ in the [Power Settings](https://docs.qgroundcontrol.com/master/en/SetupView/Power.html) but you won't need to calibrate the _voltage divider_.
+Using the Power Module that comes with the kit you will need to configure the _Number of Cells_ in the [Power Settings](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/power.html) but you won't need to calibrate the _voltage divider_.
 You will have to update the _voltage divider_ if you are using any other power module (e.g. the one from the Pixracer).
 :::
 

--- a/en/assembly/quick_start_pixhawk4_mini.md
+++ b/en/assembly/quick_start_pixhawk4_mini.md
@@ -87,7 +87,7 @@ Be careful with the voltage of servo you are going to use here.
 <!--In the future, when Pixhawk 4 kit is available, add wiring images/videos for different airframes.-->
 
 :::note
-Using the Power Module that comes with the kit you will need to configure the _Number of Cells_ in the [Power Settings](https://docs.qgroundcontrol.com/master/en/SetupView/Power.html) but you won't need to calibrate the _voltage divider_.
+Using the Power Module that comes with the kit you will need to configure the _Number of Cells_ in the [Power Settings](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/power.html) but you won't need to calibrate the _voltage divider_.
 You will have to update the _voltage divider_ if you are using any other power module (e.g. the one from the Pixracer).
 :::
 

--- a/en/companion_computer/pixhawk_rpi.md
+++ b/en/companion_computer/pixhawk_rpi.md
@@ -270,7 +270,7 @@ The configuration steps are:
    :::
 
 1. Check that the [uxrce_dds_client](../modules/modules_system.md#uxrce-dds-client) module is now running.
-   YOu can do this by running the following command in the QGroundControl [MAVLink Console](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_console.html):
+   YOu can do this by running the following command in the QGroundControl [MAVLink Console](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_console.html):
 
    ```sh
    uxrce_dds_client status

--- a/en/companion_computer/video_streaming.md
+++ b/en/companion_computer/video_streaming.md
@@ -32,7 +32,7 @@ To setup and use video steaming with QGC:
 
    For other platforms follow the instructions in [QGroundControl VideoReceiver README](https://github.com/mavlink/qgroundcontrol/blob/master/src/VideoReceiver/README.md).
 
-1. Enable video in _Fly View_: [QGroundControl > General Settings (Settings View) > Video](https://docs.qgroundcontrol.com/master/en/SettingsView/General.html#video)
+1. Enable video in _Fly View_: [QGroundControl > General Settings (Settings View) > Video](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/settings_view/general.html#video)
 1. If everything works, you should see the video stream displayed in the QGC Video Switcher (QGC Fly View bottom left corner).
    You can click on the video switcher to toggle the video full-screen, as shown in the screenshot below.
 

--- a/en/complete_vehicles/crazyflie2.md
+++ b/en/complete_vehicles/crazyflie2.md
@@ -98,7 +98,7 @@ After setting up the PX4 development environment, follow these steps to install 
    The yellow LED should start blinking indicating bootloader mode.
    Then the red LED should turn on indicating that the flashing process has started.
 1. Wait for completion.
-1. Done! Calibrate the sensors using [QGroundControl](https://docs.qgroundcontrol.com/master/en/SetupView/Sensors.html).
+1. Done! Calibrate the sensors using [QGroundControl](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/sensors.html).
 
 :::note
 If QGroundControl does not connect with the vehicle, ensure that in [nuttx-config](https://github.com/PX4/PX4-Autopilot/blob/main/boards/bitcraze/crazyflie/nuttx-config/nsh/defconfig) for crazyflie `# CONFIG_DEV_LOWCONSOLE is not set` is replaced by `CONFIG_DEV_LOWCONSOLE=y`.

--- a/en/complete_vehicles/crazyflie21.md
+++ b/en/complete_vehicles/crazyflie21.md
@@ -114,7 +114,7 @@ After setting up the PX4 development environment, follow these steps to install 
    The yellow LED should start blinking indicating bootloader mode.
    Then the red LED should turn on indicating that the flashing process has started.
 1. Wait for completion.
-1. Done! Calibrate the sensors using [QGroundControl](https://docs.qgroundcontrol.com/master/en/SetupView/Sensors.html).
+1. Done! Calibrate the sensors using [QGroundControl](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/sensors.html).
 
 ## Flashing Original Bitcraze Firmware
 

--- a/en/complete_vehicles/px4_vision_kit.md
+++ b/en/complete_vehicles/px4_vision_kit.md
@@ -118,7 +118,7 @@ The kit contains all the essential drone hardware except a battery and a radio c
 
 In addition, users will need ground station hardware/software:
 
-- Laptop or tablet running [QGroundControl](https://docs.qgroundcontrol.com/master/en/getting_started/download_and_install.html) (QGC).
+- Laptop or tablet running [QGroundControl](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/getting_started/download_and_install.html) (QGC).
 
 ## First-time Setup
 

--- a/en/computer_vision/visual_inertial_odometry.md
+++ b/en/computer_vision/visual_inertial_odometry.md
@@ -37,7 +37,7 @@ To setup ROS and PX4:
 - Verify the connection to the flight controller.
 
   :::tip
-  You can use the _QGroundControl_ [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_inspector.html) to verify that you're getting `ODOMETRY` or `VISION_POSITION_ESTIMATE` messages (or check for `HEARTBEAT` messages that have the component id 197 (`MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY`)).
+  You can use the _QGroundControl_ [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_inspector.html) to verify that you're getting `ODOMETRY` or `VISION_POSITION_ESTIMATE` messages (or check for `HEARTBEAT` messages that have the component id 197 (`MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY`)).
   :::
 
 - [Verify that VIO is set up correctly](#verify_estimate) before your first flight!
@@ -108,7 +108,7 @@ Perform the following checks to verify that VIO is working properly _before_ you
 
 - Set the PX4 parameter `MAV_ODOM_LP` to `1``.
   PX4 will then stream back the received external pose as MAVLink [ODOMETRY](https://mavlink.io/en/messages/common.html#ODOMETRY) messages.
-  You can check these MAVLink messages with the _QGroundControl_ [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_inspector.html)
+  You can check these MAVLink messages with the _QGroundControl_ [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_inspector.html)
 - Yaw the vehicle until the quaternion of the `ODOMETRY` message is very close to a unit quaternion (w=1, x=y=z=0).
   - At this point, the body frame is aligned with the reference frame of the external pose system.
   - If you do not manage to get a quaternion close to the unit quaternion without rolling or pitching your vehicle, your frame probably still has a pitch or roll offset.
@@ -148,7 +148,7 @@ If it is connecting properly common problems/solutions are:
 - **Problem:** I get toilet-bowling when VIO is enabled.
 
   - Make sure the orientation of the camera matches the transform in the launch file.
-    Use the _QGroundControl_ [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_inspector.html) to verify that the velocities in the `ODOMETRY` message coming from MAVROS are aligned to the FRD coordinate system.
+    Use the _QGroundControl_ [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_inspector.html) to verify that the velocities in the `ODOMETRY` message coming from MAVROS are aligned to the FRD coordinate system.
 
 - **Problem:** I want to use vision position to do loop closing, and also want to run GPS.
   - This is really difficult, because when they disagree it will confuse the EKF.

--- a/en/config/README.md
+++ b/en/config/README.md
@@ -67,7 +67,7 @@ If you need help with the configuration you can ask for help on the [QGroundCont
 
 ## See Also
 
-- [QGroundControl > Setup](https://docs.qgroundcontrol.com/master/en/SetupView/SetupView.html)
+- [QGroundControl > Setup](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/setup_view.html)
 - [Flight Controller Peripherals](../peripherals/README.md) - Setup specific sensors, optional sensors, actuators, and so on.
 - [Advanced Configuration](../advanced_config/README.md) - Factory/OEM calibration, configuring advanced features, less-common configuration.
 - Vehicle-Centric Config/Tuning:

--- a/en/config/accelerometer.md
+++ b/en/config/accelerometer.md
@@ -47,5 +47,5 @@ You can then proceed to the next sensor.
 
 ## Further Information
 
-- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/SetupView/sensors_px4.html#accelerometer)
+- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/sensors_px4.html#accelerometer)
 - [PX4 Setup Video - @1m46s](https://youtu.be/91VGmdSlbo4?t=1m46s) (Youtube)

--- a/en/config/airframe.md
+++ b/en/config/airframe.md
@@ -31,5 +31,5 @@ After mapping actuators to outputs you should perform [ESC Calibration](../advan
 
 ## Further Information
 
-- [QGroundControl User Guide > Airframe](https://docs.qgroundcontrol.com/master/en/SetupView/Airframe.html)
+- [QGroundControl User Guide > Airframe](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/airframe.html)
 - [PX4 Setup Video - @37s](https://youtu.be/91VGmdSlbo4?t=35s) (Youtube)

--- a/en/config/airspeed.md
+++ b/en/config/airspeed.md
@@ -39,4 +39,4 @@ To calibrate the airspeed sensor:
 
 ## Further Information
 
-- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/SetupView/sensors_px4.html#airspeed)
+- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/sensors_px4.html#airspeed)

--- a/en/config/battery.md
+++ b/en/config/battery.md
@@ -141,7 +141,7 @@ This setting corresponds to [parameter](../advanced_config/parameters.md): [BAT1
 
 If you have a vehicle that measures voltage through a power module and the ADC of the flight controller then you should check and calibrate the measurements once per board. To calibrate you'll need a multimeter.
 
-The easiest way to calibrate the divider is by using _QGroundControl_ and following the step-by-step guide on [Setup > Power Setup](https://docs.qgroundcontrol.com/master/en/SetupView/Power.html) (QGroundControl User Guide).
+The easiest way to calibrate the divider is by using _QGroundControl_ and following the step-by-step guide on [Setup > Power Setup](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/power.html) (QGroundControl User Guide).
 
 :::note
 This setting corresponds to parameters: [BAT1_V_DIV](../advanced_config/parameter_reference.md#BAT1_V_DIV) and [BAT2_V_DIV](../advanced_config/parameter_reference.md#BAT2_V_DIV).
@@ -157,7 +157,7 @@ This setting is not needed if you are using the basic configuration (without loa
 
 If you are using [Current-based Load Compensation](#current_based_load_compensation) or [Current Integration](#current_integration) the amps per volt divider must be calibrated.
 
-The easiest way to calibrate the dividers is by using _QGroundControl_ and following the step-by-step guide on [Setup > Power Setup](https://docs.qgroundcontrol.com/master/en/SetupView/Power.html) (QGroundControl User Guide).
+The easiest way to calibrate the dividers is by using _QGroundControl_ and following the step-by-step guide on [Setup > Power Setup](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/power.html) (QGroundControl User Guide).
 
 :::note
 This setting corresponds to parameter(s): [BAT1_A_PER_V](../advanced_config/parameter_reference.md#BAT1_A_PER_V) and [BAT2_A_PER_V](../advanced_config/parameter_reference.md#BAT2_A_PER_V).

--- a/en/config/compass.md
+++ b/en/config/compass.md
@@ -110,5 +110,5 @@ See [Logging](../dev_log/logging.md) for more information.
 - [Peripherals > GPS & Compass](../gps_compass/README.md)
 - [Basic Assembly](../assembly/README.md) (setup guides for each flight controller)
 - [Compass Power Compensation](../advanced_config/compass_power_compensation.md) (Advanced Configuration)
-- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/SetupView/sensors_px4.html#compass)
+- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/sensors_px4.html#compass)
 - [PX4 Setup Video - @2m38s](https://youtu.be/91VGmdSlbo4?t=2m38s) (Youtube)

--- a/en/config/flight_controller_orientation.md
+++ b/en/config/flight_controller_orientation.md
@@ -50,4 +50,4 @@ You can use [Level Horizon Calibration](../config/level_horizon_calibration.md) 
 ## Further Information
 
 - [Advanced Orientation Tuning](../advanced_config/advanced_flight_controller_orientation_leveling.md) (advanced users only).
-- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/SetupView/sensors_px4.html#flight_controller_orientation)
+- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/sensors_px4.html#flight_controller_orientation)

--- a/en/config/flight_mode.md
+++ b/en/config/flight_mode.md
@@ -59,7 +59,7 @@ All values are automatically saved as they are changed.
 ## RC Transmitter Setup
 
 This section contains a small number of possible setup configurations for taranis.
-QGroundControl _may_ have [setup information for other transmitters here](https://docs.qgroundcontrol.com/master/en/SetupView/FlightModes.html#transmitter-setup).
+QGroundControl _may_ have [setup information for other transmitters here](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/flight_modes.html#transmitter-setup).
 
 
 <a id="taranis_setup"></a>
@@ -108,6 +108,6 @@ The *QGroundControl* configuration is then [as described above](#flight-mode-sel
 ## Further Information
 
 * [Flight Modes Overview](../flight_modes/README.md)
-* [QGroundControl > Flight Modes](https://docs.qgroundcontrol.com/master/en/SetupView/FlightModes.html#px4-pro-flight-mode-setup)
+* [QGroundControl > Flight Modes](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/flight_modes.html#px4-pro-flight-mode-setup)
 * [PX4 Setup Video - @6m53s](https://youtu.be/91VGmdSlbo4?t=6m53s) (Youtube)
 * [Radio switch parameters](../advanced_config/parameter_reference.md#radio-switches) - Can be used to set mappings via parameters

--- a/en/config/gyroscope.md
+++ b/en/config/gyroscope.md
@@ -26,4 +26,4 @@ If you move the vehicle _QGroundControl_ will automatically restart the gyroscop
 
 ## Further Information
 
-- [QGroundControl User Guide > Gyroscope](https://docs.qgroundcontrol.com/master/en/SetupView/sensors_px4.html#gyroscope)
+- [QGroundControl User Guide > Gyroscope](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/sensors_px4.html#gyroscope)

--- a/en/config/joystick.md
+++ b/en/config/joystick.md
@@ -24,7 +24,7 @@ In summary:
 
 - Open _QGroundControl_
 - Set the parameter [COM_RC_IN_MODE=1](../advanced_config/parameter_reference.md#COM_RC_IN_MODE) - `Joystick`
-  - See [Parameters](https://docs.qgroundcontrol.com/master/en/SetupView/Parameters.html) for information about setting parameters
+  - See [Parameters](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/parameters.html) for information about setting parameters
   - Setting the parameter to `2` or `3` also enables Joystick under some circumstances.
 - Connect the joystick
 - Configure the connected joystick in: **Vehicle Setup > Joystick**.

--- a/en/config/level_horizon_calibration.md
+++ b/en/config/level_horizon_calibration.md
@@ -32,5 +32,5 @@ Check that the artificial horizon displayed in the flight view has the indicator
 ## Further Information
 
 - [Advanced Orientation Tuning](../advanced_config/advanced_flight_controller_orientation_leveling.md) (advanced users only).
-- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/SetupView/sensors_px4.html#level-horizon)
+- [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/sensors_px4.html#level-horizon)
 - [PX4 Setup Video "Gyroscope" - @1m14s](https://youtu.be/91VGmdSlbo4?t=1m14s) (Youtube)

--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -360,4 +360,4 @@ The [relevant parameters](../advanced_config/parameters.md) are shown below:
 
 ## Further Information
 
-- [QGroundControl User Guide > Safety Setup](https://docs.qgroundcontrol.com/master/en/SetupView/Safety.html)
+- [QGroundControl User Guide > Safety Setup](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/safety.html)

--- a/en/config_mc/README.md
+++ b/en/config_mc/README.md
@@ -153,7 +153,7 @@ Yes but it must be physically feasible. E.g. if you make a quadrotor where all m
 
 ## See Also
 
-- [QGroundControl > Setup](https://docs.qgroundcontrol.com/master/en/SetupView/SetupView.html)
+- [QGroundControl > Setup](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/setup_view.html)
 - [Flight Controller Peripherals](../peripherals/README.md) - Setup specific sensors, optional sensors, actuators, and so on.
 - [Advanced Configuration](../advanced_config/README.md) - Factory/OEM calibration, configuring advanced features, less-common configuration.
 - Vehicle-Centric Config/Tuning:

--- a/en/debug/mavlink_shell.md
+++ b/en/debug/mavlink_shell.md
@@ -16,7 +16,7 @@ If the system does not start properly you should instead use the [System Console
 
 ### QGroundControl MAVLink Console
 
-The easiest way to access shell is to use the [QGroundControl MAVLink Console](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_console.html) (see **Analyze View > Mavlink Console**).
+The easiest way to access shell is to use the [QGroundControl MAVLink Console](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_console.html) (see **Analyze View > Mavlink Console**).
 
 ### mavlink_shell.py
 

--- a/en/dev_airframes/adding_a_new_frame.md
+++ b/en/dev_airframes/adding_a_new_frame.md
@@ -266,7 +266,7 @@ param set-default PWM_MAIN_DIS4 1500
 
 ## Adding a New Airframe Group
 
-Airframe "groups" are used to group similar airframes for selection in [QGroundControl](https://docs.qgroundcontrol.com/master/en/SetupView/Airframe.html) and in the [Airframe Reference](../airframes/airframe_reference.md).
+Airframe "groups" are used to group similar airframes for selection in [QGroundControl](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/airframe.html) and in the [Airframe Reference](../airframes/airframe_reference.md).
 Every group has a name, and an associated svg image which shows the common geometry, number of motors, and direction of motor rotation for the grouped airframes.
 
 The airframe metadata files used by _QGroundControl_ and the documentation source code are generated from the airframe description, via a script, using the build command: `make airframe_metadata`

--- a/en/dev_setup/building_px4.md
+++ b/en/dev_setup/building_px4.md
@@ -43,7 +43,7 @@ This will bring up the PX4 console below:
 
 :::note
 You may need to start _QGroundControl_ before proceeding, as the default PX4 configuration requires a ground control connection before takeoff.
-This can be [downloaded from here](https://docs.qgroundcontrol.com/master/en/getting_started/download_and_install.html).
+This can be [downloaded from here](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/getting_started/download_and_install.html).
 :::
 
 The drone can be flown by typing:

--- a/en/dev_setup/dev_env_windows_wsl.md
+++ b/en/dev_setup/dev_env_windows_wsl.md
@@ -228,7 +228,7 @@ The easiest way to set up and use QGroundControl is to download the Linux versio
 
 You can do this using from within the WSL shell.
 
-1. In a web browser, navigate to the QGC [Ubuntu download section](https://docs.qgroundcontrol.com/master/en/getting_started/download_and_install.html#ubuntu)
+1. In a web browser, navigate to the QGC [Ubuntu download section](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/getting_started/download_and_install.html#ubuntu)
 1. Right-click on the **QGroundControl.AppImage** link, and select "Copy link address".
    This will be something like _https://d176td9ibe4jno.cloudfront.net/builds/master/QGroundControl.AppImage_
 1. [Open a WSL shell](#opening-a-wsl-shell) and enter the following commands to download the appimage and make it executable (replace the AppImage URL where indicated):
@@ -251,7 +251,7 @@ You will not be able to use it to install PX4 firmware because WSL does not allo
 
 ### QGroundcontrol on Windows
 
-Install [QGroundControl on Windows](https://docs.qgroundcontrol.com/master/en/getting_started/download_and_install.html#windows) if you want to be able to update hardware with firmware created within PX4.
+Install [QGroundControl on Windows](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/getting_started/download_and_install.html#windows) if you want to be able to update hardware with firmware created within PX4.
 
 These steps describe how you can connect to the simulation running in the WSL:
 

--- a/en/dronecan/pomegranate_systems_pm.md
+++ b/en/dronecan/pomegranate_systems_pm.md
@@ -44,7 +44,7 @@ Source code and build instructions can be found on [the bitbucket](https://bitbu
 
 1. Enable DroneCAN by setting the [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE) parameter to `2` (Sensors Automatic Config) or `3`.
 1. Enable DroneCAN battery monitoring by setting [UAVCAN_SUB_BAT](../advanced_config/parameter_reference.md#UAVCAN_SUB_BAT) to `1` or `2` ( depending on your battery).
-1. Set the following module parameters using the [MAVLink console](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_console.html):
+1. Set the following module parameters using the [MAVLink console](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_console.html):
    - Battery capacity in mAh: `battery_capacity_mAh`
    - Battery voltage when _full_: `battery_full_V`,
    - Battery voltage when _empty_: `battery_empty_V`

--- a/en/flight_modes_fw/mission.md
+++ b/en/flight_modes_fw/mission.md
@@ -16,7 +16,7 @@ The mission is typically created and uploaded with a Ground Control Station (GCS
 
 ## Description
 
-Missions are usually created in a ground control station (e.g. [QGroundControl](https://docs.qgroundcontrol.com/master/en/PlanView/PlanView.html)) and uploaded prior to launch.
+Missions are usually created in a ground control station (e.g. [QGroundControl](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/plan_view/plan_view.html)) and uploaded prior to launch.
 They may also be created by a developer API, and/or uploaded in flight.
 
 [Mission commands](#mission-commands) are handled in a way that is appropriate for each fixed-wing flight characteristics (for example loiter is implemented as flying in a circle).
@@ -49,7 +49,7 @@ At high level all vehicle types behave in the same way when MISSION mode is enga
 1. The mission will only reset when the vehicle is disarmed or when a new mission is uploaded.
 
    :::tip
-   To automatically disarm the vehicle after it lands, in _QGroundControl_ go to [Vehicle Setup > Safety](https://docs.qgroundcontrol.com/master/en/SetupView/Safety.html), navigate to _Land Mode Settings_ and check the box labeled _Disarm after_.
+   To automatically disarm the vehicle after it lands, in _QGroundControl_ go to [Vehicle Setup > Safety](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/safety.html), navigate to _Land Mode Settings_ and check the box labeled _Disarm after_.
    Enter the time to wait after landing before disarming the vehicle.
    :::
 
@@ -72,7 +72,7 @@ We recommend you centre the control sticks before switching to any other mode.
 For more information about mission planning, see:
 
 - [Mission Planning](../flying/missions.md)
-- [Plan View](https://docs.qgroundcontrol.com/master/en/PlanView/PlanView.html) (_QGroundControl_ User Guide)
+- [Plan View](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/plan_view/plan_view.html) (_QGroundControl_ User Guide)
 
 ## Mission Feasibility Checks
 
@@ -94,8 +94,8 @@ _QGroundControl_ provides additional GCS-level mission handling support (in addi
 
 For more information see:
 
-- [Remove mission after vehicle lands](https://docs.qgroundcontrol.com/master/en/releases/stable_v3.2_long.html#remove-mission-after-vehicle-lands)
-- [Resume mission after Return mode](https://docs.qgroundcontrol.com/master/en/releases/stable_v3.2_long.html#resume-mission)
+- [Remove mission after vehicle lands](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/releases/stable_v3.2_long.html#remove-mission-after-vehicle-lands)
+- [Resume mission after Return mode](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/releases/stable_v3.2_long.html#resume-mission)
 
 ## Mission Parameters
 
@@ -230,7 +230,7 @@ For more infomormation about takeoff behaviour and configuration see [Takeoff mo
 ## Mission Landing
 
 Fixed-wing mission landing is the recommended way to land a plane autonomously.
-This can be planned in _QGroundControl_ using [fixed-wing landing pattern](https://docs.qgroundcontrol.com/master/en/PlanView/pattern_fixed_wing_landing.html).
+This can be planned in _QGroundControl_ using [fixed-wing landing pattern](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/plan_view/pattern_fixed_wing_landing.html).
 
 If possible, always plan the landing such that it does the approach into the wind.
 

--- a/en/flight_modes_mc/mission.md
+++ b/en/flight_modes_mc/mission.md
@@ -18,7 +18,7 @@ The mission is typically created and uploaded with a Ground Control Station (GCS
 
 ## Description
 
-Missions are usually created in a ground control station (e.g. [QGroundControl](https://docs.qgroundcontrol.com/master/en/PlanView/PlanView.html)) and uploaded prior to launch.
+Missions are usually created in a ground control station (e.g. [QGroundControl](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/plan_view/plan_view.html)) and uploaded prior to launch.
 They may also be created by a developer API, and/or uploaded in flight.
 
 Individual [mission commands](#mission-commands) are handled in a way that is appropriate to multicopter flight characteristics (for example loiter is implemented as _hover_ ).
@@ -52,7 +52,7 @@ At high level all vehicle types behave in the same way when MISSION mode is enga
 1. The mission will only reset when the vehicle is disarmed or when a new mission is uploaded.
 
    :::tip
-   To automatically disarm the vehicle after it lands, in _QGroundControl_ go to [Vehicle Setup > Safety](https://docs.qgroundcontrol.com/master/en/SetupView/Safety.html), navigate to _Land Mode Settings_ and check the box labeled _Disarm after_.
+   To automatically disarm the vehicle after it lands, in _QGroundControl_ go to [Vehicle Setup > Safety](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/safety.html), navigate to _Land Mode Settings_ and check the box labeled _Disarm after_.
    Enter the time to wait after landing before disarming the vehicle.
    :::
 
@@ -75,7 +75,7 @@ We recommend you centre the control sticks before switching to any other mode.
 For more information about mission planning, see:
 
 - [Mission Planning](../flying/missions.md)
-- [Plan View](https://docs.qgroundcontrol.com/master/en/PlanView/PlanView.html) (_QGroundControl_ User Guide)
+- [Plan View](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/plan_view/plan_view.html) (_QGroundControl_ User Guide)
 
 ## Mission Feasibility Checks
 
@@ -93,8 +93,8 @@ _QGroundControl_ provides additional GCS-level mission handling support (in addi
 
 For more information see:
 
-- [Remove mission after vehicle lands](https://docs.qgroundcontrol.com/master/en/releases/stable_v3.2_long.html#remove-mission-after-vehicle-lands)
-- [Resume mission after Return mode](https://docs.qgroundcontrol.com/master/en/releases/stable_v3.2_long.html#resume-mission)
+- [Remove mission after vehicle lands](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/releases/stable_v3.2_long.html#remove-mission-after-vehicle-lands)
+- [Resume mission after Return mode](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/releases/stable_v3.2_long.html#resume-mission)
 
 ## Mission Parameters
 

--- a/en/flight_modes_mc/orbit.md
+++ b/en/flight_modes_mc/orbit.md
@@ -27,7 +27,7 @@ The _Orbit_ guided flight mode allows you to command a multicopter (or VTOL in m
 _QGroundControl_ (or other compatible GCS or MAVLink API) is _required_ to enable the mode, and to set the center position, initial radius and altitude of the orbit.
 Once enabled the vehicle will fly as fast as possible to the closest point on the commanded circle trajectory and do a slow (1m/s) clockwise orbit on the planned circle, facing the center.
 
-Instructions for how to start an orbit can be found here: [FlyView > Orbit Location](https://docs.qgroundcontrol.com/master/en/FlyView/FlyView.html#orbit) (_QGroundControl_ guide).
+Instructions for how to start an orbit can be found here: [FlyView > Orbit Location](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/fly_view/fly_view.html#orbit) (_QGroundControl_ guide).
 
 :::note
 The use of an RC control is _optional_.

--- a/en/flying/geofence.md
+++ b/en/flying/geofence.md
@@ -29,7 +29,7 @@ The Geofence is planned in _QGroundControl_ alongside the mission and rally poin
 
 ![Geofence Plan](../../assets/qgc/plan_geofence/geofence_overview.jpg)
 
-Geofence planning is fully documented in [Plan View > GeoFence](https://docs.qgroundcontrol.com/master/en/PlanView/PlanGeoFence.html) (QGroundControl User Guide).
+Geofence planning is fully documented in [Plan View > GeoFence](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/plan_view/plan_geofence.html) (QGroundControl User Guide).
 
 In summary:
 

--- a/en/flying/missions.md
+++ b/en/flying/missions.md
@@ -13,7 +13,7 @@ Manually planning missions is straightforward:
 You can also use the *Pattern* tool to automate creation of survey grids.
 
 :::tip
-For more information see the [QGroundControl User Guide](https://docs.qgroundcontrol.com/master/en/PlanView/PlanView.html).
+For more information see the [QGroundControl User Guide](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/plan_view/plan_view.html).
 :::
 
 ![planning-mission](../../assets/flying/planning_mission.jpg)

--- a/en/flying/plan_safety_points.md
+++ b/en/flying/plan_safety_points.md
@@ -19,7 +19,7 @@ At high level:
 1. Select the **Upload Required** button to upload the rally points (along with any [mission](../flying/missions.md) and [geofence](../flying/geofence.md)) to the vehicle.
 
 :::tip
-More complete documentation can be found in the *QGroundControl User Guide*: [Plan View - Rally Points](https://docs.qgroundcontrol.com/master/en/PlanView/PlanRallyPoints.html).
+More complete documentation can be found in the *QGroundControl User Guide*: [Plan View - Rally Points](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/plan_view/plan_rally_points.html).
 :::
 
 ## Using Safety Points

--- a/en/frames_plane/reptile_dragon_2.md
+++ b/en/frames_plane/reptile_dragon_2.md
@@ -364,7 +364,7 @@ make ark_fmu-v6x_default upload
 ### Parameter Config
 
 This param file contains the custom PX4 parameter configuration for this build, including radio setup, tuning and sensor config.
-Load the file via QGC using the instructions at [Parameters> Tools](https://docs.qgroundcontrol.com/master/en/SetupView/Parameters.html#tools) (QGC User Guide).
+Load the file via QGC using the instructions at [Parameters> Tools](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/parameters.html#tools) (QGC User Guide).
 
 - [Snapshot of PX4 airframe params](https://github.com/PX4/PX4-user_guide/raw/main/assets/airframes/fw/reptile_dragon_2/reptile_dragon_2_params.params)
 

--- a/en/frames_plane/turbo_timber_evolution.md
+++ b/en/frames_plane/turbo_timber_evolution.md
@@ -227,4 +227,4 @@ I use full flaps on landing to slow the otherwise slippery airframe.
 [Snapshot of PX4 airframe params](https://github.com/PX4/PX4-user_guide/raw/main/assets/airframes/fw/turbo_timber_evolution/tteparams.params)
 
 This param file contains the custom PX4 parameter config for this build, including radio setup, tuning and sensor config.
-The param file can be loaded via QGC using the instructions at [Parameters> Tools ](https://docs.qgroundcontrol.com/master/en/SetupView/Parameters.html#tools) (QGC User Guide).
+The param file can be loaded via QGC using the instructions at [Parameters> Tools ](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/parameters.html#tools) (QGC User Guide).

--- a/en/getting_started/flight_reporting.md
+++ b/en/getting_started/flight_reporting.md
@@ -9,7 +9,7 @@ Keeping flight logs is a legal requirement in some jurisdictions.
 
 ## Downloading Logs from the Flight Controller
 
-Logs can be downloaded using [QGroundControl](http://qgroundcontrol.com/): **[Analyze View > Log Download](https://docs.qgroundcontrol.com/master/en/analyze_view/log_download.html)**.
+Logs can be downloaded using [QGroundControl](http://qgroundcontrol.com/): **[Analyze View > Log Download](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/log_download.html)**.
 
 ![Flight Log Download](../../assets/qgc/analyze/log_download.jpg)
 
@@ -28,7 +28,7 @@ For more information see: [Flight Analysis](../dev_log/flight_log_analysis.md).
   
 :::tip
 If you have a constant high-rate MAVLink connection to the vehicle (not just a telemetry link) then you can use *QGroundControl* to automatically upload logs directly to *Flight Review*.
-For more information see [Settings > MAVLink Settings > MAVLink 2 Logging (PX4 only)](https://docs.qgroundcontrol.com/master/en/SettingsView/MAVLink.html#logging).
+For more information see [Settings > MAVLink Settings > MAVLink 2 Logging (PX4 only)](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/settings_view/mavlink.html#logging).
 :::
 
 ## Sharing the Log Files for Review by PX4 Developers

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -228,7 +228,7 @@ Prearmed and disarmed should both safe, and a particular vehicle may support eit
 
 :::tip
 Sometimes a vehicle will not arm for reasons that are not obvious.
-QGC v4.2.0 (Daily build at time of writing) and later provide an arming check report in [Fly View > Arming and Preflight Checks](https://docs.qgroundcontrol.com/master/en/FlyView/FlyView.html#arm).
+QGC v4.2.0 (Daily build at time of writing) and later provide an arming check report in [Fly View > Arming and Preflight Checks](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/fly_view/fly_view.html#arm).
 From PX4 v1.14 this provides comprehensive information about arming problems along with possible solutions.
 :::
 

--- a/en/gps_compass/rtk_gps.md
+++ b/en/gps_compass/rtk_gps.md
@@ -130,7 +130,7 @@ The following settings may need to be changed (using *QGroundControl*).
 
 #### RTK GPS settings
 
-The RTK GPS settings are specified in the *QGroundControl* [General Settings](https://docs.qgroundcontrol.com/master/en/SettingsView/General.html#rtk_gps) (**SettingsView > General Settings > RTK GPS**).
+The RTK GPS settings are specified in the *QGroundControl* [General Settings](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/settings_view/general.html#rtk_gps) (**SettingsView > General Settings > RTK GPS**).
 
 ![RTK GPS Setup](../../assets/qgc/setup/rtk/settings_view_general_rtk_gps.jpg)
 
@@ -147,8 +147,8 @@ The MAVLink2 protocol must be used because it makes more efficient use of lower-
 This should be enabled by default on recent builds.
 
 To ensure MAVLink2 is used:
-* Update the telemetry module firmware to the latest version (see [QGroundControl > Setup > Firmware](https://docs.qgroundcontrol.com/master/en/SetupView/Firmware.html)).
-* Set [MAV_PROTO_VER](../advanced_config/parameter_reference.md#MAV_PROTO_VER) to 2 (see [QGroundControl Setup > Parameters](https://docs.qgroundcontrol.com/master/en/SetupView/Parameters.html))
+* Update the telemetry module firmware to the latest version (see [QGroundControl > Setup > Firmware](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/firmware.html)).
+* Set [MAV_PROTO_VER](../advanced_config/parameter_reference.md#MAV_PROTO_VER) to 2 (see [QGroundControl Setup > Parameters](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/parameters.html))
 
 
 #### Tuning

--- a/en/modules/hello_sky.md
+++ b/en/modules/hello_sky.md
@@ -534,7 +534,7 @@ And finally run your app:
 px4_simple_app
 ```
 
-If you start _QGroundControl_, you can check the sensor values in the real time plot ([Analyze > MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_inspector.html)).
+If you start _QGroundControl_, you can check the sensor values in the real time plot ([Analyze > MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_inspector.html)).
 
 ## Wrap-Up
 

--- a/en/payloads/README.md
+++ b/en/payloads/README.md
@@ -74,7 +74,7 @@ In this case the sprayer must be controlled as a [generic actuator](#generic-act
 
 - The [Generic Actuator Control with MAVLink](#generic-actuator-control-with-mavlink) section explains how you can connect flight controller outputs to your sprayer so that they can be controlled using MAVLink.
   Most sprayers provide controls to activate/deactivate a pump; some also allow control over the rate of flow or the spray field (i.e. by controlling the nozzle shape, or using a spinner to distribute the payload).
-- You can define the area to spray using a [Survey pattern](https://docs.qgroundcontrol.com/master/en/PlanView/pattern_survey.html), or you can define the grid to fly using waypoints.
+- You can define the area to spray using a [Survey pattern](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/plan_view/pattern_survey.html), or you can define the grid to fly using waypoints.
   In either case, it is important to ensure that the vehicle flight path and altitude provide adequate coverage for your particular spray being used.
 - You should add a ["Set actuator" mission item](#generic-actuator-control-in-missions) to your mission before and after the survey pattern in order to enable and disable the sprayer.
 

--- a/en/peripherals/adsb_flarm.md
+++ b/en/peripherals/adsb_flarm.md
@@ -120,7 +120,7 @@ To enable this feature:
 
 1. Uncomment the code in `AdsbConflict::run_fake_traffic()`([AdsbConflict.cpp](https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/adsb/AdsbConflict.cpp#L342C1-L342C1)).
 1. Rebuild and run PX4.
-1. Execute the [`navigator fake_traffic` command](../modules/modules_controller.md#navigator) in the [QGroundControl MAVLink Shell](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_console.html) (or some other [PX4 Console or MAVLink shell](../debug/consoles.md), such as the PX4 simulator terminal).
+1. Execute the [`navigator fake_traffic` command](../modules/modules_controller.md#navigator) in the [QGroundControl MAVLink Shell](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_console.html) (or some other [PX4 Console or MAVLink shell](../debug/consoles.md), such as the PX4 simulator terminal).
 
 The code in `run_fake_traffic()` is then executed.
 You should see ADS-B warnings in the Console/MAVLink shell, and QGC should also show an ADS-B traffic popup.

--- a/en/peripherals/camera.md
+++ b/en/peripherals/camera.md
@@ -18,7 +18,7 @@ This allows more precise mapping of images to GPS position for geotagging, or th
 
 ## Trigger Configuration
 
-Camera triggering is usually configured from the _QGroundControl_ [Vehicle Setup > Camera](https://docs.qgroundcontrol.com/master/en/SetupView/Camera.html#px4-camera-setup) section.
+Camera triggering is usually configured from the _QGroundControl_ [Vehicle Setup > Camera](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/camera.html#px4-camera-setup) section.
 
 ![Trigger pins](../../assets/camera/trigger_pins.png)
 

--- a/en/releases/1.14.md
+++ b/en/releases/1.14.md
@@ -27,7 +27,7 @@ The new actuator configuration UI is available on QGroundControl 4.2.0 or newer.
 ### Improved Preflight Failure Check Reporting (QGC Arming Checks UI)
 
 PX4 v1.14 adds much improved preflight failure _reporting_ through the [events interface](../concept/events_interface.md).
-If the vehicle won't arm, you can more easily find out why in the [QGC Arming Checks UI](https://docs.qgroundcontrol.com/master/en/FlyView/FlyView.html#arm).
+If the vehicle won't arm, you can more easily find out why in the [QGC Arming Checks UI](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/fly_view/fly_view.html#arm).
 No more wondering if it's a problem with the safety switch, a poor calibration, or something in the internals of the estimator!
 
 :::note

--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -304,7 +304,7 @@ Be sure to perform the following checks before your first flight:
 
 * Set the PX4 parameter `MAV_ODOM_LP` to 1.
   PX4 will then stream back the received external pose as MAVLink [ODOMETRY](https://mavlink.io/en/messages/common.html#ODOMETRY) messages.
-* You can check these MAVLink messages with the *QGroundControl* [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_inspector.html)
+* You can check these MAVLink messages with the *QGroundControl* [MAVLink Inspector](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_inspector.html)
   In order to do this, yaw the vehicle until the quaternion of the `ODOMETRY` message is very close to a unit quaternion. (w=1, x=y=z=0)
 * At this point the body frame is aligned with the reference frame of the external pose system.
   If you do not manage to get a quaternion close to the unit quaternion without rolling or pitching your vehicle, your frame probably still have a pitch or roll offset.

--- a/en/sensor/thunderfly_tachometer.md
+++ b/en/sensor/thunderfly_tachometer.md
@@ -47,11 +47,11 @@ Both transmissive and reflective sensor types may be used for pulse generation.
 ### Starting driver
 
 The driver is not started automatically (in any airframe).
-You will need to start it manually, either using the [QGroundControl MAVLink Console](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_console.html) or by adding the driver to the [startup script](../concept/system_startup.md#customizing-the-system-startup) on an SD card.
+You will need to start it manually, either using the [QGroundControl MAVLink Console](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_console.html) or by adding the driver to the [startup script](../concept/system_startup.md#customizing-the-system-startup) on an SD card.
 
 #### Start driver from console
 
-Start the driver from the [console](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_console.html) using the command:
+Start the driver from the [console](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_console.html) using the command:
 
 ```sh
 pcf8583 start -X -b <bus number>
@@ -81,7 +81,7 @@ You can verify the counter is working using several methods
 
 #### PX4 (NuttX) MAVLink Console
 
-The [QGroundControl MAVLink Console](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_console.html) can also be used to check that the driver is running and the UORB topics it is outputting.
+The [QGroundControl MAVLink Console](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_console.html) can also be used to check that the driver is running and the UORB topics it is outputting.
 
 To check the status of the TFRPM01 driver run the command:
 
@@ -102,7 +102,7 @@ For periodic display, you can add `-n 50` parameter after the command, which pri
 
 #### QGroundControl MAVLink Inspector
 
-The QGroundControl [Mavlink Inspector](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_inspector.html) can be used to observe MAVLink messages from PX4, including [RAW_RPM](https://mavlink.io/en/messages/common.html#RAW_RPM) emitted by the driver:
+The QGroundControl [Mavlink Inspector](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_inspector.html) can be used to observe MAVLink messages from PX4, including [RAW_RPM](https://mavlink.io/en/messages/common.html#RAW_RPM) emitted by the driver:
 
 1. Start the inspector from the QGC menu: **Analyze tools > Mavlink Inspector**
 1. Check that `RAW_RPM` is present in the list of messages (if it is missing, check that the driver is running).

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -253,8 +253,8 @@ If you don't have a joystick you can alternatively control the vehicle using QGr
 
 For setup information see the _QGroundControl User Guide_:
 
-- [Joystick Setup](https://docs.qgroundcontrol.com/master/en/SetupView/Joystick.html)
-- [Virtual Joystick](https://docs.qgroundcontrol.com/master/en/SettingsView/VirtualJoystick.html)
+- [Joystick Setup](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/joystick.html)
+- [Virtual Joystick](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/settings_view/virtual_joystick.html)
 
 <!-- FYI Airsim info on this setting up remote controls: https://github.com/Microsoft/AirSim/blob/master/docs/remote_controls.md -->
 

--- a/en/simulation/hitl.md
+++ b/en/simulation/hitl.md
@@ -92,7 +92,7 @@ In summary, HITL runs PX4 on the actual hardware using standard firmware, but SI
    - [NAV_RCL_ACT](../advanced_config/parameter_reference.md#NAV_RCL_ACT) to "Disabled". This ensures that no RC failsafe actions interfere when not running HITL with a radio control.
 
    :::tip
-   The _QGroundControl User Guide_ also has instructions on [Joystick](https://docs.qgroundcontrol.com/master/en/SetupView/Joystick.html) and [Virtual Joystick](https://docs.qgroundcontrol.com/master/en/SettingsView/VirtualJoystick.html) setup.
+   The _QGroundControl User Guide_ also has instructions on [Joystick](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/joystick.html) and [Virtual Joystick](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/settings_view/virtual_joystick.html) setup.
    :::
 
 Once configuration is complete, **close** _QGroundControl_ and disconnect the flight controller hardware from the computer.
@@ -162,4 +162,4 @@ Make sure _QGroundControl_ is not running!
 
 ## Fly an Autonomous Mission in HITL
 
-You should be able to use _QGroundControl_ to [run missions](https://docs.qgroundcontrol.com/master/en/FlyView/FlyView.html#missions) and otherwise control the vehicle.
+You should be able to use _QGroundControl_ to [run missions](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/fly_view/fly_view.html#missions) and otherwise control the vehicle.

--- a/en/smart_batteries/rotoye_batmon.md
+++ b/en/smart_batteries/rotoye_batmon.md
@@ -51,7 +51,7 @@ In *QGroundControl*:
    - `BATx_SOURCE` to `External`,
    - `SENS_EN_BAT` to `true`, 
    - `BAT_SMBUS_MODEL` to `3:Rotoye`
-1. Open the [MAVLink Console](https://docs.qgroundcontrol.com/master/en/analyze_view/mavlink_console.html)
+1. Open the [MAVLink Console](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/analyze_view/mavlink_console.html)
 1. Start the [batt_smbus driver](../modules/modules_driver.md) in the console.
    For example, to run two BatMons on the same bus:
    ```sh 

--- a/en/telemetry/esp8266_wifi_module.md
+++ b/en/telemetry/esp8266_wifi_module.md
@@ -87,7 +87,7 @@ If you're using a module with any other WiFi name you will need to manually set 
 _QGroundControl_ will automatically connect to the vehicle when the ground station computer is attached to the "Pixracer" WiFi access point.
 For any other access point name you will need to manually create a custom comm link:
 
-1. Go to [Application Settings > Comm Links](https://docs.qgroundcontrol.com/master/en/SettingsView/SettingsView.html)
+1. Go to [Application Settings > Comm Links](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/settings_view/settings_view.html)
 2. Add new connection with appropriate settings.
 3. Select the new connection, and click **Connect**.
 4. The vehicle should now connect
@@ -99,7 +99,7 @@ You should now see HUD movement on your QGC computer via wireless link and be ab
 ![QGC Summary showing Wifi Bridge](../../assets/qgc/summary/wifi_bridge.png)
 
 :::tip
-If you have any problem connecting, see [QGC Usage Problems](https://docs.qgroundcontrol.com/master/en/troubleshooting/qgc_usage.html).
+If you have any problem connecting, see [QGC Usage Problems](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/troubleshooting/qgc_usage.html).
 :::
 
 ## ESP8266 Flashing/Firmware (Advanced)

--- a/en/telemetry/microhard_serial.md
+++ b/en/telemetry/microhard_serial.md
@@ -45,7 +45,7 @@ You can configure PX4 to use any other free serial port a different baud rate, b
 QGroundControl autodetects a serial telemetry connection with the baud rate 57600.
 
 For any other rate you will need to add a serial comms link that sets the rate that was used.
-See [Application Settings > Comms Links](https://docs.qgroundcontrol.com/master/en/SettingsView/SettingsView.html).
+See [Application Settings > Comms Links](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/settings_view/settings_view.html).
 
 ### Radio Configuration
 

--- a/en/telemetry/sik_radio.md
+++ b/en/telemetry/sik_radio.md
@@ -29,7 +29,7 @@ The vehicle-based radio is connected to the flight-controller's `TELEM1` port, a
 Hardware sourced from most [vendors](#vendors) should come pre-configured with the latest firmware.
 You may need to update older hardware with new firmware, for example to gain support for MAVLink 2.
 
-You can update the radio firmware using _QGroundControl_: [QGroundControl User Guide > Loading Firmware](https://docs.qgroundcontrol.com/master/en/SetupView/Firmware.html).
+You can update the radio firmware using _QGroundControl_: [QGroundControl User Guide > Loading Firmware](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/firmware.html).
 
 ## Advanced Setup/Configuration
 

--- a/en/test_and_ci/docker.md
+++ b/en/test_and_ci/docker.md
@@ -195,7 +195,7 @@ docker rm 45eeb98f1dd9
 
 When running a simulation instance e.g. SITL inside the docker container and controlling it via _QGroundControl_ from the host, the communication link has to be set up manually. The autoconnect feature of _QGroundControl_ does not work here.
 
-In _QGroundControl_, navigate to [Settings](https://docs.qgroundcontrol.com/master/en/SettingsView/SettingsView.html) and select Comm Links. Create a new link that uses the UDP protocol. The port depends on the used [configuration](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/rcS) e.g. port 14570 for the SITL config. The IP address is the one of your docker container, usually 172.17.0.1/16 when using the default network. The IP address of the docker container can be found with the following command (assuming the container name is `mycontainer`):
+In _QGroundControl_, navigate to [Settings](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/settings_view/settings_view.html) and select Comm Links. Create a new link that uses the UDP protocol. The port depends on the used [configuration](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/rcS) e.g. port 14570 for the SITL config. The IP address is the one of your docker container, usually 172.17.0.1/16 when using the default network. The IP address of the docker container can be found with the following command (assuming the container name is `mycontainer`):
 
 ```sh
 $ docker inspect -f '{ {range .NetworkSettings.Networks}}{ {.IPAddress}}{ {end}}' mycontainer


### PR DESCRIPTION
This fixes all links broken to qgc following rename - note that I attempted to fix these with redirects in QGC with only partial success. Either way this is  the "right" way to do it.

Fixes #3020