### PR TITLE
Group the battery related failsafes

### DIFF
--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -47,27 +47,28 @@ This includes the most important failsafe settings (battery, RC loss etc.) and t
 
 ### Low Battery Failsafe
 
-The low battery failsafe is triggered when the battery capacity drops below one (or more warning) level values.
+The low battery failsafe is triggered when the battery capacity drops below battery failafe level values.
+You can configure both the levels and the failsafe actions at each level in QGroundControl.
 
 ![Safety - Battery (QGC)](../../assets/qgc/setup/safety/safety_battery.png)
 
-The most common configuration is to set the values and action as above (with `Warn > Failsafe > Emergency`).
-With this configuration the failsafe will trigger warning, then return, and finally landing if capacity drops below the respective levels.
+The most common configuration is to set the values and action as above (with `Warn > Failsafe > Emergency`), and to set the [Failsafe Action](#COM_LOW_BAT_ACT) to warn at "warn level", trigger Return mode at "Failsafe level", and land immediately at "Emergency level".
 
-It is also possible to set the _Failsafe Action_ to warn, return, or land when the [Battery Failsafe Level](#BAT_CRIT_THR) failsafe level is reached.
+There are several other battery related failsafe mechanisms that may be configured using parameters:
+
+- The "remaining flight time for safe return" failsafe ([COM_FLTT_LOW_ACT](#COM_FLTT_LOW_ACT)) is engaged when PX4 estimates that the vehicle has just enough battery remaining for a return mode landing.
+  You can configure this to ignore the failsafe, warn, or engage Return mode.
+- The "minimum battery" for arming parameter ([COM_ARM_BAT_MIN](#COM_ARM_BAT_MIN)) prevents arming in the first place if the battery level is below the specified value.
 
 The settings and underlying parameters are shown below.
 
-| Setting                                         | Parameter                                                                    | Description                                                                                                                                                               |
-| ----------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Failsafe Action                                 | [COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT) | Warn, Return, or Land based when capacity drops below [Battery Failsafe Level](#BAT_CRIT_THR), OR Warn, then return, then land based on each of the level settings below. |
-| Battery Warn Level                              | [BAT_LOW_THR](../advanced_config/parameter_reference.md#BAT_LOW_THR)         | Percentage capacity for warnings (or other actions).                                                                                                                      |
-| <a id="BAT_CRIT_THR"></a>Battery Failsafe Level | [BAT_CRIT_THR](../advanced_config/parameter_reference.md#BAT_CRIT_THR)       | Percentage capacity for Return action (or other actions if a single action selected).                                                                                     |
-| Battery Emergency Level                         | [BAT_EMERGEN_THR](../advanced_config/parameter_reference.md#BAT_EMERGEN_THR) | Percentage capacity for triggering Land (immediately) action.                                                                                                             |
-
-::: tip
-There is also a configuration parameter [COM_ARM_BAT_MIN](#COM_ARM_BAT_MIN) that allows you to prevents arming in the first place if the battery level is too low.
-:::
+| Setting                                                              | Parameter                                                                      | Description                                                                                                                     |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| <a id="COM_LOW_BAT_ACT"></a>Failsafe Action                          | [COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT)   | Warn, Return, or Land based when capacity drops below the trigger levels.                                                       |
+| <a id="BAT_LOW_THR"></a>Battery Warn Level                           | [BAT_LOW_THR](../advanced_config/parameter_reference.md#BAT_LOW_THR)           | Percentage capacity for warnings (or other actions).                                                                            |
+| <a id="BAT_CRIT_THR"></a>Battery Failsafe Level                      | [BAT_CRIT_THR](../advanced_config/parameter_reference.md#BAT_CRIT_THR)         | Percentage capacity for Return action (or other actions if a single action selected).                                           |
+| <a id="BAT_EMERGEN_THR"></a>Battery Emergency Level                  | [BAT_EMERGEN_THR](../advanced_config/parameter_reference.md#BAT_EMERGEN_THR)   | Percentage capacity for triggering Land (immediately) action.                                                                   |
+| <a id="COM_FLTT_LOW_ACT"></a> Low flight time for safe return action | [COM_FLTT_LOW_ACT](../advanced_config/parameter_reference.md#COM_FLTT_LOW_ACT) | Action when return mode can only just reach safety with remaining battery. `0`: None, `1`: Warning, `3`: Return mode (default). |
 
 ### Manual Control Loss failsafe
 
@@ -227,13 +228,9 @@ The relevant parameters are shown below:
 
 The maximum flight time failsafe ([COM_FLT_TIME_MAX](#COM_FLT_TIME_MAX)) allows you to set a maximum flight time after takeoff, at which the vehicle will automatically enter return mode (it will also "warn" at 90% of this time). This is disabled by default.
 
-The "remaining flight time for safe return" failsafe ([COM_FLTT_LOW_ACT](#COM_FLTT_LOW_ACT)) is engaged when PX4 estimates that the vehicle has just enough flight time for a return mode landing.
-You can configure this to ignore the failsafe, warn, or engage Return mode.
-
-| Parameter                                                                                                   | Description                                                                                               |
-| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| <a id="COM_FLT_TIME_MAX"></a>[COM_FLT_TIME_MAX](../advanced_config/parameter_reference.md#COM_FLT_TIME_MAX) | Maximum allowed flight time before Return mode will be engaged, in seconds. `-1`: Disabled (default).     |
-| <a id="COM_FLTT_LOW_ACT"></a>[COM_FLTT_LOW_ACT](../advanced_config/parameter_reference.md#COM_FLTT_LOW_ACT) | Remaining flight time for safe return mode failsafe. `0`: None, `1`: Warning, `3`: Return mode (default). |
+| Parameter                                                                                                   | Description                                                                                           |
+| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| <a id="COM_FLT_TIME_MAX"></a>[COM_FLT_TIME_MAX](../advanced_config/parameter_reference.md#COM_FLT_TIME_MAX) | Maximum allowed flight time before Return mode will be engaged, in seconds. `-1`: Disabled (default). |
 
 ### Mission Feasibility Checks
 

--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -4,8 +4,15 @@ PX4 has a number of safety features to protect and recover your vehicle if somet
 
 - _Failsafes_ allow you to specify areas and conditions under which you can safely fly, and the [action](#failsafe-actions) that will be performed if a failsafe is triggered (for example, landing, holding position, or returning to a specified point).
   The most important failsafe settings are configured in the _QGroundControl_ [Safety Setup](#qgroundcontrol-safety-setup) page.
-  Others must be configured via [parameters](#other-failsafe-settings).
+  Others must be configured via [parameters](../advanced_config/parameters.md).
 - [Safety switches](#emergency-switches) on the remote control can be used to immediately stop motors or return the vehicle in the event of a problem.
+
+## QGroundControl Safety Setup
+
+The _QGroundControl_ Safety Setup page is accessed by clicking the _QGroundControl_ icon, **Vehicle Setup**, and then **Safety** in the sidebar.
+This includes many of the most important failsafe settings (battery, RC loss etc.) and the settings for the triggered actions _Return_ and _Land_.
+
+![Safety Setup(QGC)](../../assets/qgc/setup/safety/safety_setup.png)
 
 ## Failsafe Actions
 
@@ -38,14 +45,37 @@ For example if both RC and GPS are lost, and manual control loss is set to [Retu
 The exact behavior when different failsafes are triggered can be tested with the [Failsafe State Machine Simulation](safety_simulation.md).
 :::
 
-## QGroundControl Safety Setup
+### Return Mode Settings
 
-The _QGroundControl_ Safety Setup page is accessed by clicking the _QGroundControl_ icon, **Vehicle Setup**, and then **Safety** in the sidebar.
-This includes the most important failsafe settings (battery, RC loss etc.) and the settings for the triggered actions _Return_ and _Land_.
+<!-- Propose replace section by a summary and links - return mode is complicated -->
 
-![Safety Setup(QGC)](../../assets/qgc/setup/safety/safety_setup.png)
+_Return_ is a common [failsafe action](#failsafe-actions) that engages [Return mode](../flight_modes/return.md) to return the vehicle to the home position.
+The default settings for each vehicle are usually suitable, though for fixed wing vehicles you will usually need to define a mission landing.
 
-### Low Battery Failsafe
+::: tip
+If you want to change the configuration you should carefully read the [Return mode](../flight_modes/return.md) documentation _for your vehicle type_ to understand the options.
+:::
+
+QGC allows users to set some aspects of the return mode and landing behaviour, such as the altitude to fly back, and the loiter time if you need to deploy landing gear.
+
+![Safety - Return Home Settings (QGC)](../../assets/qgc/setup/safety/safety_return_home.png)
+
+### Land Mode Settings
+
+_Land at the current position_ is a common [failsafe action](#failsafe-actions) (in particular for multicopters), that engages [Land Mode](../flight_modes_mc/land.md).
+The default settings for each vehicle are usually suitable.
+
+::: tip
+If you want to change the configuration you should carefully read the [Land mode](../flight_modes_fw/land.md) documentation _for your vehicle type_ to understand the options.
+:::
+
+QGC allows users to set some aspects of the landing behaviour, such as the time to disarm after landing and the descent rate (for multicopters only).
+
+![Safety - Land Mode Settings (QGC)](../../assets/qgc/setup/safety/safety_land_mode.png)
+
+## Battery Failsafes
+
+### Battery level failsafe
 
 The low battery failsafe is triggered when the battery capacity drops below battery failafe level values.
 You can configure both the levels and the failsafe actions at each level in QGroundControl.
@@ -54,23 +84,32 @@ You can configure both the levels and the failsafe actions at each level in QGro
 
 The most common configuration is to set the values and action as above (with `Warn > Failsafe > Emergency`), and to set the [Failsafe Action](#COM_LOW_BAT_ACT) to warn at "warn level", trigger Return mode at "Failsafe level", and land immediately at "Emergency level".
 
-There are several other battery related failsafe mechanisms that may be configured using parameters:
+The settings and underlying parameters are shown below.
+
+| Setting                                             | Parameter                                                                    | Description                                                                           |
+| --------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| <a id="COM_LOW_BAT_ACT"></a>Failsafe Action         | [COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT) | Warn, Return, or Land based when capacity drops below the trigger levels.             |
+| <a id="BAT_LOW_THR"></a>Battery Warn Level          | [BAT_LOW_THR](../advanced_config/parameter_reference.md#BAT_LOW_THR)         | Percentage capacity for warnings (or other actions).                                  |
+| <a id="BAT_CRIT_THR"></a>Battery Failsafe Level     | [BAT_CRIT_THR](../advanced_config/parameter_reference.md#BAT_CRIT_THR)       | Percentage capacity for Return action (or other actions if a single action selected). |
+| <a id="BAT_EMERGEN_THR"></a>Battery Emergency Level | [BAT_EMERGEN_THR](../advanced_config/parameter_reference.md#BAT_EMERGEN_THR) | Percentage capacity for triggering Land (immediately) action.                         |
+
+### Flight Time Failsafes
+
+There are several other "battery related" failsafe mechanisms that may be configured using parameters:
 
 - The "remaining flight time for safe return" failsafe ([COM_FLTT_LOW_ACT](#COM_FLTT_LOW_ACT)) is engaged when PX4 estimates that the vehicle has just enough battery remaining for a return mode landing.
   You can configure this to ignore the failsafe, warn, or engage Return mode.
+- The "maximum flight time failsafe" ([COM_FLT_TIME_MAX](#COM_FLT_TIME_MAX)) allows you to set a maximum flight time after takeoff, at which the vehicle will automatically enter return mode (it will also "warn" at 90% of this time). This is like a "hard coded" estimate of the total flight time in a battery. The feature is disabled by default.
 - The "minimum battery" for arming parameter ([COM_ARM_BAT_MIN](#COM_ARM_BAT_MIN)) prevents arming in the first place if the battery level is below the specified value.
 
 The settings and underlying parameters are shown below.
 
 | Setting                                                              | Parameter                                                                      | Description                                                                                                                     |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="COM_LOW_BAT_ACT"></a>Failsafe Action                          | [COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT)   | Warn, Return, or Land based when capacity drops below the trigger levels.                                                       |
-| <a id="BAT_LOW_THR"></a>Battery Warn Level                           | [BAT_LOW_THR](../advanced_config/parameter_reference.md#BAT_LOW_THR)           | Percentage capacity for warnings (or other actions).                                                                            |
-| <a id="BAT_CRIT_THR"></a>Battery Failsafe Level                      | [BAT_CRIT_THR](../advanced_config/parameter_reference.md#BAT_CRIT_THR)         | Percentage capacity for Return action (or other actions if a single action selected).                                           |
-| <a id="BAT_EMERGEN_THR"></a>Battery Emergency Level                  | [BAT_EMERGEN_THR](../advanced_config/parameter_reference.md#BAT_EMERGEN_THR)   | Percentage capacity for triggering Land (immediately) action.                                                                   |
 | <a id="COM_FLTT_LOW_ACT"></a> Low flight time for safe return action | [COM_FLTT_LOW_ACT](../advanced_config/parameter_reference.md#COM_FLTT_LOW_ACT) | Action when return mode can only just reach safety with remaining battery. `0`: None, `1`: Warning, `3`: Return mode (default). |
+| <a id="COM_FLT_TIME_MAX"></a> Maximum flight time failsafe level     | [COM_FLT_TIME_MAX](../advanced_config/parameter_reference.md#COM_FLT_TIME_MAX) | Maximum allowed flight time before Return mode will be engaged, in seconds. `-1`: Disabled (default).                           |
 
-### Manual Control Loss failsafe
+## Manual Control Loss Failsafe
 
 The manual control loss failsafe may be triggered if the connection to the [RC transmitter](../getting_started/rc_transmitter_receiver.md) or [joystick](../config/joystick.md) is lost, and there is no fallback.
 If using an [RC transmitter](../getting_started/rc_transmitter_receiver.md) this is triggered if the RC [transmitter link is lost](../getting_started/rc_transmitter_receiver.md#set-signal-loss-behaviour).
@@ -94,7 +133,7 @@ Additional (and underlying) parameter settings are shown below.
 | <a id="NAV_RCL_ACT"></a>[NAV_RCL_ACT](../advanced_config/parameter_reference.md#NAV_RCL_ACT)          | Failsafe Action             | Disabled, Loiter, Return, Land, Disarm, Terminate.                                                                                                                                                                                                                                                                                                                                                       |
 | <a id="COM_RCL_EXCEPT"></a>[COM_RCL_EXCEPT](../advanced_config/parameter_reference.md#COM_RCL_EXCEPT) | RC Loss Exceptions          | Set the modes in which manual control loss is ignored: Mission, Hold, Offboard.                                                                                                                                                                                                                                                                                                                          |
 
-### Data Link Loss Failsafe
+## Data Link Loss Failsafe
 
 The Data Link Loss failsafe is triggered if a telemetry link (connection to ground station) is lost.
 
@@ -107,7 +146,7 @@ The settings and underlying parameters are shown below.
 | Data Link Loss Timeout | [COM_DL_LOSS_T](../advanced_config/parameter_reference.md#COM_DL_LOSS_T) | Amount of time after losing the data connection before the failsafe will trigger. |
 | Failsafe Action        | [NAV_DLL_ACT](../advanced_config/parameter_reference.md#NAV_DLL_ACT)     | Disabled, Hold mode, Return mode, Land mode, Disarm, Terminate.                   |
 
-### Geofence Failsafe
+## Geofence Failsafe
 
 The _Geofence Failsafe_ is triggered when the drone breaches a "virtual" perimeter.
 In its simplest form, the perimeter is set up as a cylinder centered around the home position.
@@ -140,52 +179,9 @@ The following settings also apply, but are not displayed in the QGC UI.
 | <a id="GF_PREDICT"></a>Preemptive geofence triggering              | [GF_PREDICT](../advanced_config/parameter_reference.md#GF_PREDICT)           | (Experimental) Trigger geofence if current motion of the vehicle is predicted to trigger the breach (rather than late triggering after the breach). |
 | <a id="CBRK_FLIGHTTERM"></a>Circuit breaker for flight termination | [CBRK_FLIGHTTERM](../advanced_config/parameter_reference.md#CBRK_FLIGHTTERM) | Enables/Disables flight termination action (disabled by default).                                                                                   |
 
-### Return Mode Settings
+## Position (GNSS) Loss Failsafe
 
-<!-- Propose replace section by a summary and links - return mode is complicated -->
-
-_Return_ is a common [failsafe action](#failsafe-actions) that engages [Return mode](../flight_modes/return.md) to return the vehicle to the home position.
-This section shows how to set the land/loiter behaviour after returning.
-
-![Safety - Return Home Settings (QGC)](../../assets/qgc/setup/safety/safety_return_home.png)
-
-The settings and underlying parameters are shown below:
-
-| Setting                                      | Parameter                                                                    | Description                                                                                            |
-| -------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| <a id="RTL_RETURN_ALT"></a>Climb to altitude | [RTL_RETURN_ALT](../advanced_config/parameter_reference.md#RTL_RETURN_ALT)   | Vehicle ascend to this minimum height (if below it) for the return flight.                             |
-| Return behaviour                             |                                                                              | Choice list of _Return then_: Land, Loiter and do not land, or Loiter and land after a specified time. |
-| <a id="RTL_DESCEND_ALT"></a>Loiter Altitude  | [RTL_DESCEND_ALT](../advanced_config/parameter_reference.md#RTL_DESCEND_ALT) | If return with loiter is selected you can also specify the altitude at which the vehicle hold.         |
-| <a id="RTL_LAND_DELAY"></a>Loiter Time       | [RTL_LAND_DELAY](../advanced_config/parameter_reference.md#RTL_LAND_DELAY)   | If return with loiter then land is selected you can also specify how long the vehicle will hold.       |
-
-::: info
-The return behaviour is defined by [RTL_LAND_DELAY](../advanced_config/parameter_reference.md#RTL_LAND_DELAY).
-If negative the vehicle will land immediately.
-Additional information can be found in [Return mode](../flight_modes/return.md).
-:::
-
-### Land Mode Settings
-
-_Land at the current position_ is a common [failsafe action](#failsafe-actions) (in particular for multicopters), that engages [Land Mode](../flight_modes_mc/land.md).
-This section shows how to control when and if the vehicle automatically disarms after landing.
-For Multicopters (only) you can additionally set the descent rate.
-
-![Safety - Land Mode Settings (QGC)](../../assets/qgc/setup/safety/safety_land_mode.png)
-
-The settings and underlying parameters are shown below:
-
-| Setting                        | Parameter                                                                    | Description                                                                                                                          |
-| ------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| Disarm After                   | [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) | Select checkbox to specify that the vehicle will disarm after landing. The value must be non-zero but can be a fraction of a second. |
-| Landing Descent Rate (MC only) | [MPC_LAND_SPEED](../advanced_config/parameter_reference.md#MPC_LAND_SPEED)   | Rate of descent.                                                                                                                     |
-
-## Other Failsafe Settings
-
-This section contains information about failsafe settings that cannot be configured through the _QGroundControl_ [Safety Setup](#qgroundcontrol-safety-setup) page.
-
-### Position (GPS) Loss Failsafe
-
-The _Position Loss Failsafe_ is triggered if the quality of the PX4 position estimate falls below acceptable levels (this might be caused by GPS loss) while in a mode that requires an acceptable position estimate.
+The _Position Loss Failsafe_ is triggered if the quality of the PX4 global position estimate falls below acceptable levels (this might be caused by GPS loss) while in a mode that requires an acceptable position estimate.
 
 The failure action is controlled by [COM_POSCTL_NAVL](../advanced_config/parameter_reference.md#COM_POSCTL_NAVL), based on whether RC control is assumed to be available (and altitude information):
 
@@ -212,9 +208,9 @@ Parameters that only affect Fixed-wing vehicles:
 | <a id="FW_GPSF_LT"></a>[FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT) | Loiter time (waiting for GPS recovery before it goes into land or flight termination). Set to 0 to disable. |
 | <a id="FW_GPSF_R"></a>[FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)    | Fixed roll/bank angle while circling.                                                                       |
 
-### Offboard Loss Failsafe
+## Offboard Loss Failsafe
 
-The _Offboard Loss Failsafe_ is triggered if the offboard link is lost while under Offboard control.
+The _Offboard Loss Failsafe_ is triggered if the offboard link is lost while under [Offboard control](../flight_modes/offboard.md).
 Different failsafe behaviour can be specified based on whether or not there is also an RC connection available.
 
 The relevant parameters are shown below:
@@ -224,22 +220,7 @@ The relevant parameters are shown below:
 | [COM_OF_LOSS_T](../advanced_config/parameter_reference.md#COM_OF_LOSS_T)   | Delay after loss of offboard connection before the failsafe is triggered.                                         |
 | [COM_OBL_RC_ACT](../advanced_config/parameter_reference.md#COM_OBL_RC_ACT) | Failsafe action if RC is available: Position mode, Altitude mode, Manual mode, Return mode, Land mode, Hold mode. |
 
-### Flight Time Failsafe
-
-The maximum flight time failsafe ([COM_FLT_TIME_MAX](#COM_FLT_TIME_MAX)) allows you to set a maximum flight time after takeoff, at which the vehicle will automatically enter return mode (it will also "warn" at 90% of this time). This is disabled by default.
-
-| Parameter                                                                                                   | Description                                                                                           |
-| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| <a id="COM_FLT_TIME_MAX"></a>[COM_FLT_TIME_MAX](../advanced_config/parameter_reference.md#COM_FLT_TIME_MAX) | Maximum allowed flight time before Return mode will be engaged, in seconds. `-1`: Disabled (default). |
-
-### Mission Feasibility Checks
-
-A number of checks are run to ensure that a mission can only be started if it is _feasible_.
-For example, the checks ensures that the first waypoint isn't too far away, and that the mission flight path doesn't conflict with any geofences.
-
-As these are not strictly speaking "failsafes" they are documented in [Mission Mode (FW) > Mission Feasibility Checks](../flight_modes_fw/mission.md#mission-feasibility-checks) and [Mission Mode (MC) > Mission Feasibility Checks](../flight_modes_mc/mission.md#mission-feasibility-checks).
-
-### Traffic Avoidance Failsafe
+## Traffic Avoidance Failsafe
 
 The Traffic Avoidance Failsafe allows PX4 to respond to transponder data (e.g. from [ADSB transponders](../advanced_features/traffic_avoidance_adsb.md)) during missions.
 
@@ -249,7 +230,7 @@ The relevant parameters are shown below:
 | ---------------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | [NAV_TRAFF_AVOID](../advanced_config/parameter_reference.md#NAV_TRAFF_AVOID) | Set the failsafe action: Disabled, Warn, Return mode, Land mode. |
 
-### Quad-chute Failsafe
+## Quad-chute Failsafe
 
 Failsafe for when a VTOL vehicle can no longer fly in fixed-wing mode, perhaps due to the failure of a pusher motor, airspeed sensor, or control surface.
 If the failsafe is triggered, the vehicle will immediately switch to multicopter mode and execute the action defined in parameter [COM_QC_ACT](#COM_QC_ACT).
@@ -270,7 +251,7 @@ The parameters that control when the quad-chute will trigger are listed in the t
 | <a id="VT_FW_QC_R"></a>[VT_FW_QC_R](../advanced_config/parameter_reference.md#VT_FW_QC_R)                   | Absolute roll threshold for quad-chute triggering in FW mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | <a id="VT_FW_QC_P"></a>[VT_FW_QC_P](../advanced_config/parameter_reference.md#VT_FW_QC_P)                   | Absolute pitch threshold for quad-chute triggering in FW mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 
-### High Wind Failsafe
+## High Wind Failsafe
 
 The high wind failsafe can trigger a warning and/or other mode change when the wind speed exceeds the warning and maximum wind-speed threshhold values.
 The relevant parameters are listed in the table below.
@@ -324,6 +305,13 @@ One example of an ATS device is the [FruityChutes Sentinel Automatic Trigger Sys
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | <a id="FD_EXT_ATS_EN"></a>[FD_EXT_ATS_EN](../advanced_config/parameter_reference.md#FD_EXT_ATS_EN)       | Enable PWM input on AUX5 or MAIN5 (depending on board) for engaging failsafe from an external automatic trigger system (ATS). Default: Disabled. |
 | <a id="FD_EXT_ATS_TRIG"></a>[FD_EXT_ATS_TRIG](../advanced_config/parameter_reference.md#FD_EXT_ATS_TRIG) | The PWM threshold from external automatic trigger system for engaging failsafe. Default: 1900 ms.                                                |
+
+## Mission Feasibility Checks
+
+A number of checks are run to ensure that a mission can only be started if it is _feasible_.
+For example, the checks ensures that the first waypoint isn't too far away, and that the mission flight path doesn't conflict with any geofences.
+
+As these are not strictly speaking "failsafes" they are documented in [Mission Mode (FW) > Mission Feasibility Checks](../flight_modes_fw/mission.md#mission-feasibility-checks) and [Mission Mode (MC) > Mission Feasibility Checks](../flight_modes_mc/mission.md#mission-feasibility-checks).
 
 ## Emergency Switches
 

--- a/en/flight_modes_mc/position.md
+++ b/en/flight_modes_mc/position.md
@@ -79,7 +79,7 @@ All the parameters in the [Multicopter Position Control](../advanced_config/para
 ### Position Loss/Safety
 
 Position mode is dependent on having an acceptable position estimate.
-If the estimate falls below acceptable levels, for example due to GPS loss, this may trigger a [Position (GPS) Loss Failsafe](../config/safety.md#position-gps-loss-failsafe).
+If the estimate falls below acceptable levels, for example due to GPS loss, this may trigger a [Position (GPS) Loss Failsafe](../config/safety.md#position-gnss-loss-failsafe).
 Depending on configuration, whether you have a remote control, and whether there is an adequate altitude estimate, PX4 may switch to altitude mode, manual mode, land mode or terminate.
 
 ## See Also

--- a/en/getting_started/tunes.md
+++ b/en/getting_started/tunes.md
@@ -181,7 +181,7 @@ Your browser does not support the audio element.
 </audio>
 <!-- 7,  BATTERY_WARNING_SLOW -->
 
-- Low battery warning ([failsafe](../config/safety.md#low-battery-failsafe)).
+- Low battery warning ([failsafe](../config/safety.md#battery-level-failsafe)).
 
 #### Battery Warning Fast
 
@@ -191,7 +191,7 @@ Your browser does not support the audio element.
 </audio>
 <!-- 8, BATTERY_WARNING_FAST -->
 
-- Critical low battery warning ([failsafe](../config/safety.md#low-battery-failsafe)).
+- Critical low battery warning ([failsafe](../config/safety.md#battery-level-failsafe)).
 
 
 #### GPS Warning Slow

--- a/en/power_module/index.md
+++ b/en/power_module/index.md
@@ -2,7 +2,7 @@
 
 _Power Modules_ provide a regulated power supply for the flight controller (FC), along with information about battery voltage and current.
 The voltage/current information is used to determine the consumed power, and to hence to estimate remaining battery capacity.
-This in turn allows the flight controller to provide failsafe warnings and other actions in the event of low power: [Safety > Low Battery Failsafe](../config/safety.md#low-battery-failsafe).
+This in turn allows the flight controller to provide failsafe warnings and other actions in the event of low power: [Safety > Low Battery Failsafe](../config/safety.md#battery-level-failsafe).
 
 _Power Distribution Boards (PDB)_ are circuit boards that may be used to simplify splitting the output of the battery to various parts of the drone, and in particular motors.
 PDBs will sometimes include a power module for the FC, ESCs for motors, and a battery elimination circuit (BEC) for powering servos.

--- a/en/smart_batteries/index.md
+++ b/en/smart_batteries/index.md
@@ -11,4 +11,4 @@ PX4 supports (at least) following smart batteries:
 
 - [Mavlink Battery Protocol](https://mavlink.io/en/services/battery.html)
 - [batt_smbus](../modules/modules_driver.md) - PX4 SMBus Battery Driver docs
-- [Safety > Low Battery Failsafe](../config/safety.md#low-battery-failsafe).
+- [Safety > Low Battery Failsafe](../config/safety.md#battery-level-failsafe).


### PR DESCRIPTION
This groups battery safety failsafes, including COM_FLTT_LOW_ACT. This was requested in https://github.com/PX4/PX4-user_guide/pull/3308#discussion_r1698000714 by @sfuhrer 

To make this structurally sensible, I have also removed the QGC-centric nature of the doc - there are just failsafes. If QGC exposes the settings I show those, if not I talk about the params. 

In one way this is good. QGC settings for safety are pretty out of date, so I can highlight that better with this split.