### PR TITLE
Autotune - version specific fixes

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -21,6 +21,7 @@ export default defineConfig({
     //"kr/**/*.md",
     //"zh/**/*.md",
     //"uk/**/*.md",
+    "**/_*.md", //Remove source docs that start with "_" (included/not rendered)
   ],
   ignoreDeadLinks: true,
   markdown: {

--- a/_link_checker_sc/ignore_errors.json
+++ b/_link_checker_sc/ignore_errors.json
@@ -937,5 +937,24 @@
     "type": "PageNotLinkedInternally",
     "fileRelativeToRoot": "en\\assembly\\_assembly.md",
     "hideReason": "Its a convenience file"
+  },
+  {
+    "type": "LinkedFileMissingAnchor",
+    "fileRelativeToRoot": "en\\frames_plane\\reptile_dragon_2.md",
+    "link": {
+      "url": "../config/autotune_fw.md#enable-disable-autotune-switch",
+      "text": "autotuning switch"
+    },
+    "hideReason": "The link is in an imported document. Link checker doesn't know about imports."
+  },
+  {
+    "type": "PageNotInTOC",
+    "fileRelativeToRoot": "en\\config\\_autotune.md",
+    "hideReason": "It is not intended to be built"
+  },
+  {
+    "type": "PageNotLinkedInternally",
+    "fileRelativeToRoot": "en\\config\\_autotune.md",
+    "hideReason": "Page is intended to be an orphan"
   }
 ]

--- a/en/config/_autotune.md
+++ b/en/config/_autotune.md
@@ -1,7 +1,20 @@
-# Auto-tuning
+<!-- This is the single-source for autotuning docs used in the autotune_mc.md and autotune_fy.md
+At time of writing, only FW, MC, and VTOL, support autotuning.
+VTOL has its own doc that references the other two
+-->
+
+<div v-if="$frontmatter.frame === 'Multicopter'">
+
+# Auto-tuning (Multicopter)
+
+</div>
+<div v-else-if="$frontmatter.frame === 'Plane'">
+
+# Auto-tuning (Fixed-Wing)
+
+</div>
 
 Auto-tuning automates the process of tuning the PX4 rate and attitude controllers, which are the most important controllers for stable and responsive flight (other tuning is more "optional").
-It is currently enabled for multicopter, fixed-wing, and hybrid VTOL fixed-wing vehicles.
 
 Tuning only needs to be done once, and is recommended unless you're using a vehicle that has already been tuned by the manufacturer (and not modified since).
 
@@ -11,7 +24,7 @@ The airframe must fly well enough to handle moderate disturbances, and should be
 
 - Test that your vehicle is [stable enough for autotuning](#pre-tuning-test).
 - Be ready to abort the autotuning process.
-  You can do this by changing flight modes or using an auto-tune enable/disable switch ([if configured](#enable-disable-autotune-switch-fixed-wing)).
+  You can do this by changing flight modes<div style="display: inline;" v-if="$frontmatter.frame === 'Plane'"> or using an auto-tune enable/disable switch ([if configured](#enable-disable-autotune-switch))</div>.
 - Verify that the vehicle flies well after tuning.
 
 :::
@@ -23,17 +36,12 @@ The airframe must fly well enough to handle moderate disturbances, and should be
 The vehicle must be able to fly and adequately stabilize itself before running auto-tune.
 This test ensures that the vehicle can fly safely in position controlled modes.
 
-::: info
-During [Airframe Setup](../config/airframe.md) you should have selected the frame that most closely matches your vehicle.
-This may fly well enough to run autotuning.
-:::
-
 To make sure the vehicle is stable enough for auto-tuning:
 
 1. Perform a normal preflight safety checklist to ensure the flight zone is clear and has enough space.
-1. Takeoff and prepare for the test
-   - **Multicopters:** Take off and hover at 1m above ground in [Altitude mode](../flight_modes_mc/altitude.md) or Stabilized mode.
-   - **Fixed-wing:** Take off and fly at cruise speed in [Position mode](../flight_modes_mc/position.md) or [Altitude mode](../flight_modes_mc/altitude.md).
+
+1. Take off and <div style="display: inline;" v-if="$frontmatter.frame === 'Multicopter'">hover at 1m above ground in [Altitude mode](../flight_modes_mc/altitude.md) or [Manual/Stabilized mode](../flight_modes_mc/manual_stabilized.md)</div><div style="display: inline;" v-else-if="$frontmatter.frame === 'Plane'">fly at cruise speed in [Position mode](../flight_modes_fw/position.md) or [Altitude mode](../flight_modes_fw/altitude.md)</div>.
+
 1. Use the RC transmitter roll stick to perform the following maneuver, tilting the vehicle just a few degrees: _roll left > roll right > center_ (The whole maneuver should take about 3 seconds).
    The vehicle should stabilise itself within 2 oscillations.
 1. Repeat the maneuver, tilting with larger amplitudes at each attempt.
@@ -41,36 +49,40 @@ To make sure the vehicle is stable enough for auto-tuning:
 1. Repeat the same maneuvers but on the pitch axis.
    As above, start with small angles and confirm that the vehicle can stabilise itself within 2 oscillations before increasing the tilt.
 
-If the drone can stabilize itself within 2 oscillations it is ready for the auto-tuning procedure.
+If the drone can stabilize itself within 2 oscillations it is ready for the [auto-tuning procedure](#auto-tuning-procedure).
 
-If not, go to the [troubleshooting](#troubleshooting) section, which explains the minimal manual tuning to prepare the vehicle for auto-tuning.
+::: warning
+If the drone cannot stabilize itself sufficiently, follow the instructions in the [troubleshooting](#troubleshooting) section.
+These explain the minimal manual tuning to prepare the vehicle for auto-tuning.
+:::
 
-### Auto-tuning Procedure
+## Auto-tuning Procedure
 
 The auto-tuning sequence must be performed in a **safe flight zone, with enough space**.
 It takes about 40 seconds ([between 19 and 68 seconds](#how-long-does-autotuning-take)).
 For best results, we recommend running the test in calm weather conditions.
 
-The recommended modes for autotuning are [Hold mode](../flight_modes_fw/hold.md) (FW) and [Altitude mode](../flight_modes_mc/altitude.md) (MC), but any other flight mode can be used.
+The recommended mode for autotuning is <div style="display: inline;" v-if="$frontmatter.frame === 'Multicopter'">[Altitude mode](../flight_modes_mc/altitude.md)</div><div  style="display: inline;" v-else-if="$frontmatter.frame === 'Plane'">[Hold mode](../flight_modes_fw/hold.md)</div>, but any other flight mode can be used.
 During auto tuning, the RC sticks can still be used to fly the vehicle.
-
-::: info
-The auto-tuning sequence can be aborted at any time by changing flight modes or using the [enable/disable Autotune switch](#enable-disable-autotune-switch-fixed-wing) (if configured).
-:::
 
 The test steps are:
 
 1. Perform the [pre-tuning test](#pre-tuning-test).
-1. Takeoff using RC control and prepare for test:
-   - **Multicopters:** Takeoff using the remote controller in [Altitude mode](../flight_modes_mc/altitude.md).
-     Hover the vehicle at a safe distance and at a few meters above ground (between 4 and 20m).
-   - **Fixed-wing:** Once flying at cruise speed, activate [Hold mode](../flight_modes_mc/hold.md).
-     This will guide the plane to fly in circle at constant altitude and speed.
+
+1. Takeoff using RC control <div style="display: inline;" v-if="$frontmatter.frame === 'Multicopter'">in [Altitude mode](../flight_modes_mc/altitude.md).
+   Hover the vehicle at a safe distance and at a few meters above ground (between 4 and 20m).</div><div v-else-if="$frontmatter.frame === 'Plane'">
+   Once flying at cruise speed, activate [Hold mode](../flight_modes_fw/hold.md).
+   This will guide the plane to fly in circle at constant altitude and speed.</div>
+
 1. Enable autotune.
 
+   <div v-if="$frontmatter.frame === 'Plane'">
+
    :::tip
-   If an [Enable/Disable Autotune Switch](#enable-disable-autotune-switch-fixed-wing) is configured you can just toggle the switch to the "enabled" position.
+   If an [Enable/Disable Autotune Switch](#enable-disable-autotune-switch) is configured you can just toggle the switch to the "enabled" position.
    :::
+
+   </div>
 
    1. In QGroundControl, open the menu: **Vehicle setup > PID Tuning**
 
@@ -82,72 +94,105 @@ The test steps are:
 
 1. The drone will first start to perform quick roll motions followed by pitch and yaw motions.
    The progress is shown in the progress bar, next to the _Autotune_ button.
-1. Apply the tuning:
+1. <div style="display: inline;" v-if="$frontmatter.frame === 'Multicopter'">Manually land and disarm to apply the new tuning parameters.
+   Takeoff carefully and manually test that the vehicle is stable.</div><div v-else-if="$frontmatter.frame === 'Plane'">The tuning will be immediately/automatically be applied and tested in flight (by default).
+   PX4 will then run a 4 second test and revert the new tuning if a problem is detected.</div>
 
-   - **Fixed-Wing:** The tuning will be immediately/automatically be applied and tested in flight (by default).
-     PX4 will then run a 4 second test and revert the new tuning if a problem is detected.
-   - **Multicopters:** Manually land and disarm to apply the new tuning parameters.
-     Takeoff carefully and manually test that the vehicle is stable.
-
-1. If any strong oscillations occur, land immediately and follow the instructions in the [Troubleshooting](#troubleshooting) section below.
+::: warning
+If any strong oscillations occur, land immediately and follow the instructions in the [Troubleshooting](#troubleshooting) section below.
+:::
 
 Additional notes:
 
-- **VTOL:** Hybrid VTOL fixed-wing vehicles must be tuned twice, following multicopter instructions in MC mode and fixed-wing instructions in FW mode.
-- **Multicopter:** The instructions above tune the vehicle in [Altitude mode](../flight_modes_mc/altitude.md).
+<div v-if="$frontmatter.frame === 'Multicopter'">
+
+- The instructions above tune the vehicle in [Altitude mode](../flight_modes_mc/altitude.md).
   You can instead takeoff in [Takeoff mode](../flight_modes_mc/takeoff.md) and tune in [Position mode](../flight_modes_mc/position.md) if the vehicle is is _known_ to be stable in these modes.
-- **Fixed-wing:** Autotuning can also be run in [Altitude mode](../flight_modes_fw/altitude.md) or [Position mode](../flight_modes_fw/position.md).
+
+</div>
+<div v-else-if="$frontmatter.frame === 'Plane'">
+
+- Autotuning can also be run in [Altitude mode](../flight_modes_fw/altitude.md) or [Position mode](../flight_modes_fw/position.md).
   However running the test while flying straight requires a larger safe area for tuning, and does not give a significantly better tuning result.
-- Whether tuning is applied in-air or after landing can be [configured using parameters](#apply-parameters-when-in-air-landed).
+
+</div>
+
+- Whether tuning is applied while flying or after landing can be [configured using parameters](#apply-tuning-when-in-air-landed).
 
 ## Troubleshooting
 
-#### The drone oscillates when performing the testing maneuvers prior to the auto-tuning
+### Drone oscillates when performing the pre-tuning test
 
-- slow oscillations (1 oscillation per second or slower): this often occurs on large platforms and means that the attitude loop is too fast compared to the rate loop.
-  - **Multicopter:** decrease [MC_ROLL_P](../advanced_config/parameter_reference.md#MC_ROLL_P) and [MC_PITCH_P](../advanced_config/parameter_reference.md#MC_PITCH_P) by steps of 1.0.
-  - **Fixed-wing:** increase [FW_R_TC](../advanced_config/parameter_reference.md#FW_R_TC) and [FW_P_TC](../advanced_config/parameter_reference.md#FW_P_TC) by steps of 0.1.
-- fast oscillations (more than 1 oscillation per second): this is because the gain of the rate loop is too high.
-  - **Multicopter:** decrease `MC_[ROLL|PITCH|YAW]RATE_K` by steps of 0.02
-  - **Fixed-wing:** decrease [FW_RR_P](../advanced_config/parameter_reference.md#FW_RR_P), [FW_PR_P](../advanced_config/parameter_reference.md#FW_PR_P), [FW_YR_P](../advanced_config/parameter_reference.md#FW_YR_P) by steps of 0.01.
+<div v-if="$frontmatter.frame === 'Multicopter'">
 
-#### The auto-tuning sequence fails
+Slow oscillations (1 oscillation per second or slower): this often occurs on large platforms and means that the attitude loop is too fast compared to the rate loop:
+
+- Decrease [MC_ROLL_P](../advanced_config/parameter_reference.md#MC_ROLL_P) and [MC_PITCH_P](../advanced_config/parameter_reference.md#MC_PITCH_P) by steps of 1.0.
+
+Fast oscillations (more than 1 oscillation per second): this is because the gain of the rate loop is too high.
+
+- Decrease `MC_[ROLL|PITCH|YAW]RATE_K` by steps of 0.02
+
+</div>
+<div v-else-if="$frontmatter.frame === 'Plane'">
+
+Slow oscillations (1 oscillation per second or slower): this often occurs on large platforms and means that the attitude loop is too fast compared to the rate loop.
+
+- Increase [FW_R_TC](../advanced_config/parameter_reference.md#FW_R_TC) and [FW_P_TC](../advanced_config/parameter_reference.md#FW_P_TC) by steps of 0.1.
+
+Fast oscillations (more than 1 oscillation per second): this is because the gain of the rate loop is too high.
+
+- Decrease [FW_RR_P](../advanced_config/parameter_reference.md#FW_RR_P), [FW_PR_P](../advanced_config/parameter_reference.md#FW_PR_P), [FW_YR_P](../advanced_config/parameter_reference.md#FW_YR_P) by steps of 0.01.
+
+</div>
+
+### The auto-tuning sequence fails
 
 If the drone was not moving enough during auto-tuning, the system identification algorithm might have issues to find the correct coefficients.
-Increase the [FW_AT_SYSID_AMP](../advanced_config/parameter_reference.md#FW_AT_SYSID_AMP), [MC_AT_SYSID_AMP](../advanced_config/parameter_reference.md#MC_AT_SYSID_AMP) by steps of 1 and trigger the auto-tune again.
 
-#### The drone oscillates after auto-tuning
+Increase the <div style="display: inline;" v-if="$frontmatter.frame === 'Multicopter'">[MC_AT_SYSID_AMP](../advanced_config/parameter_reference.md#MC_AT_SYSID_AMP)</div><div style="display: inline;" v-else-if="$frontmatter.frame === 'Plane'">[FW_AT_SYSID_AMP](../advanced_config/parameter_reference.md#FW_AT_SYSID_AMP)</div> parameter by steps of 1 and trigger the auto-tune again.
+
+### The drone oscillates after auto-tuning
 
 Due to effects not included in the mathematical model such as delays, saturation, slew-rate, airframe flexibility, the loop gain can be too high.
-To fix this, follow the same steps described [when the drone oscillates in the pre-tuning test](#the-drone-oscillates-when-performing-the-testing-maneuvers-prior-to-the-auto-tuning).
+To fix this, follow the same steps described [when the drone oscillates in the pre-tuning test](#drone-oscillates-when-performing-the-pre-tuning-test).
 
-#### I still can't get it to work
+### I still can't get it to work
 
-Attempt manual tuning using the appropriate guides:
-
-- [Multicopter PID Tuning Guide](../config_mc/pid_tuning_guide_multicopter_basic.md) (Manual/Simple)
-- [Multicopter PID Tuning Guide](../config_mc/pid_tuning_guide_multicopter.md) (Advanced/Detailed)
-- [Fixed-Wing PID Tuning Guide](../config_fw/pid_tuning_guide_fixedwing.md)
+Attempt manual tuning using the guides listed in [See also](#see-also) below.
 
 ## Optional Configuration
 
-### Apply Parameters When In-Air/Landed
+### Apply Tuning when In-Air/Landed
 
-By default MC vehicles land before parameters are applied, while FW vehicles apply the parameters in-air and then test that the controllers work properly.
-This behaviour can be configured using the [MC_AT_APPLY](../advanced_config/parameter_reference.md#MC_AT_APPLY) and [FW_AT_APPLY](../advanced_config/parameter_reference.md#FW_AT_APPLY) parameters respectively:
+
+<div v-if="$frontmatter.frame === 'Multicopter'">
+
+By multicopters land before parameters are applied.
+This behaviour can be configured using the [MC_AT_APPLY](../advanced_config/parameter_reference.md#MC_AT_APPLY) parameter:
+
+</div>
+<div v-else-if="$frontmatter.frame === 'Plane'">
+
+By default fixed wing tuning the parameters are applied while flying, and then PX4 runs a test to confirm that the controllers work properly.
+This behaviour can be configured using the [FW_AT_APPLY](../advanced_config/parameter_reference.md#FW_AT_APPLY) parameter:
+
+</div>
 
 - `0`: the gains are not applied.
   This is used for testing purposes if the user wants to inspect results of the auto-tuning algorithm without using them directly.
 - `1`: apply the gains after disarm (default for multirotors).
   The operator can then test the new tuning while taking-off carefully.
-- `2`: apply immediately (default for fixed-fings).
+- `2`: apply immediately (default for fixed-wings).
   The new tuning is applied, disturbances are sent to the controller and the stability is monitored during the next 4 seconds.
   If the control loop is unstable, the control gains are immediately reverted back to their previous value.
   If the test passes, the pilot can then use the new tuning.
 
-### Enable/Disable Autotune Switch (Fixed-Wing)
+<div v-if="$frontmatter.frame === 'Plane'">
 
-A remote control switch can be configured to enable/disable autotune (in any mode) using an RC AUX channel.
+### Enable/Disable Autotune Switch
+
+A remote control switch can be configured to enable/disable autotune (in any mode) using an RC AUX channel (note, this is only supported on fixed-wing vehicles).
 
 To map a switch:
 
@@ -155,17 +200,19 @@ To map a switch:
 1. Set [RC_MAP_AUX1](../advanced_config/parameter_reference.md#RC_MAP_AUX1) to match the RC channel for your switch (you can use any of `RC_MAP_AUX1` to `RC_MAP_AUX6`).
 1. Set [FW_AT_MAN_AUX](../advanced_config/parameter_reference.md#FW_AT_MAN_AUX) to the selected channel (i.e. `1: Aux 1` if you mapped `RC_MAP_AUX1`).
 
-The auto tuner will be disabled when the switch is below `0.5` (on the manual control setpoint range of of `[-1, 1]` and enabled when the switch channel is above `0.5`.
+The auto tuner will be disabled when the switch is below `0.5` (on the manual control setpoint range of of `[-1, 1]`) and enabled when the switch channel is above `0.5`.
 
-If using an RC AUX switch to enable autotuning, make sure to [select the tuning axes](#select-tuning-axis-fixed-wing) before flight.
+If using an RC AUX switch to enable autotuning, make sure to [select the tuning axes](#select-tuning-axis) before flight.
 
-### Select Tuning Axis (Fixed-Wing)
+### Select Tuning Axis
 
 Fixed-wing vehicles (only) can select which axes are tuned using the [FW_AT_AXES](../advanced_config/parameter_reference.md#FW_AT_AXES) bitmask parameter:
 
 - bit `0`: roll (default)
 - bit `1`: pitch (default)
 - bit `2`: yaw
+
+</div>
 
 ## Developers/SDKs
 
@@ -203,7 +250,7 @@ The flight stack will apply a small disturbance to the vehicle in each axis and 
 For fixed-wing vehicles the new tuning is applied in-air by default, after which the vehicle tests the new settings and reverts the tuning if the controllers are not stable.
 For multicopter, the vehicle lands and applies the new tuning parameters after disarming; the pilot is expected to then take off carefully and test the tuning.
 
-The tuning process takes about 40 seconds ([between 19 and 68 seconds](#how-long-does-autotuning-take)).
+The tuning process takes about 40 seconds ([between 19 and 70 seconds](#how-long-does-autotuning-take)).
 The default behaviour can be configured using [parameters](#optional-configuration).
 
 ### FAQ
@@ -246,8 +293,18 @@ If not, perhaps say "not very" but you should expect that the vehicle might defl
 
 -->
 
+<div v-if="$frontmatter.frame === 'Multicopter'">
+
 ## See also
 
 - [Multicopter PID Tuning Guide](../config_mc/pid_tuning_guide_multicopter_basic.md) (Manual/Simple)
 - [Multicopter PID Tuning Guide](../config_mc/pid_tuning_guide_multicopter.md) (Advanced/Detailed)
+
+</div>
+<div v-else-if="$frontmatter.frame === 'Plane'">
+
+## See also
+
 - [Fixed-Wing PID Tuning Guide](../config_fw/pid_tuning_guide_fixedwing.md)
+
+</div>

--- a/en/config/autotune_fw.md
+++ b/en/config/autotune_fw.md
@@ -1,4 +1,5 @@
 ---
+title: Fixed-wing Auto-Tuning
 frame: Plane
 newEditLink: en/config/_autotune.md
 ---

--- a/en/config/autotune_mc.md
+++ b/en/config/autotune_mc.md
@@ -1,4 +1,5 @@
 ---
+title: Multicopter Auto-Tuning
 frame: Multicopter
 newEditLink: en/config/_autotune.md
 ---

--- a/en/config/autotune_vtol.md
+++ b/en/config/autotune_vtol.md
@@ -1,6 +1,10 @@
----
-frame: VTOL
-newEditLink: en/config/_autotune.md
----
+# Autotuning (VTOL)
 
-<!--@include: _autotune.md-->
+Auto-tuning automates the process of tuning the PX4 rate and attitude PID controllers, which are the most important controllers for stable and responsive flight (other tuning is more "optional").
+
+Tuning only needs to be done once, and is recommended unless you're using a vehicle that has already been tuned by the manufacturer (and not modified since).
+
+Hybrid VTOL fixed-wing vehicles ("VTOL") must be tuned following the multicopter instructions in MC mode and then the fixed-wing instructions in FW mode:
+
+- [Auto-tune (Multicopter)](../config/autotune_mc.md)
+- [Auto-tune (Fixed-wing)](../config/autotune_mc.md)

--- a/en/frames_plane/reptile_dragon_2.md
+++ b/en/frames_plane/reptile_dragon_2.md
@@ -380,7 +380,7 @@ In particular you should check:
 You should enable Manual, Acro, and Position modes on your controller (at least for the first flight).
 For instructions see [Flight mode Configuration](../config/flight_mode.md)
 
-We also recommend configuring an [autotuning switch](../config/autotune_fw.md#enable-disable-autotune-switch-fixed-wing) for the first flight, as this makes it easier to enable/disable autotuning while flying.
+We also recommend configuring an [autotuning switch](../config/autotune_fw.md#enable-disable-autotune-switch) for the first flight, as this makes it easier to enable/disable autotuning while flying.
 
 The channel mappings for this build are included in the supplied [params file](#parameter-config).
 The channel order is throttle, roll, pitch, yaw, (blank), and flight mode


### PR DESCRIPTION
This makes each of the versions for vtol, mc, fw to be version specific, and also stops any files named with the `_` prefix from being rendered.