### PR TITLE
Offboard mode: split out into separate docs for MC/VTOL etc

### DIFF
--- a/en/flight_modes/offboard.md
+++ b/en/flight_modes/offboard.md
@@ -1,4 +1,4 @@
-# Offboard Mode
+# Offboard Mode (Generic/All Frames)
 
 [<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
 

--- a/en/flight_modes_fw/offboard.md
+++ b/en/flight_modes_fw/offboard.md
@@ -1,0 +1,4 @@
+<Redirect to="../flight_modes/offboard" />
+
+# Offboard Mode (Fixed Wing)
+

--- a/en/flight_modes_mc/offboard.md
+++ b/en/flight_modes_mc/offboard.md
@@ -1,0 +1,4 @@
+<Redirect to="../flight_modes/offboard" />
+
+# Offboard Mode (Multicopter)
+

--- a/en/flight_modes_vtol/offboard.md
+++ b/en/flight_modes_vtol/offboard.md
@@ -1,0 +1,4 @@
+<Redirect to="../flight_modes/offboard" />
+
+# Offboard Mode (VTOL)
+


### PR DESCRIPTION
For all the mode docs we've tried to make them more vehicle-frame specific, reducing the effort for readers to find relevant information.  I'm having trouble doing this for Offboard mode, as it can be used with ROS or MAVLink, and the support differs on each for what setpoint or setpoint combinations you can set. I.e. you could do this, but there would be A LOT of duplication.

For now this just creates topics for MC, FW, etc that redirect to the main topic. That allows there to be separate sidebar topics.