### PR TITLE
Add safety switch, buzzer and led cross links to basic concepts

### DIFF
--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -197,9 +197,31 @@ PX4 does not _require_ a manual control system for autonomous flight modes.
 
 ### Safety Switch
 
-Some vehicles have a _safety switch_ that must be engaged before the vehicle can be [armed](#arming-and-disarming) (when armed, motors are powered and propellers can turn).
+Vehicles may include a _safety switch_ that must be engaged before the vehicle can be [armed](#arming-and-disarming) (when armed, motors are powered and propellers can turn).
 
-Commonly the safety switch is integrated into a GPS unit, but it may also be a separate physical component.
+This switch is almost always integrated into the [GPS](../gps_compass/index.md) module that is connected to the Pixhawk `GPS1` port — along with the [buzzer](#buzzer) and [UI LED](#leds).
+
+The switch may be disabled by default, though this depends on the particular flight controller and airframe configuration.
+You can disable/enable use of the switch with the [CBRK_IO_SAFETY](../advanced_config/parameter_reference.md#CBRK_IO_SAFETY) parameter.
+
+::: info
+Safety switches are optional.
+Many argue that it is safer for users never to approach a powered system, even to enable/disable this interlock.
+:::
+
+### Buzzer
+
+Vehicles commonly include a buzzer for providing audible notification of vehicle state and readiness to fly (see [Tune meanings](../getting_started/tunes.md)).
+
+This buzzer is almost always integrated into the [GPS](../gps_compass/index.md) module that is connected to the Pixhawk `GPS1` port — along with the [safety switch](#safety-switch) and [UI LED](#leds).
+You can disable the notification tunes using the parameter [CBRK_BUZZER](../advanced_config/parameter_reference.md#CBRK_BUZZER).
+
+### LEDs
+
+Vehicles should have a superbright [UI RGB LED](../getting_started/led_meanings.html#ui-led) that indicates the current readiness for flight.
+
+Historically this was included in the flight controller board.
+On more recent flight controllers this is almost always an [I2C peripheral](../sensor_bus/i2c_general.md) integrated into the [GPS](../gps_compass/index.md) module that is connected to the Pixhawk `GPS1` port — along with the [safety switch](#safety-switch) and [buzzer](#buzzer).
 
 ### Data/Telemetry Radios
 

--- a/en/getting_started/tunes.md
+++ b/en/getting_started/tunes.md
@@ -1,6 +1,6 @@
 # Tune Meanings (Pixhawk Series)
 
-[Pixhawk-series flight controllers](../flight_controller/pixhawk_series.md) use audible tones/tunes and [LEDs](../getting_started/led_meanings.md) to indicate vehicle state and events (e.g. arming success and failure, low battery warnings).
+[Pixhawk-series flight controllers](../flight_controller/pixhawk_series.md) use audible tones/tunes from a [buzzer](../getting_started/px4_basic_concepts.html#buzzer) and colours/sequences from a [LED](../getting_started/led_meanings.md) to indicate vehicle state and events (e.g. arming success and failure, low battery warnings).
 
 The set of standard sounds are listed below.
 

--- a/en/gps_compass/index.md
+++ b/en/gps_compass/index.md
@@ -5,6 +5,7 @@ A GNSS system is needed for missions, and some other automatic and manual/assist
 
 Most GNSS modules also contain a [compass/magnetometer](../gps_compass/magnetometer.md) part (see link for calibration/setup information).
 Because of this the GNSS module should be mounted as far away from the motor/ESC power supply lines as possible - typically on a pedestal or wing (for fixed-wing).
+Many also include a [safety switch](../getting_started/px4_basic_concepts.md#safety-switch), [buzzer](../getting_started/px4_basic_concepts.md#buzzer) and [UI LED](../getting_started/led_meanings.html#ui-led).
 
 ![GPS + Compass](../../assets/hardware/gps/gps_compass.jpg)
 

--- a/en/sensor_bus/i2c_general.md
+++ b/en/sensor_bus/i2c_general.md
@@ -4,7 +4,7 @@
 
 It is recommended for:
 
-* Connecting offboard components that require low bandwidth and low latency communication, e.g. [rangefinders](../sensor/rangefinders.md), [magnetometers](../gps_compass/index.md), [airspeed sensors](../sensor/airspeed.md) and [tachometers](../sensor/tachometers.md) .
+* Connecting offboard components that require low bandwidth and low latency communication, e.g. [rangefinders](../sensor/rangefinders.md), [magnetometers](../gps_compass/magnetometer.md), [airspeed sensors](../sensor/airspeed.md) and [tachometers](../sensor/tachometers.md) .
 * Compatibility with peripheral devices that only support I2C.
 * Allowing multiple devices to attach to a single bus, which is useful for conserving ports.
 


### PR DESCRIPTION
These were missing from the hardware and basic concepts, which meant I had nowhere to link for changes to the assembly guide. Adding these to basic concepts to give high level 