### PR TITLE
Fix broken links to ROS2 index

### DIFF
--- a/en/ros2/index.md
+++ b/en/ros2/index.md
@@ -1,6 +1,6 @@
 # ROS 2
 
-[ROS 2](https://index.ros.org/doc/ros2/) is the newest version of [ROS](http://www.ros.org/) (Robot Operating System), a general purpose robotics library that can be used with the PX4 Autopilot to create powerful drone applications.
+[ROS 2](https://docs.ros.org/en/humble/#) is the newest version of [ROS](http://www.ros.org/) (Robot Operating System), a general purpose robotics library that can be used with the PX4 Autopilot to create powerful drone applications.
 It captures most of the learnings and features of [ROS 1](../ros/ros1.md), improving a number of flaws of the earlier version.
 
 :::warning Tip

--- a/en/ros2/user_guide.md
+++ b/en/ros2/user_guide.md
@@ -124,7 +124,7 @@ To install ROS 2 and its dependencies:
    ::: tab foxy
    To install ROS 2 "Foxy" on Ubuntu 20.04:
    
-   -  Follow the official installation guide: [Install ROS 2 Foxy](https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Install-Debians/).
+   -  Follow the official installation guide: [Install ROS 2 Foxy](https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html).
 
    You can install _either_ the desktop (`ros-foxy-desktop`) _or_ bare-bones versions (`ros-foxy-ros-base`), *and* the development tools (`ros-dev-tools`).
    :::


### PR DESCRIPTION
Fixes #3303

Note that this fixes the two cases in the `/en` tree. All the others will be fixed automatically when the translations round-trip through crowdin.