### PR TITLE
Mag calibration disabled if euler mag orientation set

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -447,6 +447,7 @@
       * [CameraCapture](msg_docs/CameraCapture.md)
       * [CameraStatus](msg_docs/CameraStatus.md)
       * [CameraTrigger](msg_docs/CameraTrigger.md)
+      * [CanInterfaceStatus](msg_docs/CanInterfaceStatus.md)
       * [CellularStatus](msg_docs/CellularStatus.md)
       * [CollisionConstraints](msg_docs/CollisionConstraints.md)
       * [CollisionReport](msg_docs/CollisionReport.md)

--- a/en/config/flight_controller_orientation.md
+++ b/en/config/flight_controller_orientation.md
@@ -56,8 +56,7 @@ You can confirm that auto detection worked by looking at the [CAL_MAGn_ROT](../a
 
 If a non-standard orientation has been used you will need to set the [CAL_MAGx_ROLL](../advanced_config/parameter_reference.md#CAL_MAG0_ROLL), [CAL_MAGx_PITCH](../advanced_config/parameter_reference.md#CAL_MAG0_PITCH), and [CAL_MAGx_YAW](../advanced_config/parameter_reference.md#CAL_MAG0_YAW) parameters for each compass to the angles that were used.
 
-This will automatically set [CAL_MAGn_ROT](../advanced_config/parameter_reference.md#CAL_MAG0_ROT) to "custom euler angle".
-Note that you will need to disable the [SENS_MAG_AUTOROT](../advanced_config/parameter_reference.md#SENS_MAG_AUTOROT) parameter before performing compass calibration, as this will map the angle to some multiple of 45° in all axes (so 30° would be detected as 0° or 45°).
+This will automatically set [CAL_MAGn_ROT](../advanced_config/parameter_reference.md#CAL_MAG0_ROT) to "custom euler angle" and prevents automatic calibration for the selected compass (even if [SENS_MAG_AUTOROT](../advanced_config/parameter_reference.md#SENS_MAG_AUTOROT) is set).
 
 ## Further Information
 


### PR DESCRIPTION
Follow on from #3107

As discussed with @bresch , the orientation is detected every time you calibrate if SENS_MAG_AUTOROT is enabled unless a custom Euler angle is set. This just makes it clear you don't need to worry about the custom angles being overwritten.

Also added CanInterfaceStatus to sidebar.