### PR TITLE
Update dev_env_linux_ubuntu.md - move the video guide

### DIFF
--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -18,12 +18,6 @@ This setup is supported by the PX4 dev team.
 The instructions may also work on other Debian Linux based systems.
 :::
 
-## Video Guide
-
-This video shows how to install the toolchain for NuttX and simulation targets ([as covered below](#simulation-and-nuttx-pixhawk-targets)) along with the basic testing covered in [Building PX4 Software](../dev_setup/building_px4.md).
-
-@[youtube](https://youtu.be/OtValQdAdrU).
-
 ## Simulation and NuttX (Pixhawk) Targets
 
 :::warning
@@ -238,6 +232,13 @@ If you're working with ROS "Melodic on Ubuntu 18.04:
 - Your catkin (ROS build system) workspace is created at **~/catkin_ws/**.
 - The script uses instructions from the ROS Wiki "Melodic" [Ubuntu page](http://wiki.ros.org/melodic/Installation/Ubuntu).
   :::
+
+## Video Guide
+
+This video shows how to install the toolchain for NuttX and simulation targets ([as covered below](#simulation-and-nuttx-pixhawk-targets)) along with the basic testing covered in [Building PX4 Software](../dev_setup/building_px4.md).
+Note however that it was created some years ago and has not been verified to work on recent builds, while the documentation has.
+
+@[youtube](https://youtu.be/OtValQdAdrU).
 
 ## Next Steps
 


### PR DESCRIPTION
The video guide for PX4 dev on linux apparently doesn't work. It looks OK to me though. So I've pushed it to the end of the doc and added a "use at your own risk" kind of warning.