### PR TITLE
Autotuning - link to params

### DIFF
--- a/en/config/_autotune.md
+++ b/en/config/_autotune.md
@@ -298,7 +298,7 @@ If not, perhaps say "not very" but you should expect that the vehicle might defl
 
 - [Multicopter PID Tuning Guide](../config_mc/pid_tuning_guide_multicopter_basic.md) (Manual/Simple)
 - [Multicopter PID Tuning Guide](../config_mc/pid_tuning_guide_multicopter.md) (Advanced/Detailed)
-- [Parameters > Autotuning](../advanced_config/parameter_reference.html#autotune) (prefixed with `MC_AT_`).
+- [Parameters > Autotuning](../advanced_config/parameter_reference.md#autotune) (prefixed with `MC_AT_`).
 
 </div>
 <div v-else-if="$frontmatter.frame === 'Plane'">
@@ -306,6 +306,6 @@ If not, perhaps say "not very" but you should expect that the vehicle might defl
 ## See also
 
 - [Fixed-Wing PID Tuning Guide](../config_fw/pid_tuning_guide_fixedwing.md)
-- [Parameters > Autotuning](../advanced_config/parameter_reference.html#autotune) (prefixed with `FW_AT_`).
+- [Parameters > Autotuning](../advanced_config/parameter_reference.md#autotune) (prefixed with `FW_AT_`).
 
 </div>

--- a/en/config/_autotune.md
+++ b/en/config/_autotune.md
@@ -78,9 +78,9 @@ The test steps are:
 
    <div v-if="$frontmatter.frame === 'Plane'">
    <div class="tip custom-block"><p class="custom-block-title">TIP</p>
-   
+
    If an [Enable/Disable Autotune Switch](#enable-disable-autotune-switch) is configured you can just toggle the switch to the "enabled" position.
-   
+
    </div></div>
 
    1. In QGroundControl, open the menu **Vehicle setup > PID Tuning**:
@@ -298,6 +298,7 @@ If not, perhaps say "not very" but you should expect that the vehicle might defl
 
 - [Multicopter PID Tuning Guide](../config_mc/pid_tuning_guide_multicopter_basic.md) (Manual/Simple)
 - [Multicopter PID Tuning Guide](../config_mc/pid_tuning_guide_multicopter.md) (Advanced/Detailed)
+- [Parameters > Autotuning](../advanced_config/parameter_reference.html#autotune) (prefixed with `MC_AT_`).
 
 </div>
 <div v-else-if="$frontmatter.frame === 'Plane'">
@@ -305,5 +306,6 @@ If not, perhaps say "not very" but you should expect that the vehicle might defl
 ## See also
 
 - [Fixed-Wing PID Tuning Guide](../config_fw/pid_tuning_guide_fixedwing.md)
+- [Parameters > Autotuning](../advanced_config/parameter_reference.html#autotune) (prefixed with `FW_AT_`).
 
 </div>

--- a/en/peripherals/serial_configuration.md
+++ b/en/peripherals/serial_configuration.md
@@ -102,6 +102,14 @@ The following ports are commonly mapped to specific functions on all boards:
   The configuration uses [MAV_2_CONFIG](../advanced_config/parameter_reference.md#MAV_2_CONFIG) and appropriate settings for the UDP port etc.
   For more information see [PX4 Ethernet Setup > PX4 MAVLink Serial Port Configuration](../advanced_config/ethernet_setup.md#px4-mavlink-serial-port-configuration) and [MAVLink Peripherals (OSD/GCS/Companion Computers/etc.)](../peripherals/mavlink_peripherals.md).
 
+- `USB-C` (the USB-C port normally used for connecting to QGroundControl)
+
+  This is configured by default as a MAVLink port the onboard profile (for companion computers).
+  The configuration for MAVLink is unique to this port (it doesn't use the `MAV_X_CONFIG` parameters).
+
+  - [SYS_USB_AUTO](../advanced_config/parameter_reference.md#SYS_USB_AUTO) sets whether the port is set to no partiular protocol, autodetects the protocol, or sets the comms link to MAVLink.
+  - [USB_MAV_MODE](../advanced_config/parameter_reference.md#USB_MAV_MODE) sets the MAVLink profile that is used if MAVLink is set or detected.
+
 Other ports generally have no assigned functions by default (are disabled).
 
 ## Troubleshooting

--- a/en/sensor/sfxx_lidar.md
+++ b/en/sensor/sfxx_lidar.md
@@ -60,9 +60,9 @@ If the I2C address is equal to `0x66` the sensor can be used with PX4.
 
 Set the [SENS_EN_SF1XX](../advanced_config/parameter_reference.md#SENS_EN_SF1XX) parameter to match the rangefinder model and then reboot.
 
-## Serial Setup
+VTOL vehicles may choose to also set [SF1XX_MODE](../advanced_config/parameter_reference.md#SF1XX_MODE) to `2: Disabled during VTOL fast forward flight`.
 
-<a id="serial_hardware_setup"></a>
+## Serial Setup {#serial_hardware_setup}
 
 ### Hardware
 
@@ -82,6 +82,8 @@ If the configuration parameter is not available in _QGroundControl_ then you may
 :::
 
 Then set the [SENS_EN_SF0X](../advanced_config/parameter_reference.md#SENS_EN_SF0X) parameter to match the rangefinder model and reboot.
+
+VTOL vehicles may choose to also set [SF1XX_MODE](../advanced_config/parameter_reference.md#SF1XX_MODE) to `2: Disabled during VTOL fast forward flight`.
 
 ## Further Information
 

--- a/en/simulation/failsafes.md
+++ b/en/simulation/failsafes.md
@@ -47,6 +47,8 @@ To control how fast the battery depletes to the minimal value use the parameter 
 By changing [SIM_BAT_MIN_PCT](../advanced_config/parameter_reference.md#SIM_BAT_MIN_PCT) in flight, you can also test regaining capacity to simulate inaccurate battery state estimation or in-air charging technology.
 :::
 
+It is also possible to disable the simulated battery using [SIM_BAT_ENABLE](../advanced_config/parameter_reference.md#SIM_BAT_ENABLE) in order to, for example, provide an external battery simulation via MAVLink.
+
 ## Sensor/System Failure
 
 [Failure injection](../debug/failure_injection.md) can be used to simulate different types of failures in many sensors and systems.


### PR DESCRIPTION
This just a link to make it clear there are some param affecting autotuning.

Also pulls forward some info about SFxx lidar mode and VTOL, some Simulator params, and the USB-C port configuration.