### PR TITLE
Flight mode reorg follow up (for FW)

### DIFF
--- a/en/flight_modes_fw/README.md
+++ b/en/flight_modes_fw/README.md
@@ -51,7 +51,7 @@ A high level description of the modes is provided below (select the mode-specifi
 [Position mode](../flight_modes_fw/position.md) is the easiest and safest manual mode.
 It is supported on vehicles that have a position estimate (e.g. GPS).
 
-The roll stick controls left/right horizontal movement and the pitch stick is used to ascend/descend.
+The vehicle performs a [coordinated turn](https://en.wikipedia.org/wiki/Coordinated_flight) if the roll sticks are non-zero, while the pitch stick controls the rate of ascent/descent.
 The throttle determines airspeed — at 50% throttle the aircraft will hold its current altitude with a preset cruise speed.
 
 When all sticks are released/centered (no roll, pitch, yaw, and ~50% throttle) the aircraft will return to straight, level flight, and keep its current altitude and flight path irrespective of wind.
@@ -72,7 +72,7 @@ _Altitude mode_ is similar to [Position mode](#position-mode) in that when the s
 The difference is that position mode holds the actual flight path steady against wind, while altitude just holds the heading.
 :::
 
-The roll stick controls left/right horizontal movement and the pitch stick controls the rate of ascent/descent.
+The vehicle performs a [coordinated turn](https://en.wikipedia.org/wiki/Coordinated_flight) if the roll sticks are non-zero, while the pitch stick controls the rate of ascent/descent.
 The throttle determines airspeed — at 50% throttle the aircraft will hold its current altitude with a preset cruise speed.
 
 When all sticks are released/centered (no roll, pitch, yaw, and ~50% throttle) the aircraft will return to straight, level flight (subject to wind) and keep its current altitude.
@@ -93,11 +93,11 @@ _Stabilized mode_ is similar to [Altitude mode](#altitude-mode) in that releasin
 It is much easier to fly than [Manual mode](#manual-mode) because you can't roll or flip it, and if needed it is easy to level the vehicle (by centering the control sticks).
 :::
 
-The vehicle climb/descends based on pitch input and performs a [coordinated turn](https://en.wikipedia.org/wiki/Coordinated_flight) if the roll/pitch sticks are non-zero.
+The vehicle climb/descends based on pitch and throttle input and performs a [coordinated turn](https://en.wikipedia.org/wiki/Coordinated_flight) if the roll sticks are non-zero.
 Roll and pitch are angle controlled (you can't roll upside down or loop).
 
 The vehicle will glide if the throttle is lowered to 0% (motor stops).
-In order to perform a turn the command must be held throughout the maneuver because if the roll is released the plane will stop turning and level itself (the same is true for pitch and yaw commands).
+In order to perform a turn the command must be held throughout the maneuver because if the roll is released the plane will stop turning and level itself (the same is true for pitch commands).
 
 The yaw stick can be used to increase/reduce the yaw rate of the vehicle in turns.
 If left at center the controller does the turn coordination by itself, meaning that it will apply the necessary yaw rate for the current roll angle to perform a smooth turn.

--- a/en/flight_modes_fw/README.md
+++ b/en/flight_modes_fw/README.md
@@ -46,9 +46,6 @@ A high level description of the modes is provided below (select the mode-specifi
 
 ## Easy Manual Modes
 
-In the easy manual modes, roll and pitch sticks set the vehicle angle, resulting in left-right and forward-back movement _in the horizontal plane_ (respectively).
-Not only does this make movement predictable, but because angles are controlled, the vehicle is impossible to flip.
-
 ### Position Mode
 
 [Position mode](../flight_modes_fw/position.md) is the easiest and safest manual mode.

--- a/en/flight_modes_fw/README.md
+++ b/en/flight_modes_fw/README.md
@@ -89,7 +89,7 @@ If left at center the controller does the turn coordination by itself, meaning t
 [Stabilized mode](../flight_modes_fw/stabilized.md) is a manual mode were centering the sticks levels the vehicle attitude (roll and pitch) and maintains the horizontal posture.
 
 :::note
-_Stabilized mode_ is similar to [Altitude mode](#altitude-mode) in that releasing the sticks levels the vehicle, but unlike altitude mode it does not maintain altitude or heading.
+_Stabilized mode_ is similar to [Altitude mode](#altitude-mode) in that releasing the sticks levels the vehicle, but unlike altitude mode it does not maintain altitude or airspeed.
 It is much easier to fly than [Manual mode](#manual-mode) because you can't roll or flip it, and if needed it is easy to level the vehicle (by centering the control sticks).
 :::
 

--- a/en/flight_modes_fw/README.md
+++ b/en/flight_modes_fw/README.md
@@ -13,8 +13,10 @@ Manual-Easy:
 
 - [Position](#position-mode) — Easiest and safest manual mode for vehicles that have a position fix/GPS.
   Releasing sticks levels the vehicle and locks it to a straight flight path, even against wind.
+  Airspeed is actively controlled if an airspeed sensor is installed.
 - [Altitude](#altitude-mode) — Easiest and safest _non-GPS_ manual mode.
   Releasing sticks levels the vehicle and maintain heading (unlike with position mode, wind can move the vehicle off the original track).
+  Airspeed is actively controlled if an airspeed sensor is installed.
 - [Stabilized](#stabilized-mode) — Releasing the sticks levels the vehicle and maintains the horizontal posture.
 
 Manual-Acrobatic
@@ -25,7 +27,7 @@ Manual-Acrobatic
   This sends stick input directly to control allocation for "fully" manual control.
 
 Autonomous:
-
+Airspeed is actively controlled if an airspeed sensor is installed in any autonomous flight mode.
 - [Hold](#hold-mode) — Vehicle circles around the GPS hold position at the current altitude.
 - [Return](#return-mode) — Vehicle flies a clear path to land at a safe location.
   By default the destination is a mission landing pattern.

--- a/en/flight_modes_fw/README.md
+++ b/en/flight_modes_fw/README.md
@@ -56,7 +56,10 @@ The throttle determines airspeed — at 50% throttle the aircraft will hold its 
 
 When all sticks are released/centered (no roll, pitch, yaw, and ~50% throttle) the aircraft will return to straight, level flight, and keep its current altitude and flight path irrespective of wind.
 This makes it easy to recover from any problems when flying.
-Roll, pitch and yaw are all angle-controlled (so it is impossible to roll over or loop the vehicle).
+Roll and pitch are angle-controlled (so it is impossible to roll over or loop the vehicle).
+
+The yaw stick can be used to increase/reduce the yaw rate of the vehicle in turns.
+If left at center the controller does the turn coordination by itself, meaning that it will apply the necessary yaw rate for the current roll angle to perform a smooth turn.
 
 ![FW Position Mode](../../assets/flight_modes/position_fw.png)
 
@@ -76,6 +79,9 @@ When all sticks are released/centered (no roll, pitch, yaw, and ~50% throttle) t
 This makes it easy to recover from any problems when flying.
 Roll, pitch and yaw are all angle-controlled (so it is impossible to roll over or loop the vehicle).
 
+The yaw stick can be used to increase/reduce the yaw rate of the vehicle in turns.
+If left at center the controller does the turn coordination by itself, meaning that it will apply the necessary yaw rate for the current roll angle to perform a smooth turn.
+
 ![FW Altitude Mode](../../assets/flight_modes/altitude_fw.png)
 
 ### Stabilized Mode
@@ -92,6 +98,9 @@ Roll and pitch are angle controlled (you can't roll upside down or loop).
 
 The vehicle will glide if the throttle is lowered to 0% (motor stops).
 In order to perform a turn the command must be held throughout the maneuver because if the roll is released the plane will stop turning and level itself (the same is true for pitch and yaw commands).
+
+The yaw stick can be used to increase/reduce the yaw rate of the vehicle in turns.
+If left at center the controller does the turn coordination by itself, meaning that it will apply the necessary yaw rate for the current roll angle to perform a smooth turn.
 
 ![FW Manual Flight](../../assets/flight_modes/stabilized_fw.png)
 

--- a/en/flight_modes_fw/position.md
+++ b/en/flight_modes_fw/position.md
@@ -35,6 +35,13 @@ Manual mode where centered sticks put vehicle into straight and level flight whe
 
 ## Parameters
 
-| Parameter | Description |
-| --------- | ----------- |
-| &nbsp;    | &nbsp;      |
+The mode is affected by the following parameters:
+
+| Parameter                                                                                                | Description                                                                                                              |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| <a id="FW_AIRSPD_MIN"></a>[FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN)       | Min airspeed/throttle. Default: 10 m/s.                                                                                  |
+| <a id="FW_AIRSPD_MAX"></a>[FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX)       | Max airspeed/throttle. Default: 20 m/s.                                                                                  |
+| <a id="FW_AIRSPD_TRIM"></a>[FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM)    | Cruise speed. Default: 15 m/s.                                                                                           |
+| <a id="FW_MAN_P_MAX"></a>[FW_MAN_P_MAX](../advanced_config/parameter_reference.md#FW_MAN_P_MAX)          | Max pitch for manual control in attitude stabilized mode. Default: 45 degrees.                                           |
+| <a id="FW_MAN_R_MAX"></a>[FW_MAN_R_MAX](../advanced_config/parameter_reference.md#FW_MAN_R_MAX)          | Max roll for manual control in attitude stabilized mode. Default: 45 degrees.                                            |
+| <a id="FW_NPFG_CONTROL"></a>[FW NPFG Control](../advanced_config/parameter_reference.md#fw-npfg-control) | The roll/yaw needed to maintain the commanded altitude and airspeed are also affected by the FW NPFG Control parameters. |

--- a/en/flight_modes_fw/stabilized.md
+++ b/en/flight_modes_fw/stabilized.md
@@ -42,8 +42,12 @@ The vehicle course and altitude are not maintained, and can drift due to wind.
 
 ## Parameters
 
-| Parameter | Description |
-| --------- | ----------- |
-| &nbsp;    | &nbsp;      |
+The mode is affected by the following parameters:
+
+| Parameter                                                                                                | Description                                                                                                              |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+<a id="FW_MAN_P_MAX"></a>[FW_MAN_P_MAX](../advanced_config/parameter_reference.md#FW_MAN_P_MAX)          | Max pitch for manual control in attitude stabilized mode. Default: 45 degrees.                                           |
+| <a id="FW_MAN_R_MAX"></a>[FW_MAN_R_MAX](../advanced_config/parameter_reference.md#FW_MAN_R_MAX)          | Max roll for manual control in attitude stabilized mode. Default: 45 degrees.                                            |
+
 
 <!-- this document needs to be extended -->

--- a/en/flight_modes_mc/offboard.md
+++ b/en/flight_modes_mc/offboard.md
@@ -1,4 +1,3 @@
 <Redirect to="../flight_modes/offboard" />
 
 # Offboard Mode (Multicopter)
-


### PR DESCRIPTION
Follow up on https://github.com/PX4/PX4-user_guide/pull/3039

Do we really need the mode description in three levels of details (README overveiw, README bit more detailed, and then separate section for them all). Maybe okay to remove the middle level? I've done my proposals here though mainly in there, so those things I would need to copy over to the detail sections then.