### PR TITLE
index file - add import of _contributors.md file

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -104,6 +104,8 @@ You can access these from the Languages menu (top right):
 
 ![Language Selector](../assets/vuepress/language_selector.png)
 
+<!--@include: _contributors.md-->
+
 ## License
 
 PX4 code is free to use and modify under the terms of the permissive [BSD 3-clause license](https://opensource.org/licenses/BSD-3-Clause).


### PR DESCRIPTION
Adds import of _contributors.md file in language root directory (e.g. `/uk/_contributors.md`). This will render if the file exists but otherwise fails silently.

This is to support the contributor list in #3224