### PR TITLE
Fix broken links to GZ default models

### DIFF
--- a/en/sim_gazebo_gz/index.md
+++ b/en/sim_gazebo_gz/index.md
@@ -215,7 +215,7 @@ where `ARGS` is a list of environment variables including:
 
 - `PX4_GZ_WORLD`:
   Sets the Gazebo world file for a new simulation.
-  If it is not given, then [default](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/gz/worlds/default.sdf) is used.
+  If it is not given, then [default](https://github.com/PX4/PX4-gazebo-models/blob/main/worlds/default.sdf) is used.
 
   - This variable is ignored if an existing simulation is already running.
   - This value should be [specified for the selected airframe](#adding-new-worlds-and-models) but may be overridden using this argument.

--- a/en/sim_gazebo_gz/index.md
+++ b/en/sim_gazebo_gz/index.md
@@ -295,7 +295,7 @@ To add a new model:
    ```
 
    - `PX4_SIMULATOR=${PX4_SIMULATOR:=gz}` sets the default simulator (Gz) for that specific airframe.
-   - `PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}` sets the [default world](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/gz/worlds/default.sdf) for that specific airframe.
+   - `PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}` sets the [default world](https://github.com/PX4/PX4-gazebo-models/blob/main/worlds/default.sdf) for that specific airframe.
 
    - Setting the default value of `PX4_SIM_MODEL` lets you start the simulation with just:
 


### PR DESCRIPTION
This replaces #3317 which had merge commits that I couldn't fix, and fixes another example in same file