### PR TITLE
Make images display inline, as per usual default

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -8,7 +8,7 @@
  *
  * Each colors have exact same color scale system with 3 levels of solid
  * colors with different brightness, and 1 soft color.
- * 
+ *
  * - `XXX-1`: The most solid color used mainly for colored text. It must
  *   satisfy the contrast ratio against when used on top of `XXX-soft`.
  *
@@ -150,4 +150,13 @@
 
 .medium-zoom-image {
   z-index: 21;
+}
+
+
+/**
+ * Override styles as needed
+ * -------------------------------------------------------------------------- */
+
+ .vp-doc img {
+  display: inline; /* block by default set by vitepress */
 }


### PR DESCRIPTION
Layout changed in vitepress so image are block elements. This reverts that change so that layout is side-by-side where that makes sense.