### PR TITLE
Update SD card advice in logging and general concepts

### DIFF
--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -105,17 +105,17 @@ The **SanDisk Extreme U3 32GB** and **Samsung EVO Plus 32** are known to be reli
 
 The table below shows the **mean sequential write speed [KB/s]** / **maximum write time per block (average) [ms]** for F4- (Pixracer), F7-, and H7-based flight controllers.
 
-| SD Card                                                       | F4           | F7  | H7  |
-| ------------------------------------------------------------- | ------------ | --- | --- |
-| SanDisk Extreme U3 32GB                                       | 461 / **15** | ?/? | ?/? |
-| Samsung EVO Plus 32                                           | ?/?          | ?/? | ?/? |
-| Sandisk Ultra Class 10 8GB                                    | 348 / 40     | ?/? | ?/? |
-| Sandisk Class 4 8GB                                           | 212 / 60     | ?/? | ?/? |
-| SanDisk Class 10 32 GB (High Endurance Video Monitoring Card) | 331 / 220    | ?/? | ?/? |
-| Lexar U1 (Class 10), 16GB High-Performance                    | 209 / 150    | ?/? | ?/? |
-| Sandisk Ultra PLUS Class 10 16GB                              | 196 /500     | ?/? | ?/? |
-| Sandisk Pixtor Class 10 16GB                                  | 334 / 250    | ?/? | ?/? |
-| Sandisk Extreme PLUS Class 10 32GB                            | 332 / 150    | ?/? | ?/? |
+| SD Card                                                       | F4            | F7         | H7        |
+| ------------------------------------------------------------- | ------------- | ---------- | --------- |
+| SanDisk Extreme U3 32GB                                       | 1500 / **15** | 1800/10    | 2900/8    |
+| Samsung EVO Plus 32GB                                         | 1700/10-60    | 1800/10-60 | 1900/9-60 |
+| Sandisk Ultra Class 10 8GB                                    | 348 / 40      | ?/?        | ?/?       |
+| Sandisk Class 4 8GB                                           | 212 / 60      | ?/?        | ?/?       |
+| SanDisk Class 10 32 GB (High Endurance Video Monitoring Card) | 331 / 220     | ?/?        | ?/?       |
+| Lexar U1 (Class 10), 16GB High-Performance                    | 209 / 150     | ?/?        | ?/?       |
+| Sandisk Ultra PLUS Class 10 16GB                              | 196 /500      | ?/?        | ?/?       |
+| Sandisk Pixtor Class 10 16GB                                  | 334 / 250     | ?/?        | ?/?       |
+| Sandisk Extreme PLUS Class 10 32GB                            | 332 / 150     | ?/?        | ?/?       |
 
 Logging bandwidth with the default topics is around 50 KB/s, which almost all SD cards satisfy in terms of their mean sequential write speed.
 

--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -101,15 +101,29 @@ amount of dropouts:
 ## SD Cards
 
 The maximum supported SD card size for NuttX is 32GB (SD Memory Card Specifications Version 2.0).
-The **SanDisk Extreme U3 32GB** and **Samsung EVO Plus 32** known to be reliable cards (do not exhibit write-time spikes, and thus virtually no dropouts).
+The **SanDisk Extreme U3 32GB** and **Samsung EVO Plus 32** are known to be reliable cards (do not exhibit write-time spikes, and thus virtually no dropouts).
 
-Logging bandwidth with the default topics is around 50 KB/s, which almost all SD cards satisfy in terms of their mean sequential write speed (many cards, such as the SanDisk Extreme U3, have mean sequential write speed of 2000KB/s under NuttX).
+The table below shows the **mean sequential write speed [KB/s]** / **maximum write time per block (average) [ms]** for F4- (Pixracer), F7-, and H7-based flight controllers.
+
+| SD Card                                                       | F4           | F7  | H7  |
+| ------------------------------------------------------------- | ------------ | --- | --- |
+| SanDisk Extreme U3 32GB                                       | 461 / **15** | ?/? | ?/? |
+| Samsung EVO Plus 32                                           | ?/?          | ?/? | ?/? |
+| Sandisk Ultra Class 10 8GB                                    | 348 / 40     | ?/? | ?/? |
+| Sandisk Class 4 8GB                                           | 212 / 60     | ?/? | ?/? |
+| SanDisk Class 10 32 GB (High Endurance Video Monitoring Card) | 331 / 220    | ?/? | ?/? |
+| Lexar U1 (Class 10), 16GB High-Performance                    | 209 / 150    | ?/? | ?/? |
+| Sandisk Ultra PLUS Class 10 16GB                              | 196 /500     | ?/? | ?/? |
+| Sandisk Pixtor Class 10 16GB                                  | 334 / 250    | ?/? | ?/? |
+| Sandisk Extreme PLUS Class 10 32GB                            | 332 / 150    | ?/? | ?/? |
+
+Logging bandwidth with the default topics is around 50 KB/s, which almost all SD cards satisfy in terms of their mean sequential write speed.
 
 More important than the mean write speed is spikes (or generally high values) in the maximum write time per block (of 4 KB) or `fsync` times, as a long write time means a larger log buffer is needed to avoid dropouts.
 
 PX4 uses bigger buffers on F7/H7 and read caching, which is enough to compensate for spikes in many poor cards.
-That said, if your card has an `fsync` or write duration of several 100ms it is should not be preferred for use with PX4. 
-You can check the value by running [sd_bench](../modules/modules_command.md#sd-bench) should be run with more iterations (around 100 should do). 
+That said, if your card has an `fsync` or write duration of several 100ms it is should not be preferred for use with PX4.
+You can check the value by running [sd_bench](../modules/modules_command.md#sd-bench) should be run with more iterations (around 100 should do).
 
 ```sh
 sd_bench -r 100

--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -103,7 +103,7 @@ amount of dropouts:
 The maximum supported SD card size for NuttX is 32GB (SD Memory Card Specifications Version 2.0).
 The **SanDisk Extreme U3 32GB** and **Samsung EVO Plus 32** known to be reliable cards (do not exhibit write-time spikes, and thus virtually no dropouts).
 
-Logging bandwidth with the default topics is around 50 KB/s, which almost all SD cards satisfy in terms of their mean sequential write speed (many cards, such as the SanDisk Extreme U3, have mean sequential write speed of 2000KB/s).
+Logging bandwidth with the default topics is around 50 KB/s, which almost all SD cards satisfy in terms of their mean sequential write speed (many cards, such as the SanDisk Extreme U3, have mean sequential write speed of 2000KB/s under NuttX).
 
 More important than the mean write speed is spikes (or generally high values) in the maximum write time per block (of 4 KB) or `fsync` times, as a long write time means a larger log buffer is needed to avoid dropouts.
 

--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -101,7 +101,7 @@ amount of dropouts:
 ## SD Cards
 
 The maximum supported SD card size for NuttX is 32GB (SD Memory Card Specifications Version 2.0).
-The **SanDisk Extreme U3 32GB** is recommended as it does not exhibit write-time spikes (and thus virtually no dropouts).
+The **SanDisk Extreme U3 32GB** and **Samsung EVO Plus 32** known to be reliable cards (do not exhibit write-time spikes, and thus virtually no dropouts).
 
 Logging bandwidth with the default topics is around 50 KB/s, which almost all SD cards satisfy in terms of their mean sequential write speed (many cards, such as the SanDisk Extreme U3, have mean sequential write speed of 2000KB/s).
 

--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -100,33 +100,27 @@ amount of dropouts:
 
 ## SD Cards
 
-The following provides performance results for different SD cards.
-Tests were done on a Pixracer; the results are applicable to Pixhawk as well.
+The maximum supported SD card size for NuttX is 32GB (SD Memory Card Specifications Version 2.0).
+The **SanDisk Extreme U3 32GB** is recommended as it does not exhibit write-time spikes (and thus virtually no dropouts).
+
+Logging bandwidth with the default topics is around 50 KB/s, which almost all SD cards satisfy in terms of their mean sequential write speed (many cards, such as the SanDisk Extreme U3, have mean sequential write speed of 2000KB/s).
+
+More important than the mean write speed is spikes (or generally high values) in the maximum write time per block (of 4 KB) or `fsync` times, as a long write time means a larger log buffer is needed to avoid dropouts.
+
+PX4 uses bigger buffers on F7/H7 and read caching, which is enough to compensate for spikes in many poor cards.
+That said, if your card has an `fsync` of several 100ms then it is probably unusable. 
+You can check the value by running [sd_bench](../modules/modules_command.md#sd-bench) should be run with more iterations (around 100 should do). 
+
+```sh
+sd_bench -r 100
+```
+
+This defines the minimum buffer size: the larger this maximum, the larger the log buffer needs to be to avoid dropouts.
+PX4 uses bigger buffers on F7/H7 and read caching to make up for some of these issues.
 
 :::note
-The maximum supported SD card size for NuttX is 32GB (SD Memory Card Specifications Version 2.0).
+If you have concerns about a particular card you can run the above test and report the results to https://github.com/PX4/PX4-Autopilot/issues/4634.
 :::
-
-| SD Card                                                       | Mean Seq. Write Speed [KB/s] | Max Write Time / Block (average) [ms] |
-| ------------------------------------------------------------- | ---------------------------- | ------------------------------------- |
-| SanDisk Extreme U3 32GB                                       | 461                          | **15**                                |
-| Sandisk Ultra Class 10 8GB                                    | 348                          | 40                                    |
-| Sandisk Class 4 8GB                                           | 212                          | 60                                    |
-| SanDisk Class 10 32 GB (High Endurance Video Monitoring Card) | 331                          | 220                                   |
-| Lexar U1 (Class 10), 16GB High-Performance                    | 209                          | 150                                   |
-| Sandisk Ultra PLUS Class 10 16GB                              | 196                          | 500                                   |
-| Sandisk Pixtor Class 10 16GB                                  | 334                          | 250                                   |
-| Sandisk Extreme PLUS Class 10 32GB                            | 332                          | 150                                   |
-
-More important than the mean write speed is the maximum write time per block (of 4 KB).
-This defines the minimum buffer size: the larger this maximum, the larger the log buffer needs to be to avoid dropouts.
-Logging bandwidth with the default topics is around 50 KB/s, which all of the SD cards satisfy.
-
-By far the best card we know so far is the **SanDisk Extreme U3 32GB**.
-This card is recommended, because it does not exhibit write time spikes (and thus virtually no dropouts).
-Different card sizes might work equally well, but the performance is usually different.
-
-You can test your own SD card with `sd_bench -r 50`, and report the results to https://github.com/PX4/PX4-Autopilot/issues/4634.
 
 ## Log Streaming
 

--- a/en/dev_log/logging.md
+++ b/en/dev_log/logging.md
@@ -108,7 +108,7 @@ Logging bandwidth with the default topics is around 50 KB/s, which almost all SD
 More important than the mean write speed is spikes (or generally high values) in the maximum write time per block (of 4 KB) or `fsync` times, as a long write time means a larger log buffer is needed to avoid dropouts.
 
 PX4 uses bigger buffers on F7/H7 and read caching, which is enough to compensate for spikes in many poor cards.
-That said, if your card has an `fsync` of several 100ms then it is probably unusable. 
+That said, if your card has an `fsync` or write duration of several 100ms it is should not be preferred for use with PX4. 
 You can check the value by running [sd_bench](../modules/modules_command.md#sd-bench) should be run with more iterations (around 100 should do). 
 
 ```sh

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -188,7 +188,7 @@ PX4 uses SD memory cards for storing [flight logs](../getting_started/flight_rep
 
 By default, if no SD card is present PX4 will play the [format failed (2-beep)](../getting_started/tunes.md#format-failed) tune twice during boot (and none of the above features will be available).
 
-:::tip
+::: tip
 The maximum supported SD card size on Pixhawk boards is 32GB.
 The _SanDisk Extreme U3 32GB_ is [highly recommended](../dev_log/logging.md#sd-cards).
 :::

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -190,7 +190,7 @@ By default, if no SD card is present PX4 will play the [format failed (2-beep)](
 
 ::: tip
 The maximum supported SD card size on Pixhawk boards is 32GB.
-The _SanDisk Extreme U3 32GB_ is [highly recommended](../dev_log/logging.md#sd-cards).
+The _SanDisk Extreme U3 32GB_ and _Samsung EVO Plus 32_ are [highly recommended](../dev_log/logging.md#sd-cards).
 :::
 
 SD cards are never-the-less optional.


### PR DESCRIPTION
@bkueng This attempts to update the advice on what SD cards to use that you provided in https://discord.com/channels/1022170275984457759/1195469811229147236

The problem with the previous docs are that they show logs for Pixracer and Pixhawk on 5+ years old cards. It's hard for users to know the relevance, of that information, so I have deleted the table and just noted:
-  the minimum write speed you need and that many common cards get orders of magnitude better.
- That max write speed and spikes are the problem, and how to test. Also a finger in the air that 200ms would be risky (can we be more precise?)

1. I also want to recommend a card. I used the one from the original docs, but just changed to remove "the best we ever found".
   What should be used now?
2. This says the maximum size card supported is 32 Gb. That was written in 2018. What is the specification we support now and the corresponding max size card?

