### PR TITLE
Fix rename of pure pursuit params

### DIFF
--- a/en/frames_rover/ackermann_rover_v2.md
+++ b/en/frames_rover/ackermann_rover_v2.md
@@ -123,16 +123,16 @@ The parameters in [Tuning (basic)](#tuning-basic) must also be set to drive miss
 The module uses a control algorithm called _Pure pursuit_ and it can be beneficial to understand how it works to properly tune (see [Pure pursuit algorithm](#pure-pursuit-algorithm)).
 
 The look ahead distance sets how aggressive the controller behaves and is defined as $l_d = v \cdot k$.
-It depends on the velocity $v$ of the rover and a tuning parameter $k$ that can be set with the parameter [RA_LOOKAHD_GAIN](#RA_LOOKAHD_GAIN).
+It depends on the velocity $v$ of the rover and a tuning parameter $k$ that can be set with the parameter [PP_LOOKAHD_GAIN](#PP_LOOKAHD_GAIN).
 
 :::info
-A lower value of [RA_LOOKAHD_GAIN](#RA_LOOKAHD_GAIN) makes the controller more aggressive but can lead to oscillations!
+A lower value of [PP_LOOKAHD_GAIN](#PP_LOOKAHD_GAIN) makes the controller more aggressive but can lead to oscillations!
 :::
 
-The lookahead is constrained between [RA_LOOKAHD_MAX](#RA_LOOKAHD_MAX) and [RA_LOOKAHD_MIN](#RA_LOOKAHD_MIN).
+The lookahead is constrained between [PP_LOOKAHD_MAX](#PP_LOOKAHD_MAX) and [PP_LOOKAHD_MIN](#PP_LOOKAHD_MIN).
 
 :::info
-Increasing [RA_LOOKAHD_MIN](#RA_LOOKAHD_MIN) can help to make the steering less aggressive at slow speeds.
+Increasing [PP_LOOKAHD_MIN](#PP_LOOKAHD_MIN) can help to make the steering less aggressive at slow speeds.
 This can be useful especially if the [corner slow down effect](#corner-slow-down) is enabled.
 :::
 
@@ -142,9 +142,9 @@ To summarize, the following parameters can be used to tune the controller:
 
 | Parameter                                                                                                | Description                             | Unit |
 | -------------------------------------------------------------------------------------------------------- | --------------------------------------- | ---- |
-| <a id="RA_LOOKAHD_GAIN"></a>[RA_LOOKAHD_GAIN](../advanced_config/parameter_reference.md#RA_LOOKAHD_GAIN) | Main tuning parameter                   | -    |
-| <a id="RA_LOOKAHD_MAX"></a>[RA_LOOKAHD_MAX](../advanced_config/parameter_reference.md#RA_LOOKAHD_MAX)    | Maximum value for the look ahead radius | m    |
-| <a id="RA_LOOKAHD_MIN"></a>[RA_LOOKAHD_MIN](../advanced_config/parameter_reference.md#RA_LOOKAHD_MIN)    | Minimum value for the look ahead radius | m    |
+| <a id="PP_LOOKAHD_GAIN"></a>[PP_LOOKAHD_GAIN](../advanced_config/parameter_reference.md#PP_LOOKAHD_GAIN) | Main tuning parameter                   | -    |
+| <a id="PP_LOOKAHD_MAX"></a>[PP_LOOKAHD_MAX](../advanced_config/parameter_reference.md#PP_LOOKAHD_MAX)    | Maximum value for the look ahead radius | m    |
+| <a id="PP_LOOKAHD_MIN"></a>[PP_LOOKAHD_MIN](../advanced_config/parameter_reference.md#PP_LOOKAHD_MIN)    | Minimum value for the look ahead radius | m    |
 
 ### Cornering Parameters
 


### PR DESCRIPTION
The Rover pure pursuit param names changed in https://github.com/PX4/PX4-Autopilot/pull/23438:

| Parameter | Description | Unit |
|--------|--------|--------|
| RA_LOOKAHD_GAIN $\rightarrow$ PP_LOOKAHD_GAIN | Main tuning parameter | - |
| RA_LOOKAHD_MAX $\rightarrow$ PP_LOOKAHD_MAX | Maximum value for the look ahead radius | m |
| RA_LOOKAHD_MIN $\rightarrow$ PP_LOOKAHD_MIN | Minimum value for the look ahead radius | m | 

This fixes up the docs