### PR TITLE
correct battery realease notes

### DIFF
--- a/en/releases/main.md
+++ b/en/releases/main.md
@@ -30,7 +30,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 ### Common
 
 - [Battery level estimation improvements](../config/battery.md) ([PX4-Autopilot#23205](https://github.com/PX4/PX4-Autopilot/pull/23205)).
-  - [Voltage-based estimation with load compensation](../config/battery.md#voltage-based-estimation-with-load-compensation) now uses a real-time estimate of the internal resistance of the battery to compensative for voltage drops under load (with increased current), providing a better capacity estimate than the open-circuit voltage.
+  - [Voltage-based estimation with load compensation](../config/battery.md#voltage-based-estimation-with-load-compensation) now uses a real-time estimate of the internal resistance of the battery to compensate voltage drops under load (with increased current), providing a better capacity estimate than with the raw measured voltage.
   - Thrust-based load compensation has been removed (along with the `BATn_V_LOAD_DROP` parameters, where `n` is the battery number).
 
 ### Control


### PR DESCRIPTION
Slight correction: The internal resistance estimation is used to _calculate the open circuit voltage_ which is used instead of the _measured voltage_ to get a more accurate capacity estimate.