### PR TITLE
Remove note that you must use supported compass orientation

### DIFF
--- a/en/assembly/mount_gps_compass.md
+++ b/en/assembly/mount_gps_compass.md
@@ -15,13 +15,6 @@ The orientation follows the same frame convention as when [orienting the flight 
 If you're using the normal [Compass Calibration](../config/compass.md) process (with parameter [SENS_MAG_AUTOROT](../advanced_config/parameter_reference.md#SENS_MAG_AUTOROT) enabled), the orientation should be detected automatically.
 Otherwise you can directly select the appropriate value in [CAL_MAGn_ROT](../advanced_config/parameter_reference.md#CAL_MAG1_ROT) for up to three compasses.
 
-:::warning
-You must mount the compass in a supported orientation!
-
-If you mount the compass at an orientation that isn't supported, for example `Yaw 30`, PX4 will detect the closest supported value.
-This will result in errors/warnings, even if the calibration appeared to succeed.
-:::
-
 ## Position
 
 In order to compensate for the relative motion between the receiver and the CoG, you should [configure](../advanced_config/parameters.md) the following parameters to set the offsets: [EKF2_GPS_POS_X](../advanced_config/parameter_reference.md#EKF2_GPS_POS_X), [EKF2_GPS_POS_Y](../advanced_config/parameter_reference.md#EKF2_GPS_POS_Y) and [EKF2_GPS_POS_Z](../advanced_config/parameter_reference.md#EKF2_GPS_POS_Z).

--- a/en/assembly/mount_gps_compass.md
+++ b/en/assembly/mount_gps_compass.md
@@ -1,6 +1,6 @@
 # Mounting a GPS/Compass
 
-GPS/Compasses should be mounted on the frame as far away from other electronics as possible, with the direction marker pointing towards the front of the vehicle.
+GPS/Compasses should be mounted on the frame as far away from other electronics as possible, [oriented](#compass-orientation) upright and with the direction marker pointing towards the front of the vehicle.
 You should also configure PX4 to [set the position](#position) of the receiver relative to the centre-of-gravity (CoG).
 
 The diagram below shows the heading marker on the Pixhawk 4 and compass.
@@ -9,11 +9,12 @@ The diagram below shows the heading marker on the Pixhawk 4 and compass.
 
 ## Compass Orientation
 
-The compass can be mounted in any of the standard MAVLink orientations defined in [MAV_SENSOR_ORIENTATION](https://mavlink.io/en/messages/common.html#MAV_SENSOR_ORIENTATION).
-The orientation follows the same frame convention as when [orienting the flight controller](../config/flight_controller_orientation.md#calculating-orientation).
+The compass should ideally be oriented so that it is upright and facing towards the front of the vehicle, but if needed can be oriented at multiples of 45° from this attitude (in any axis) as defined in the [standard MAVLink orientations](https://mavlink.io/en/messages/common.html#MAV_SENSOR_ORIENTATION).
 
-If you're using the normal [Compass Calibration](../config/compass.md) process (with parameter [SENS_MAG_AUTOROT](../advanced_config/parameter_reference.md#SENS_MAG_AUTOROT) enabled), the orientation should be detected automatically.
-Otherwise you can directly select the appropriate value in [CAL_MAGn_ROT](../advanced_config/parameter_reference.md#CAL_MAG1_ROT) for up to three compasses.
+PX4 will automatically detect the orientation for any of these standard orientations during [compass calibration](../config/compass.md) ([by default](../advanced_config/parameter_reference.md#SENS_MAG_AUTOROT)).
+
+The compass can also be mounted at any other "custom euler angles", but in this case you will need to manually configure the orientations.
+For more information see [Setting the Compass Orientation](../config/flight_controller_orientation.md#setting-the-compass-orientation) in _Flight Controller/Sensor Orientation_.
 
 ## Position
 

--- a/en/config/compass.md
+++ b/en/config/compass.md
@@ -3,6 +3,11 @@
 The compass calibration process configures all connected internal and external [magnetometers](../gps_compass/README.md).
 _QGroundControl_ will guide you to position the vehicle in a number of set orientations and rotate the vehicle about the specified axis.
 
+:::note
+Compass calibration also auto-detects the compass orientation ([by default](../advanced_config/parameter_reference.md#SENS_MAG_AUTOROT)).
+If you have [mounted the compass](../assembly/mount_gps_compass.md#compass-orientation) at a non-standard angle you will need to [manually set the compass orientation](../config/flight_controller_orientation.md#setting-the-compass-orientation) before calibrating.
+:::
+
 ## Overview
 
 You will need to calibrate your compass on first use, and you may need to recalibrate it if the vehicles is ever exposed to a very strong magnetic field, or if it is used in an area with abnormal magnetic characteristics.

--- a/en/config/flight_controller_orientation.md
+++ b/en/config/flight_controller_orientation.md
@@ -1,7 +1,7 @@
 # Flight Controller/Sensor Orientation
 
-By default the flight controller (and external compass(es), if present) should be placed on the frame top-side up, oriented so that the arrow points towards the front of the vehicle.
-If the board or an external compass are mounted in any other orientation then you will need configure this in the firmware.
+By default the flight controller and external compass(es) (if present) should be placed on the frame top-side up, oriented so that the arrow points towards the front of the vehicle.
+If the board or any external compasses are mounted in any other orientation then you will need configure this in the firmware.
 
 ## Calculating Orientation
 
@@ -26,7 +26,7 @@ The axis are normally relative to the orientation of the vehicle during steady f
 For more information see [Basic Concepts](../getting_started/px4_basic_concepts.md#heading-and-directions).
 :::
 
-## Setting the Orientation
+## Setting the Flight Controller Orientation
 
 To set the orientations:
 
@@ -42,9 +42,22 @@ To set the orientations:
 
 1. Press **OK**.
 
-## Fine Tuning
-
+:::note
 You can use [Level Horizon Calibration](../config/level_horizon_calibration.md) to compensate for small miss-alignments in controller orientation and to level the horizon in flight view.
+:::
+
+## Setting the Compass Orientation
+
+PX4 will automatically detect the compass orientation as part of [compass calibration](../config/compass.md) ([by default](../advanced_config/parameter_reference.md#SENS_MAG_AUTOROT)) for any of the [standard MAVLink orientations](https://mavlink.io/en/messages/common.html#MAV_SENSOR_ORIENTATION) (upright and facing forward, or any multiple of 45° offset in any axis) .
+
+:::note
+You can confirm that auto detection worked by looking at the [CAL_MAGn_ROT](../advanced_config/parameter_reference.md#CAL_MAG0_ROT) parameters.
+:::
+
+If a non-standard orientation has been used you will need to set the [CAL_MAGx_ROLL](../advanced_config/parameter_reference.md#CAL_MAG0_ROLL), [CAL_MAGx_PITCH](../advanced_config/parameter_reference.md#CAL_MAG0_PITCH), and [CAL_MAGx_YAW](../advanced_config/parameter_reference.md#CAL_MAG0_YAW) parameters for each compass to the angles that were used.
+
+This will automatically set [CAL_MAGn_ROT](../advanced_config/parameter_reference.md#CAL_MAG0_ROT) to "custom euler angle".
+Note that you will need to disable the [SENS_MAG_AUTOROT](../advanced_config/parameter_reference.md#SENS_MAG_AUTOROT) parameter before performing compass calibration, as this will map the angle to some multiple of 45° in all axes (so 30° would be detected as 0° or 45°).
 
 ## Further Information
 


### PR DESCRIPTION
This removes a note from the compass mounting docs stating that you have to use the supported orientations.

The orientations can now be tuned by setting `CAL_MAGn_ROT` to the "Custom Euler Angle" option and then setting the orientation using `CAL_MAGn_ROLL`, `CAL_MAGn_PITCH`, `CAL_MAGn_YAW` to set the actual orientation.

This is draft because it is not clear WHEN you would need to do this. Specifically compass tuning will automatically select the right  "standard" `CAL_MAGn_ROT` during calibration, but it isn't clear whether it will recognise that the standard setting is wrong, and try set  `CAL_MAGn_ROT` to the "Custom Euler Angle" and the other values for you?

It might be that if you know the values are not right you have to set them yourself. Or that you set to the closest normal rotation and then tune. 

Can you confirm the right process @bresch  or @sfuhrer ?

EDIT NOte, I see that @sfuhrer has partially answered in https://github.com/PX4/PX4-user_guide/pull/3068#discussion_r1515759817 :

> The auto detection as well as the custom angle are fairly new features, and the docs are outdated here.
The flow is now that you only have to set the autopilot rotation, and then do a mag cal. The calibration then detects the mag orientation and sets it. AFAIK you could then override that either by setting the _ROT yourself to the correct value (e.g. "pitch 90"), or set CAL_MAG1_PITCH, CAL_MAG1_ROLL and CAL_MAG1_YAW, which then automatically sets CAL_MAG1_ROT to "Custom Euler Angle". @bresch correct?

So that indicates, but does not "confirm" that if you want a custom euler angle you need to set it explicitly - right?