### PR TITLE
Lite youtube

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -1,8 +1,6 @@
 import { defineConfig } from "vitepress";
 const getSidebar = require("./get_sidebar.js");
-//import { getSidebar } from "./get_sidebar";
 
-import blockEmbedPlugin from "markdown-it-block-embed";
 // Tabs: https://github.com/Red-Asuka/vitepress-plugin-tabs
 import tabsPlugin from "@red-asuka/vitepress-plugin-tabs";
 
@@ -28,7 +26,6 @@ export default defineConfig({
     math: true,
     config: (md) => {
       // use more markdown-it plugins!
-      md.use(blockEmbedPlugin);
       tabsPlugin(md); //https://github.com/Red-Asuka/vitepress-plugin-tabs
     },
   },
@@ -195,4 +192,12 @@ export default defineConfig({
       gtag('config', 'G-91EWVWRQ93');`,
     ],
   ],
+
+  vue: {
+    template: {
+      compilerOptions: {
+        isCustomElement: (tag) => tag === "lite-youtube",
+      },
+    },
+  },
 });

--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -1,5 +1,6 @@
 // https://vitepress.dev/guide/custom-theme
 import { h } from "vue";
+
 import DefaultTheme from "vitepress/theme";
 import "./style.css";
 
@@ -7,6 +8,14 @@ import "./style.css";
 import { onMounted, watch, nextTick } from "vue";
 import { useRoute } from "vitepress";
 import mediumZoom from "medium-zoom";
+
+// For https://www.npmjs.com/package/lite-youtube-embed
+import { inBrowser } from "vitepress";
+import "lite-youtube-embed/src/lite-yt-embed.css";
+if (inBrowser) {
+  // @ts-ignore
+  import("lite-youtube-embed");
+}
 
 // Support redirect plugin
 import Redirect from "./components/Redirect.vue";

--- a/en/can/index.md
+++ b/en/can/index.md
@@ -75,21 +75,22 @@ See [PX4 DroneCAN Firmware](../dronecan/px4_cannode_fw.md) for more information.
 
 Intro to DroneCAN (UAVCANv0) and practical example with setup in QGroundControl:
 
-@[youtube](https://youtu.be/IZMTq9fTiOM)
+<lite-youtube videoid="IZMTq9fTiOM" title="Intro to DroneCAN (UAVCANv0) and practical example with setup in QGroundControl"/>
 
 ### Cyphal
 
-UAVCAN v1 for drones — PX4 Developer Summit Virtual 2020
+UAVCAN v1 for drones (Cyphal) — PX4 Developer Summit Virtual 2020
 
-@[youtube](https://youtu.be/6Bvtn_g8liU)
+<lite-youtube videoid="6Bvtn_g8liU" title="UAVCAN v1 for drones — PX4 Developer Summit Virtual 2020"/>
 
 ---
 
 Getting started using UAVCAN v1 with PX4 on the NXP UAVCAN Board — PX4 Developer Summit Virtual 2020
-@[youtube](https://youtu.be/MwdHwjaXYKs)
+
+<lite-youtube videoid="MwdHwjaXYKs" title="Getting started using UAVCAN v1 with PX4 on the NXP UAVCAN Board"/>
 
 ---
 
 UAVCAN: a highly dependable publish-subscribe protocol for hard real-time intra-vehicular networking — PX4 Developer Summit Virtual 2019
 
-@[youtube](https://youtu.be/MBtROivYPik)
+<lite-youtube videoid="MBtROivYPik" title="UAVCAN: a highly dependable publish-subscribe protocol for hard ..."/>

--- a/en/complete_vehicles_mc/betafpv_beta75x.md
+++ b/en/complete_vehicles_mc/betafpv_beta75x.md
@@ -55,4 +55,4 @@ To install and configure PX4:
 
 ## Video
 
-@[youtube](https://youtu.be/_-O0kv0Qsh4)
+<lite-youtube videoid="_-O0kv0Qsh4" title="PX4 running on the BetaFPV Whoop"/>

--- a/en/complete_vehicles_mc/crazyflie2.md
+++ b/en/complete_vehicles_mc/crazyflie2.md
@@ -304,7 +304,3 @@ To connect to Crazyflie 2.0 via MAVROS:
   ```
 
 - Restart QGroundControl if it doesn't connect.
-
-## Flying
-
-@[youtube](https://youtu.be/2Bcy3k1h5uc)

--- a/en/complete_vehicles_mc/crazyflie21.md
+++ b/en/complete_vehicles_mc/crazyflie21.md
@@ -287,4 +287,4 @@ To connect to Crazyflie 2.1 via MAVROS:
 
 ## Flying
 
-@[youtube](https://www.youtube.com/watch?v=0qy7O3fVN2c)
+<lite-youtube videoid="0qy7O3fVN2c" title="Crazyflie 2.1 - PX4 Firmware (stabilized mode)"/>

--- a/en/complete_vehicles_mc/nanomind110.md
+++ b/en/complete_vehicles_mc/nanomind110.md
@@ -22,7 +22,7 @@ The user guide is [here](http://mindpx.net/assets/accessories/NanoMind_110_user_
 
 ### Flight video
 
-@[youtube](https://youtu.be/bLtKa--Buic)
+<lite-youtube videoid="bLtKa--Buic" title="NanoMind with external compass flying EKF2 estimator"/>
 
 ### Where to buy
 

--- a/en/concept/flight_tasks.md
+++ b/en/concept/flight_tasks.md
@@ -185,13 +185,13 @@ The second is an update, which covers the changes in PX4 v1.11.
 
 A description of how flight modes work in PX4 v1.9 (Dennis Mannhart, Matthias Grob).
 
-@[youtube](https://youtu.be/-dkQG8YLffc)
+<lite-youtube videoid="-dkQG8YLffc" title="PX4 Flight Task Architecture Overview"/>
 
 <!-- datestamp:video:youtube:20190704:PX4 Flight Task Architecture Overview — PX4 Developer Summit 2019 -->
 
 ### Overview of multicopter control from sensors to motors (PX4 Developer Summit Virtual 2020)
 
-@[youtube](https://youtu.be/orvng_11ngQ?t=560)
+<lite-youtube videoid="orvng_11ngQ" params="start=560" title="Overview of multicopter control from sensors to motors"/>
 
 <!-- datestamp:video:youtube:20200720:Overview of multicopter control from sensors to motors — PX4 Developer Summit Virtual 2020 From 9min20sec - Section on flight tasks-->
 

--- a/en/config/_autotune.md
+++ b/en/config/_autotune.md
@@ -29,7 +29,7 @@ The airframe must fly well enough to handle moderate disturbances, and should be
 
 :::
 
-@[youtube](https://youtu.be/5xswOhhqrIQ)
+<lite-youtube videoid="5xswOhhqrIQ" title="QGroundControl Autotune Feature Breakdown for PX4 Autopilot"/>
 
 ## Pre-tuning Test
 

--- a/en/config/flight_mode.md
+++ b/en/config/flight_mode.md
@@ -101,7 +101,7 @@ The video below shows how this is done with the *FrSky Taranis* transmitter.
 <!-- [youtube](https://youtu.be/scqO7vbH2jo) Video has gone private and is no longer available -->
 <!-- @[youtube](https://youtu.be/BNzeVGD8IZI?t=427) - video showing how to set the QGC side - at about 7mins and 3 secs -->
 
-@[youtube](https://youtu.be/TFEjEQZqdVA)
+<lite-youtube videoid="TFEjEQZqdVA" title="Taranis Mode Switches"/>
 
 The *QGroundControl* configuration is then [as described above](#flight-mode-selection).
 

--- a/en/config/index.md
+++ b/en/config/index.md
@@ -65,7 +65,7 @@ Auto-tuning is supported, and recommended, on the following frames:
 
 The video below shows most of the calibration process (it uses an older version of _QGroundControl_, but most of the process is unchanged).
 
-@[youtube](https://youtu.be/91VGmdSlbo4)
+<lite-youtube videoid="91VGmdSlbo4" title="PX4 Autopilot Setup Tutorial Preview"/>
 
 ## Support
 

--- a/en/contribute/docs.md
+++ b/en/contribute/docs.md
@@ -232,9 +232,9 @@ When you add a new page you must also add it to `en/SUMMARY.md`!
 
 4. Videos:
 
-   - Youtube videos can be added using the format `@[youtube](https://youtu.be/<youtube-video-id>)` (supported via the [markdown-it-block-embed](https://www.npmjs.com/package/markdown-it-block-embed) plugin).
+   - Youtube videos can be added using the format `<lite-youtube videoid="<youtube-video-id>" title="your title"/>` (supported via the [https://www.npmjs.com/package/lite-youtube-embed](https://www.npmjs.com/package/lite-youtube-embed) custom element, which has other parameters you can pass).
      - Use instructional videos sparingly as they date badly, and are hard to maintain.
-     - Cool videos of airframes in flighyt are always welcome.
+     - Cool videos of airframes in flight are always welcome.
 
 ## Where Do I Add Changes?
 

--- a/en/debug/gdb_hardfault.md
+++ b/en/debug/gdb_hardfault.md
@@ -8,7 +8,7 @@ This might occur when key areas in RAM have been corrupted.
 The following video demonstrates hardfault debugging on PX4 using Eclipse and a JTAG debugger.
 It was presented at the PX4 Developer Conference 2019.
 
-@[youtube](https://youtu.be/KZkAM_PVOi0)
+<lite-youtube videoid="KZkAM_PVOi0" title="Hardfault debugging on PX4"/>
 
 ## Debugging Hard Faults in NuttX
 

--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -83,7 +83,7 @@ The video suggests that you build source using JMAVSim, entering the command: `m
 As JMAVSim is now community-supported, you should instead build using Gazebo or Gazebo Classic, as shown in [Building the Code](../dev_setup/building_px4.md#first-build-using-a-simulator)
 :::
 
-@[youtube](https://youtu.be/OtValQdAdrU).
+<lite-youtube videoid="OtValQdAdrU" title=" Setting up your PX4 development environment on Linux"/>
 
 ## Other Targets
 

--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -13,7 +13,7 @@ To build other targets you will need to use a [different OS](../dev_setup/dev_en
 
 ## Video Guide
 
-@[youtube](https://youtu.be/tMbMGiMs1cQ)
+<lite-youtube videoid="tMbMGiMs1cQ" title="Setting up your PX4 development environment on macOS"/>
 
 ## Base Setup
 

--- a/en/dev_setup/qtcreator.md
+++ b/en/dev_setup/qtcreator.md
@@ -18,7 +18,7 @@ Qt creator offers clickable symbols, auto-completion of the complete codebase an
 
 The video below shows how it is used.
 
-@[youtube](https://www.youtube.com/watch?v=Bkk8zttWxEI&rel=0&vq=hd720)
+<lite-youtube videoid="Bkk8zttWxEI" title="(Qt Creator) PX4 Flight Stack Build Experience"/>
 
 ## IDE Setup
 
@@ -54,6 +54,6 @@ cd build/creator
 cmake ../.. -G "CodeBlocks - Unix Makefiles"
 ```
 
-That's it! Start _Qt Creator_, then complete the steps in the video below to set up the project to build.
+That's it! Start _Qt Creator_ and then set up the project to build.
 
-@[youtube](https://www.youtube.com/watch?v=0pa0gS30zNw&rel=0&vq=hd720)
+<!-- note, video here was removed/made private, and in any case out of date. Just hoping people can work it out -->

--- a/en/dronecan/ark_flow.md
+++ b/en/dronecan/ark_flow.md
@@ -123,7 +123,7 @@ If you see a solid red LED there is an error and you should check the following:
 
 ## Video
 
-@[youtube](https://www.youtube.com/watch?v=SAbRe1fi7bU&list=PLUepQApgwSozmwhOo-dXnN33i2nBEl1c0)
+<lite-youtube videoid="SAbRe1fi7bU" params="list=PLUepQApgwSozmwhOo-dXnN33i2nBEl1c0" title="ARK Flow Indoor Position Hold x64"/>
 
 <!-- ARK Flow with PX4 Optical Flow Position Hold: 20210605 -->
 

--- a/en/dronecan/sapog.md
+++ b/en/dronecan/sapog.md
@@ -93,7 +93,7 @@ To enumerate the ESC:
 
 The following video demonstrates the process:
 
-@[youtube](https://www.youtube.com/watch?v=4nSa8tvpbgQ)
+<lite-youtube videoid="4nSa8tvpbgQ" title="Zubax Orel 20 with PX4 Flight Stack - Auto-enumeration"/>
 
 ### Manual ESC Enumeration using Sapog
 

--- a/en/flight_controller/airlink.md
+++ b/en/flight_controller/airlink.md
@@ -21,7 +21,7 @@ AIRLink has two computers and integrated LTE Module:
 
 ## Feature Highlights
 
-@[youtube](https://youtu.be/VcBx9DLPN54)
+<lite-youtube videoid="VcBx9DLPN54" title="SmartAP AIRLink - The Most Advanced AI Drone Avionics"/>
 
 ## Specifications
 
@@ -86,7 +86,7 @@ Purchase from the original Sky-Drones Store (worldwide shipping with 1-2 days or
 
 ## AIRLink Enterprise Kit Accessories
 
-@[youtube](https://youtu.be/lex7axW8WQg)
+<lite-youtube videoid="lex7axW8WQg" title="SmartAP AIRLink - Unboxing"/>
 
 AIRLink Enterprise arrives with everything needed to setup the autopilot system.
 

--- a/en/flight_controller/pixhawk.md
+++ b/en/flight_controller/pixhawk.md
@@ -86,7 +86,7 @@ Order mRo Pixhawk from:
 - 3.3 and 6.6V ADC inputs
 - Internal microUSB port and external microUSB port extension
 
-@[youtube](https://youtu.be/gCCC5A-Bvv4)
+<lite-youtube videoid="gCCC5A-Bvv4" title="PX4 Pixhawk (3DR) Multicolor Led in action"/>
 
 ### Power System and Protection
 

--- a/en/flight_modes_mc/follow_me.md
+++ b/en/flight_modes_mc/follow_me.md
@@ -47,9 +47,9 @@ Angle, height, and distance values set using the RC controller are discarded whe
 If you exit Follow-Me mode and activate it again the values will be reset to their defaults.
 :::
 
-Demo video:
+### Video
 
-@[youtube](https://youtu.be/csuMtU6seXI?t=155)
+<lite-youtube videoid="csuMtU6seXI" params="start=155" title="PX4 Follow Target follows a Rover!"/>
 
 ### Safety Precautions
 
@@ -166,7 +166,9 @@ The follow-me behavior can be configured using the following parameters:
 
 3. Using the RC Adjustment for height, distance and angle, you can get some creative camera shots.
 
-   @[youtube](https://www.youtube.com/watch?v=o3DhvCL_M1E)
+   <lite-youtube videoid="o3DhvCL_M1E" title="YUN0012 almostCinematic"/>
+
+
    This video demonstrates a Google-Earth view perspective, by adjusting the height to around 50 meters (high), distance to 1 meter (close). Which allows a perspective as shot from a satellite.
 
 ## Known Issues

--- a/en/frames_autogyro/thunderfly_auto_g2.md
+++ b/en/frames_autogyro/thunderfly_auto_g2.md
@@ -144,7 +144,7 @@ It can be handled, for example, by nulling the engine’s output in the transmit
 
 ## Video
 
-@[youtube](https://youtu.be/YhXXSWz5wWs)
+<lite-youtube videoid="YhXXSWz5wWs" title="[ThunderFly] 3D printed autogyro rotor"/>
 
 ## Photo gallery of changes
 

--- a/en/frames_multicopter/dji_f450_cuav_5nano.md
+++ b/en/frames_multicopter/dji_f450_cuav_5nano.md
@@ -222,7 +222,7 @@ For instructions on how, start from [Autotune](../config/autotune_mc.md).
 
 ## Video
 
-@[youtube](https://youtu.be/b0bKNdDqVHw)
+<lite-youtube videoid="b0bKNdDqVHw" title="CUAV Nano"/>
 
 
 ## Acknowledgments

--- a/en/frames_multicopter/dji_f450_cuav_5plus.md
+++ b/en/frames_multicopter/dji_f450_cuav_5plus.md
@@ -222,7 +222,7 @@ For instructions on how, start from [Autotune](../config/autotune_mc.md).
 
 ## Video
 
-@[youtube](https://youtu.be/r-IkaVpN1Ko)
+<lite-youtube videoid="r-IkaVpN1Ko" title="CUAV V5+"/>
 
 
 ## Acknowledgments

--- a/en/frames_multicopter/holybro_x500v2_pixhawk6c.md
+++ b/en/frames_multicopter/holybro_x500v2_pixhawk6c.md
@@ -52,8 +52,6 @@ This topic provides full instructions for building the [Holybro X500 V2 ARF Kit]
 
 1. Use Socket Cap Screws M2.5*6 and screw the bottom plate on the 4 hangers (that we inserted in the 2 bars on the 3rd step of the payload holder assembly)
 
-  <!--  @[youtube](https://youtu.be/Qjs6pqarRIY) -->
-
 ### Landing Gear
 
 1. To assemble the landing gear, loosen the pre-assembled screws of the Landing Gear-Cross Bar and insert the Landing Gear-Vertical Pole and fasten the same.

--- a/en/frames_multicopter/index.md
+++ b/en/frames_multicopter/index.md
@@ -21,16 +21,16 @@ The linked sections instructions for assembling and configuring copter frames.
 
 ## Videos
 
-@[youtube](https://www.youtube.com/watch?v=LnUmYgAINBc&vq=hd720)
+<lite-youtube videoid="LnUmYgAINBc" title="3DR Iris + PX4ESC"/>
 
 DJI Flame Wheel 450 with Distance Sensor and RTK GPS (Pixhawk 3 Pro)
 
-@[youtube](https://www.youtube.com/watch?v=JovSwzoTepU)
+<lite-youtube videoid="JovSwzoTepU" title="PX4 terrain following"/>
 
 DJI Matrice 100 (Pixhawk 1)
 
-@[youtube](https://www.youtube.com/watch?v=3OGs0ONemGc)
+<lite-youtube videoid="3OGs0ONemGc" title="DJI Matrice 100 (Pixhawk 1)"/>
 
 QAV-R 5" KISS ESC Racer (Pixracer)
 
-@[youtube](https://youtu.be/wMYgqvsNEwQ)
+<lite-youtube videoid="wMYgqvsNEwQ" title="QAV-R 5 KISS ESC Racer (Pixracer)"/>

--- a/en/frames_multicopter/omnicopter.md
+++ b/en/frames_multicopter/omnicopter.md
@@ -117,7 +117,7 @@ Make sure the motors do not overheat with the changed settings.
 
 ## Video
 
-@[youtube](https://www.youtube.com/watch?v=nsPkQYugfzs)
+<lite-youtube videoid="nsPkQYugfzs" title="PX4 Based Omnicopter Using the New Dynamic Control Allocation in v1.13"/>
 
 ## Simulation
 

--- a/en/frames_multicopter/qav_r_5_kiss_esc_racer.md
+++ b/en/frames_multicopter/qav_r_5_kiss_esc_racer.md
@@ -9,7 +9,7 @@ Key information:
 - **Frame:** [Lumenier QAV-R 5"](http://www.getfpv.com/qav-r-fpv-racing-quadcopter-5.html)
 - **Flight controller:** [Pixracer](../flight_controller/pixracer.md)
 
-@[youtube](https://youtu.be/wMYgqvsNEwQ)
+<lite-youtube videoid="wMYgqvsNEwQ" title="QAV-R 5 PX4 FPV Racequad"/>
 
 ![QAV Racer complete](../../assets/airframes/multicopter/qav_r_5_kiss_esc_racer/preview.jpg)
 ![QAV Racer complete 2](../../assets/airframes/multicopter/qav_r_5_kiss_esc_racer/preview2.jpg)
@@ -46,7 +46,7 @@ These parts cover the sending side for standard FPV 5.8GHz analog FM video. You 
 
 I assembled the basic center plate and the arms like shown in this video between 09:25 and 13:26:
 
-@[youtube](https://youtu.be/7SIpJccXZjM)
+<lite-youtube videoid="7SIpJccXZjM" title="How to Build a Lumenier QAV-R"/>
 
 I mounted the four motors to the frame with the cables coming out towards the center of the frame.
 I used two of the longer motor screws that come with the frame for each motor and put them in the two holes which are further apart.

--- a/en/frames_plane/index.md
+++ b/en/frames_plane/index.md
@@ -22,10 +22,17 @@ The linked sections instructions for assembling and configuring fixed-wing frame
 
 ## Videos
 
-@[youtube](https://www.youtube.com/watch?v=VqNWwIPWJb0&ab_channel=ChrisSeto)
 
-@[youtube](https://www.youtube.com/watch?v=vMFCi3G5s6E)
+<lite-youtube videoid="VqNWwIPWJb0" params="ab_channel=ChrisSeto" title="Reptile Dragon 2 Demo Flight For Px4 Log Review"/>
 
-@[youtube](https://youtu.be/1DUV7QjcXrA)
+---
 
-@[youtube](https://www.youtube.com/watch?v=8m4_NpTQn0E&vq=hd720)
+<lite-youtube videoid="vMFCi3G5s6E" title="PX4 Turbo Timber Spot Landing"/>
+
+---
+
+<lite-youtube videoid="1DUV7QjcXrA" title="Px4 Turbo timber Evolution Short Flight"/>
+
+---
+
+<lite-youtube videoid="8m4_NpTQn0E" title="Solar-powered 81 hour endurance world record flight"/>

--- a/en/frames_plane/reptile_dragon_2.md
+++ b/en/frames_plane/reptile_dragon_2.md
@@ -463,4 +463,4 @@ The RD2 flies well in this configuration and has plenty of room onboard for sens
 
 FPV video of flight log:
 
-@[youtube](https://www.youtube.com/watch?v=VqNWwIPWJb0&ab_channel=ChrisSeto)
+<lite-youtube videoid="VqNWwIPWJb0" params="ab_channel=ChrisSeto" title="Reptile Dragon 2 Demo Flight For Px4 Log Review"/>

--- a/en/frames_plane/turbo_timber_evolution.md
+++ b/en/frames_plane/turbo_timber_evolution.md
@@ -213,14 +213,17 @@ I use full flaps on landing to slow the otherwise slippery airframe.
 
 ### Videos
 
-@[youtube](https://www.youtube.com/watch?v=vMFCi3G5s6E)
+<lite-youtube videoid="vMFCi3G5s6E" title="PX4 Turbo Timber Spot Landing"/>
 
-@[youtube](https://youtu.be/1DUV7QjcXrA)
+---
+
+<lite-youtube videoid="1DUV7QjcXrA" title="PX4 Turbo timber Evolution Short Flight"/>
 
 ### Flight Logs
 
 [Evening Flight (video of flight shown below)](https://review.px4.io/plot_app?log=d3f2c1f9-f802-48c1-ab5d-3983fc8b8719)
-@[youtube](https://www.youtube.com/watch?v=6CqigySqyAQ&ab_channel=ChrisSeto)
+
+<lite-youtube videoid="6CqigySqyAQ" params="ab_channel=ChrisSeto" title="Turbo Timber Evolution Px4 Build Log Example Flight"/>
 
 ### Parameter File
 

--- a/en/frames_rover/index.md
+++ b/en/frames_rover/index.md
@@ -59,4 +59,4 @@ Select the **Apply and Restart** button.
 
 This video shows the [Traxxas Stampede Rover](../frames_rover/traxxas_stampede.md) (an Ackermann vehicle).
 
-@[youtube](https://youtu.be/N3HvSKS3nCw)
+<lite-youtube videoid="N3HvSKS3nCw" title="Traxxas Stampede VXL Autonomous navigation with Pixhawk Mini"/>

--- a/en/frames_sub/bluerov2.md
+++ b/en/frames_sub/bluerov2.md
@@ -43,6 +43,6 @@ You will need to:
 
 ## Video
 
-@[youtube](https://www.youtube.com/watch?v=1sUaURmlmT8)
+<lite-youtube videoid="1sUaURmlmT8" title="PX4 on BlueRov Demo"/>
 
 <!-- @DanielDuecker on github is good person to ask about this frame -->

--- a/en/frames_sub/index.md
+++ b/en/frames_sub/index.md
@@ -33,6 +33,8 @@ This section lists fully assembled vehicles where you can update the software to
 
 ## Videos
 
-@[youtube](https://youtu.be/1sUaURmlmT8)
+<lite-youtube videoid="1sUaURmlmT8" title="PX4 on BlueRov Demo"/>
 
-@[youtube](https://youtu.be/xSXSoUK-iBM)
+---
+
+<lite-youtube videoid="xSXSoUK-iBM" title="Hippocampus UUV in PX4 SITL Gazebo"/>

--- a/en/frames_vtol/index.md
+++ b/en/frames_vtol/index.md
@@ -121,7 +121,7 @@ VTOL configuration is covered in a number of sections:
 
 VTOL Control & Airspeed Fault Detection (PX4 Developer Summit 2019)
 
-@[youtube](https://youtu.be/37BIBAzD6fE)
+<lite-youtube videoid="37BIBAzD6fE" title="VTOL control and airspeed fault detection"/>
 
 <!-- 20190704 -->
 
@@ -129,28 +129,28 @@ VTOL Control & Airspeed Fault Detection (PX4 Developer Summit 2019)
 
 [UAV Works VALAQ Patrol Tailsitter](https://www.valaqpatrol.com/valaq_patrol_technical_data/)
 
-@[youtube](https://youtu.be/pWt6uoqpPIw)
+<lite-youtube videoid="pWt6uoqpPIw" title="UAV Works VALAQ"/>
 
 [TBS Caipiroshka](../frames_vtol/vtol_tailsitter_caipiroshka_pixracer.md)
 
-@[youtube](https://www.youtube.com/watch?v=acG0aTuf3f8&vq=hd720)
+<lite-youtube videoid="acG0aTuf3f8" title="PX4 VTOL - Call for Testpilots"/>
 
 ### Tiltrotor
 
 [Convergence Tiltrotor](../frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.md)
 
-@[youtube](https://youtu.be/E61P2f2WPNU)
+<lite-youtube videoid="E61P2f2WPNU" title="E-flite Convergence Autonomous Mission Flight"/>
 
 ### QuadPlane VTOL
 
 [FunCub QuadPlane](../frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.md)
 
-@[youtube](https://www.youtube.com/watch?v=4K8yaa6A0ks&vq=hd720)
+<lite-youtube videoid="4K8yaa6A0ks" title="Fun Cub PX4 VTOL Maiden"/>
 
 [Falcon Vertigo QuadPlane](../frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.md)
 
-@[youtube](https://youtu.be/h7OHTigtU0s)
+<lite-youtube videoid="h7OHTigtU0s" title="PX4 Vtol test"/>
 
 [Ranger QuadPlane](../frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.md)
 
-@[youtube](https://www.youtube.com/watch?v=7tGXkW6d3sA&vq=hd720)
+<lite-youtube videoid="7tGXkW6d3sA" title="PX4 Autopilot - Experimental VTOL with Pixhawk and U-Blox M8N GPS"/>

--- a/en/frames_vtol/standardvtol.md
+++ b/en/frames_vtol/standardvtol.md
@@ -16,14 +16,12 @@ This section contains videos that are specific to Standard VTOL (videos that app
 
 [FunCub QuadPlane](../frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.md)
 
-@[youtube](https://www.youtube.com/watch?v=4K8yaa6A0ks&vq=hd720)
-
+<lite-youtube videoid="4K8yaa6A0ks" title="Fun Cub PX4 VTOL Maiden"/>
 
 [Falcon Vertigo QuadPlane](../frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.md)
 
-@[youtube](https://youtu.be/h7OHTigtU0s)
-
+<lite-youtube videoid="h7OHTigtU0s" title="PX4 Vtol test"/>
 
 [Ranger QuadPlane](../frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.md)
 
-@[youtube](https://www.youtube.com/watch?v=7tGXkW6d3sA&vq=hd720)
+<lite-youtube videoid="7tGXkW6d3sA" title="PX4 Autopilot - Experimental VTOL with Pixhawk and U-Blox M8N GPS"/>

--- a/en/frames_vtol/tailsitter.md
+++ b/en/frames_vtol/tailsitter.md
@@ -69,7 +69,7 @@ This section contains videos that are specific to Tailsitter VTOL (videos that a
 
 [TBS Caipiroshka](../frames_vtol/vtol_tailsitter_caipiroshka_pixracer.md) - Tailsitter takeoff (close up), hover, level flight, transitions.
 
-@[youtube](https://www.youtube.com/watch?v=acG0aTuf3f8&vq=hd720)
+<lite-youtube videoid="acG0aTuf3f8" title="PX4 VTOL - Call for Testpilots"/>
 
 ---
 
@@ -78,18 +78,14 @@ This section contains videos that are specific to Tailsitter VTOL (videos that a
 <!-- provided by slack user xdwgood: https://github.com/PX4/PX4-user_guide/issues/2328#issuecomment-1467234118 -->
 <!-- Update issue https://github.com/PX4/PX4-user_guide/issues/3007 -->
 
-@[youtube](https://youtu.be/gjHj6YsxcZk)
+<lite-youtube videoid="gjHj6YsxcZk" title="PX4 Autopilot Tailsitter"/>
 
 ### Quad
 
-<!--
-[Skypull](https://www.skypull.technology/) Tethered quad tailsitter (promotional video)
-@[youtube](https://youtu.be/6s-Izqb_GVs)
--->
-
 [UAV Works VALAQ Patrol Tailsitter](https://www.valaqpatrol.com/valaq_patrol_technical_data/) - Tailsitter takeoff, transition, landing.
 
-@[youtube](https://youtu.be/pWt6uoqpPIw)
+<lite-youtube videoid="pWt6uoqpPIw" title="UAV Works VALAQ"/>
+
 
 ## Gallery
 

--- a/en/frames_vtol/tiltrotor.md
+++ b/en/frames_vtol/tiltrotor.md
@@ -12,4 +12,4 @@ This section contains videos that are specific to Tiltrotor VTOL (videos that ap
 [Convergence Tiltrotor](../frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.md)
 [OMP Hobby ZMO FPV](../frames_vtol/vtol_tiltrotor_omp_hobby_zmo_fpv.md)
 
-@[youtube](https://youtu.be/E61P2f2WPNU)
+<lite-youtube videoid="E61P2f2WPNU" title="E-flite Convergence Autonomous Mission Flight"/>

--- a/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.md
+++ b/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.md
@@ -293,7 +293,7 @@ After you finish calibration the VTOL is ready to fly.
 
 ## Video
 
-@[youtube](https://youtu.be/h7OHTigtU0s)
+<lite-youtube videoid="h7OHTigtU0s" title="PX4 Vtol test"/>
 
 ## Support
 

--- a/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.md
+++ b/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.md
@@ -77,8 +77,7 @@ After you finish calibration the VTOL is ready to fly.
 
 ## Video
 
-@[youtube](https://youtu.be/4K8yaa6A0ks)
-
+<lite-youtube videoid="4K8yaa6A0ks" title="Fun Cub PX4 VTOL Maiden"/>
 
 ## Support
 

--- a/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.md
+++ b/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.md
@@ -57,13 +57,9 @@ The tools required for the conversion are;
 
 ## Wing conversion
 
-A full build log is provided in the following video.
-
 ::: info
 Please note that the conversion in this build log is performed on a wing that shows damage from a previous conversion. 
 :::
-  
-@[youtube](https://youtu.be/l_ppJ_HhAUQ)
 
 Cut both 800mm square carbon tubes to a length of 570mm and 230mm.
 

--- a/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.md
+++ b/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.md
@@ -8,7 +8,7 @@ These instructions *should* work with the updated vehicle: [TBS Caipirinha 2](ht
 A number of other components have been updated in the parts list too.
 :::
 
-@[youtube](https://www.youtube.com/watch?v=acG0aTuf3f8&vq=hd720)
+<lite-youtube videoid="acG0aTuf3f8" title="PX4 VTOL - Call for Testpilots"/>
 
 ## Parts List
 

--- a/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.md
+++ b/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.md
@@ -8,7 +8,7 @@ The original Horizon Hobby *E-Flite Convergence* frame and [Pixfalcon](../flight
 Alternatives are provided in the [Purchase](#where-to-buy) section.
 :::
 
-@[youtube](https://youtu.be/E61P2f2WPNU)
+<lite-youtube videoid="E61P2f2WPNU" title="E-flite Convergence Autonomous Mission Flight"/>
 
 
 ## Where to Buy

--- a/en/ros2/offboard_control.md
+++ b/en/ros2/offboard_control.md
@@ -203,10 +203,3 @@ void OffboardControl::publish_vehicle_command(uint16_t command, float param1, fl
 [VehicleCommand](../msg_docs/VehicleCommand.md) is one of the simplest and most powerful ways to command PX4, and by subscribing to [VehicleCommandAck](../msg_docs/VehicleCommandAck.md) you can also confirm that setting a particular command was successful.
 The param and command fields map to [MAVLink commands](https://mavlink.io/en/messages/common.html#mav_commands) and their parameter values.
 :::
-
-<!--
-
-## Demo with PX4 SITL and Gazebo Classic
-
-@[youtube](https://youtu.be/Nbc7fzxFlYo)
--->

--- a/en/sensor/optical_flow.md
+++ b/en/sensor/optical_flow.md
@@ -2,7 +2,8 @@
 
 _Optical Flow_ uses a downward facing camera and a downward facing distance sensor for velocity estimation.
 
-@[youtube](https://youtu.be/aPQKgUof3Pc)
+<lite-youtube videoid="aPQKgUof3Pc" title="ARK Flow with PX4 Optical Flow Position Hold"/>
+
 _Video: PX4 holding position using the ARK Flow sensor for velocity estimation (in [Position Mode](../flight_modes_mc/position.md))._
 
 <!-- ARK Flow with PX4 Optical Flow Position Hold: 20210605 -->

--- a/en/sim_airsim/index.md
+++ b/en/sim_airsim/index.md
@@ -10,7 +10,7 @@ See [Toolchain Installation](../dev_setup/dev_env.md) for information about the 
 [AirSim](https://microsoft.github.io/AirSim/) is a open-source, cross platform simulator for drones, built on _Unreal Engine_.
 It provides physically and visually realistic simulations of Pixhawk/PX4 using either Hardware-In-The-Loop (HITL) or Software-In-The-Loop (SITL).
 
-@[youtube](https://youtu.be/-WfTr1-OBGQ)
+<lite-youtube videoid="-WfTr1-OBGQ" title="AirSim Demo"/>
 
 <!-- datestamp:video:youtube:20170216:AirSim Demo -->
 
@@ -22,7 +22,7 @@ It provides physically and visually realistic simulations of Pixhawk/PX4 using e
 
 #### AirSim with PX4 on WSL 2
 
-@[youtube](https://youtu.be/DiqgsWIOoW4)
+<lite-youtube videoid="DiqgsWIOoW4" title="AirSim with PX4 on WSL 2"/>
 
 <!-- datestamp:video:youtube:20210401:AirSim with PX4 on WSL 2 -->
 
@@ -33,13 +33,13 @@ This limitation does not apply for AirSim because its UI is run natively in Wind
 
 #### Microsoft AirSim: Applications to Research and Industry (PX4 Developer Summit Virtual 2020)
 
-@[youtube](https://youtu.be/-YMiKaJYl44)
+<lite-youtube videoid="-YMiKaJYl44" title="Microsoft AirSim: Applications to Research and Industry"/>
 
 <!-- datestamp:video:youtube:20200716:Microsoft AirSim: Applications to Research and Industry — PX4 Developer Summit Virtual 2020 -->
 
 #### Autonomous Drone Inspections using AirSim and PX4 (PX4 Developer Summit Virtual 2020)
 
-@[youtube](https://youtu.be/JDx0MPTlhrg)
+<lite-youtube videoid="JDx0MPTlhrg" title="Autonomous Drone Inspections using AirSim and PX4"/>
 
 <!-- datestamp:video:youtube:20200716:Autonomous Drone Inspections using AirSim and PX4 — PX4 Developer Summit Virtual 2020 -->
 

--- a/en/sim_flightgear/index.md
+++ b/en/sim_flightgear/index.md
@@ -15,7 +15,7 @@ For information about multi-vehicle use see: [Multi-Vehicle Simulation with Flig
 
 **Supported Vehicles:** Autogyro, Plane, Rover.
 
-@[youtube](https://youtu.be/iqdcN5Gj4wI)
+<lite-youtube videoid="iqdcN5Gj4wI" title="[ThunderFly] PX4 SITL with Flightgear, Rascal110 - electric version"/>
 
 [![Mermaid Graph ](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggTFI7XG4gIEZsaWdodEdlYXIgLS0-IEZsaWdodEdlYXItQnJpZGdlO1xuICBGbGlnaHRHZWFyLUJyaWRnZSAtLT4gTUFWTGluaztcbiAgTUFWTGluayAtLT4gUFg0X1NJVEw7XG5cdCIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2V9)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggTFI7XG4gIEZsaWdodEdlYXIgLS0-IEZsaWdodEdlYXItQnJpZGdlO1xuICBGbGlnaHRHZWFyLUJyaWRnZSAtLT4gTUFWTGluaztcbiAgTUFWTGluayAtLT4gUFg0X1NJVEw7XG5cdCIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2V9)
 

--- a/en/sim_gazebo_classic/index.md
+++ b/en/sim_gazebo_classic/index.md
@@ -11,7 +11,7 @@ Gazebo Classic can also be used with [HITL](../simulation/hitl.md) and for [mult
 
 **Supported Vehicles:** Quad ([Iris](../airframes/airframe_reference.md#copter_quadrotor_x_generic_quadcopter), Hex (Typhoon H480), [Generic Standard VTOL (QuadPlane)](../airframes/airframe_reference.md#vtol_standard_vtol_generic_standard_vtol), Tailsitter, Plane, Rover, Submarine/UUV.
 
-@[youtube](https://www.youtube.com/watch?v=qfFF9-0k4KA&vq=hd720)
+<lite-youtube videoid="qfFF9-0k4KA" title="PX4 Flight Stack ROS 3D Software in the Loop Simulation (SITL)"/>
 
 [![Mermaid Graph: Gazebo plugin](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggTFI7XG4gIEdhemViby0tPlBsdWdpbjtcbiAgUGx1Z2luLS0-TUFWTGluaztcbiAgTUFWTGluay0tPlNJVEw7IiwibWVybWFpZCI6eyJ0aGVtZSI6ImRlZmF1bHQifSwidXBkYXRlRWRpdG9yIjpmYWxzZX0)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggTFI7XG4gIEdhemViby0tPlBsdWdpbjtcbiAgUGx1Z2luLS0-TUFWTGluaztcbiAgTUFWTGluay0tPlNJVEw7IiwibWVybWFpZCI6eyJ0aGVtZSI6ImRlZmF1bHQifSwidXBkYXRlRWRpdG9yIjpmYWxzZX0)
 
@@ -328,7 +328,7 @@ make px4_sitl gazebo-classic_rover__sonoma_raceway
 
 The video below shows that the location of the environment is aligned with the world:
 
-@[youtube](https://youtu.be/-a2WWLni5do)
+<lite-youtube videoid="-a2WWLni5do" title="Driving a simulated PX4 Rover in the Sonoma Raceway"/>
 
 ## Starting Gazebo and PX4 Separately
 

--- a/en/sim_gazebo_classic/multi_vehicle_simulation.md
+++ b/en/sim_gazebo_classic/multi_vehicle_simulation.md
@@ -41,15 +41,15 @@ The `MAV_SYS_ID` is allocated in the SITL rcS: [init.d-posix/rcS](https://github
 
 ### Video: Multiple Multicopter (Iris)
 
-@[youtube](https://youtu.be/Mskx_WxzeCk)
+<lite-youtube videoid="Mskx_WxzeCk" title="Multiple vehicle simulation in SITL gazebo"/>
 
 ### Video: Multiple Plane
 
-@[youtube](https://youtu.be/aEzFKPMEfjc)
+<lite-youtube videoid="aEzFKPMEfjc" title="PX4 Multivehicle SITL gazebo for fixedwing"/>
 
 ### Video: Multiple VTOL
 
-@[youtube](https://youtu.be/lAjjTFFZebI)
+<lite-youtube videoid="lAjjTFFZebI" title="PX4 Multivehicle SITL gazebo for VTOL"/>
 
 ### Build and Test (XRCE-DDS)
 

--- a/en/sim_gazebo_gz/index.md
+++ b/en/sim_gazebo_gz/index.md
@@ -10,7 +10,7 @@ It supersedes the older [Gazebo Classic](../sim_gazebo_classic/index.md) simulat
 
 **Supported Vehicles:** Quadrotor, Plane, VTOL
 
-@[youtube](https://youtu.be/eRzdGD2vgkU)
+<lite-youtube videoid="eRzdGD2vgkU" title="PX4 SITL Ignition Gazebo Tunnel Environment"/>
 
 ::: info
 See [Simulation](../simulation/index.md) for general information about simulators, the simulation environment, and simulation configuration (e.g. supported vehicles).

--- a/en/sim_jsbsim/index.md
+++ b/en/sim_jsbsim/index.md
@@ -13,7 +13,7 @@ Rotational earth effects are also modeled into the dynamics.
 
 **Supported Vehicles:** Plane, Quadrotor, Hexarotor
 
-@[youtube](https://youtu.be/y5azVNmIVyw)
+<lite-youtube videoid="y5azVNmIVyw" title="JSBSim with APX4 Software-In-The-Loop Simulation"/>
 
 ::: info
 See [Simulation](../simulation/index.md) for general information about simulators, the simulation environment, and simulation configuration (e.g. supported vehicles).

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -174,7 +174,7 @@ The dynamic models for the various vehicles are:
 
 ## Video
 
-@[youtube](https://youtu.be/PzIpSCRD8Jo)
+<lite-youtube videoid="PzIpSCRD8Jo" title="SIH FW demo"/>
 
 ## Credits
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@red-asuka/vitepress-plugin-tabs": "^0.0.3",
-    "markdown-it-block-embed": "^0.0.3",
+    "lite-youtube-embed": "^0.3.2",
     "markdown-it-mathjax3": "^4.3.2",
     "medium-zoom": "^1.1.0",
     "vitepress": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,6 +842,11 @@ linkify-it@^4.0.1:
   dependencies:
     uc.micro "^1.0.1"
 
+lite-youtube-embed@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.3.2.tgz"
+  integrity sha512-b1dgKyF4PHhinonmr3PB172Nj0qQgA/7DE9EmeIXHR1ksnFEC2olWjNJyJGdsN2cleKHRjjsmrziKlwXtPlmLQ==
+
 magic-string@^0.30.10:
   version "0.30.10"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz"
@@ -853,11 +858,6 @@ mark.js@8.11.1:
   version "8.11.1"
   resolved "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz"
   integrity sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==
-
-markdown-it-block-embed@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/markdown-it-block-embed/-/markdown-it-block-embed-0.0.3.tgz"
-  integrity sha512-coWuC/uZY6Z1Gp3wthhJo5yjkG3/gHErNF/emaiEvD98fKzEHNP6GCYGfJfk5o0n31xiaYjbDgef+XtabKOZzA==
 
 markdown-it-container@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Updates the docs to use https://www.npmjs.com/package/lite-youtube-embed for youtube video playing.

I do prefer a markdown syntax parser because the old syntax `@[youtube](theurl)` provided a link to the video on github, or if the syntax not understood as video. However what is most important here is a rock solid video performance that will run on all main browsers and be supported going forward.

