### PR TITLE
gps_compass: fixup params for Septentrio Mosaic

### DIFF
--- a/en/gps_compass/septentrio_mosaic-go.md
+++ b/en/gps_compass/septentrio_mosaic-go.md
@@ -2,16 +2,15 @@
 
 The mosaic-go Evaluation Kit is composed of the mosaic module soldered on an interface board inside a metallic housing.
 
-Sized at only 71 x 59 x 12 mm and weighing only 58 g, mosaic-go offers unmatched size to performance ratio. mosaic-go
-includes:
+Sized at only 71 x 59 x 12 mm and weighing only 58 g, mosaic-go offers unmatched size to performance ratio.
+mosaic-go includes:
 
 - High update rate (>100 Hz) and low latency, both crucial for control systems of autonomous applications
 - Reliable centimetre-level positioning
 - Full L2 support via P(Y) code
 
   Mosaic-go part number:
-  Single-antenna version, incorporating mosaic-X5: 410386(including accessories). Dual-antennaversion,
-  incorporatingmosaic-H: 410397(including accessories).
+  Single-antenna version, incorporating mosaic-X5: 410386(including accessories). Dual-antennaversion, incorporatingmosaic-H: 410397(including accessories).
 
 - Size: 71 x 59 x 12 mm ± 1mm
 - Weight: 58g ± 1g
@@ -91,8 +90,7 @@ _Connector type: GH connector, 1.25mm pitch, 4way. Mating connector housing: GHR
 
 1. Make sure the receiver is powered with at least 3.3V. You can use the micro USB connector or the 6-pin connector.
 2. Connect one or two GNSS antennas to the RF-IN ports on the mosaic-go.
-3. Connect the 6-pin connector (COM1) to the Pixhawk's `GPS MODULE` port. This will provide power to the mosaic-go and with
-   this single connection it will be able to send single and dual antenna information to the Pixhawk 4.
+3. Connect the 6-pin connector (COM1) to the Pixhawk's `GPS MODULE` port. This will provide power to the mosaic-go and with this single connection it will be able to send single and dual antenna information to the Pixhawk 4.
 4. In the web interface or with Rx Tools, set the receiver's baud rate to 115200 **Admin > Expert Control > Control Panel > Communication > COM Port Settings** (this is the default value).
 
 :::warning
@@ -116,9 +114,10 @@ The attitude (heading/pitch) can be computed from the orientation of the baselin
 To enable multi-antenna attitude determination, follow the following procedure:
 
 1. Attach two antennas to your vehicle, using cables of approximately the same length. The default antenna configuration is as depicted in the figure.
-   It consists in placing the antennas aligned with the longitudinal axis of the vehicle, main antenna behind aux1.
+   It consists in placing the antennas aligned with the longitudinal axis of the vehicle, main antenna behind AUX1.
    For best accuracy, try to maximize the distance between the antennas, and avoid significant height difference between the antenna ARPs.
-2. In practice, the two antenna ARPs may not be exactly at the same height in the vehicle frame, or the main-aux1 baseline may not be exactly parallel or perpendicular to the longitudinal axis of the vehicle. This leads to offsets in the computed attitude angles.
+2. In practice, the two antenna ARPs may not be exactly at the same height in the vehicle frame, or the main-aux1 baseline may not be exactly parallel or perpendicular to the longitudinal axis of the vehicle.
+   This leads to offsets in the computed attitude angles.
    These offsets can be compensated for with the **setAttitudeOffset** command.
 
 ::: info
@@ -131,13 +130,11 @@ our [Knowledge Base](https://support.septentrio.com/l/858493/2022-04-19/xgrqd) o
 
 ### Web app
 
-mosaic-H GPS/GNSS receiver module with heading comes with fully documented interfaces, commands and data messages. The
-included GNSS receiver control and analysis software [RxTools](https://web.septentrio.com/l/858493/2022-04-19/xgrqp)
-allows receiver configuration, monitoring as well as data logging and analysis.
+mosaic-H GPS/GNSS receiver module with heading comes with fully documented interfaces, commands and data messages.
+The included GNSS receiver control and analysis software [RxTools](https://web.septentrio.com/l/858493/2022-04-19/xgrqp) allows receiver configuration, monitoring as well as data logging and analysis.
 
-The receiver includes an intuitive web user interface for easy operation and monitoring allowing you to control the
-receiver from any mobile device or computer. The web interface also uses easy-to-read quality indicators ideal to
-monitor the receiver operation during the job at hand.
+The receiver includes an intuitive web user interface for easy operation and monitoring allowing you to control the receiver from any mobile device or computer.
+The web interface also uses easy-to-read quality indicators ideal to monitor the receiver operation during the job at hand.
 
 ![Septentrio web user interface]( ../../assets/hardware/gps/septentrio_sbf/septentrio_mosaic_a5_h_t_clas_gnss_module_receiverwebui.png)
 
@@ -169,7 +166,6 @@ Edit the following parameters in the GPS tab:
 - [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET): set according to your setup (note that Aux is forward at 0 offset)
 
 Go to **Tools > Reboot Vehicle**
-
 
 ## LED Status
 

--- a/en/gps_compass/septentrio_mosaic-go.md
+++ b/en/gps_compass/septentrio_mosaic-go.md
@@ -102,7 +102,7 @@ Make sure the JST cable is wired correctly (since this is not a standard cable):
 
 :::
 
-::: info 
+::: info
 PX4 will ensure that the GNSS module is automatically configured however, if you have a dual antenna setup, it
 is required to set the layout as accurately as possible in the web app.
 :::
@@ -121,7 +121,7 @@ To enable multi-antenna attitude determination, follow the following procedure:
 2. In practice, the two antenna ARPs may not be exactly at the same height in the vehicle frame, or the main-aux1 baseline may not be exactly parallel or perpendicular to the longitudinal axis of the vehicle. This leads to offsets in the computed attitude angles.
    These offsets can be compensated for with the **setAttitudeOffset** command.
 
-::: info 
+::: info
 For optimal heading results, the two antennas should be seperated by at least 30cm / 11.8 in (ideally 50cm /
 19.7in or more)
 
@@ -152,7 +152,7 @@ Edit the following parameters in the GPS tab:
 - [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG): GPS 1
 - [GPS_1_GNSS](../advanced_config/parameter_reference.md#GPS_1_GNSS): 31
 - [GPS_1_PROTOCOL](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL): Auto detect (or SBF)
-- [SER_TEL1_BAUD](../advanced_config/parameter_reference.md#SER_TEL1_BAUD): 115200 8N1
+- [SER_GPS1_BAUD](../advanced_config/parameter_reference.md#SER_GPS1_BAUD): 115200 8N1
 
 Go to **Tools > Reboot Vehicle**
 
@@ -160,13 +160,13 @@ Go to **Tools > Reboot Vehicle**
 
 Edit the following parameters in the GPS tab:
 
-- [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG): TELEM1
+- [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG): GPS 1
 - [GPS_1_GNSS](../advanced_config/parameter_reference.md#GPS_1_GNSS): 31
 - [GPS_1_PROTOCOL](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL): Auto detect (or SBF)
-- [SER_TEL1_BAUD](../advanced_config/parameter_reference.md#SER_TEL1_BAUD): 115200 8N1
-- [EKF2_GPS_CTRL](../advanced_config/parameter_reference.md#EKF2_GPS_CTRL): Bit 3 Dual antenna heading
-- [GPS_PITCH_OFFSET](../advanced_config/parameter_reference.md#GPS_PITCH_OFFSET): set according to your setup
-- [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET): set according to your setup
+- [SER_GPS1_BAUD](../advanced_config/parameter_reference.md#SER_GPS1_BAUD): 115200 8N1
+- [EKF2_GPS_CTRL](../advanced_config/parameter_reference.md#EKF2_GPS_CTRL): Add bit 3 (Dual antenna heading) which adds up to 15
+- [GPS_PITCH_OFFSET](../advanced_config/parameter_reference.md#GPS_PITCH_OFFSET): set according to your setup (note that Aux is forward at 0 offset)
+- [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET): set according to your setup (note that Aux is forward at 0 offset)
 
 Go to **Tools > Reboot Vehicle**
 
@@ -182,7 +182,7 @@ Go to **Tools > Reboot Vehicle**
 | Purple + Blue | &check;️  |    &check;️     |   &check;️   |    &check;️     |
 | Red + Green   | &check;️  |    &check;️     |              |    &check;️     |
 
-:::tip 
+:::tip
 For more detailed information about the mosaic-go and its module, please refer to the [hardware manual](https://web.septentrio.com/l/858493/2022-04-19/xgrrd) or the [Septentrio Support](https://support.septentrio.com/l/858493/2022-04-19/xgrrl) page.
 :::
 


### PR DESCRIPTION
- Fixed the baudrate param which was wrong.
- Added a note regarding dual GPS orientation.
- Clarify param bit to set.

FYI @vincentpoont2 