### PR TITLE
Path planning need an onboard computer with heartbeat streaming

### DIFF
--- a/en/computer_vision/obstacle_avoidance.md
+++ b/en/computer_vision/obstacle_avoidance.md
@@ -60,6 +60,9 @@ If PX4 stops receiving setpoint updates for more than half a second it will swit
 
 Obstacle avoidance is enabled within PX4 by [setting](../advanced_config/parameters.md) the [COM_OBS_AVOID](../advanced_config/parameter_reference.md#COM_OBS_AVOID) to 1.
 
+Note that PX4 also requires that the companion computer meets the requirements of the [Path Planning Interface](../computer_vision/path_planning_interface.md).
+For example, the vehicle will fail the prearm check `Avoidance system not ready` if the companion computer isn't broadcasting a MAVLink `HEARTBEAT` with `type` set appropriately.
+
 ::: info
 `COM_OBS_AVOID` also enables [Safe Landing](../computer_vision/safe_landing.md) and any other features that use the PX4 [Path Planning Offboard Interface](../computer_vision/path_planning_interface.md) (Trajectory Interface) to integrate external path planning services with PX4.
 :::

--- a/en/computer_vision/obstacle_avoidance.md
+++ b/en/computer_vision/obstacle_avoidance.md
@@ -61,7 +61,7 @@ If PX4 stops receiving setpoint updates for more than half a second it will swit
 Obstacle avoidance is enabled within PX4 by [setting](../advanced_config/parameters.md) the [COM_OBS_AVOID](../advanced_config/parameter_reference.md#COM_OBS_AVOID) to 1.
 
 Note that PX4 also requires that the companion computer meets the requirements of the [Path Planning Interface](../computer_vision/path_planning_interface.md).
-For example, the vehicle will fail the prearm check `Avoidance system not ready` if the companion computer isn't broadcasting a MAVLink `HEARTBEAT` with `type` set appropriately.
+For example, the vehicle will fail the prearm check `Avoidance system not ready` if the companion computer isn't broadcasting a MAVLink `HEARTBEAT` with [HEARTBEAT.system_status=MAV_STATE_ACTIVE](https://mavlink.io/en/messages/common.htmlMAV_STATE_ACTIVE).
 
 ::: info
 `COM_OBS_AVOID` also enables [Safe Landing](../computer_vision/safe_landing.md) and any other features that use the PX4 [Path Planning Offboard Interface](../computer_vision/path_planning_interface.md) (Trajectory Interface) to integrate external path planning services with PX4.

--- a/en/computer_vision/path_planning_interface.md
+++ b/en/computer_vision/path_planning_interface.md
@@ -12,7 +12,7 @@ PX4 uses a number of MAVLink interfaces for integrating path planning services f
 - The [HEARTBEAT/Connection Protocol](https://mavlink.io/en/services/heartbeat.html) is used for "proof of life" detection.
 
   ::: info
-  The companion computer must be streaming a [HEARTBEAT](https://mavlink.io/en/messages/common.html#HEARTBEAT) with `type` of [MAV_TYPE_ONBOARD_CONTROLLER](https://mavlink.io/en/messages/common.html#MAV_TYPE_ONBOARD_CONTROLLER) in order to arm while obstacle avoidance is enabled (otherwise the vehicle will fail the prearm check: `Avoidance system not ready`).
+  The companion computer must have a component id of [MAV_COMP_ID_OBSTACLE_AVOIDANCE](https://mavlink.io/en/messages/common.html#MAV_COMP_ID_OBSTACLE_AVOIDANCE) and be streaming a [HEARTBEAT](https://mavlink.io/en/messages/common.html#HEARTBEAT) with [HEARTBEAT.system_status=MAV_STATE_ACTIVE](https://mavlink.io/en/messages/common.htmlMAV_STATE_ACTIVE) in order to arm while obstacle avoidance is enabled (otherwise the vehicle will fail the prearm check: `Avoidance system not ready`).
   :::
 
 - [LOCAL_POSITION_NED](https://mavlink.io/en/messages/common.html#LOCAL_POSITION_NED) and [ALTITUDE](https://mavlink.io/en/messages/common.html#ALTITUDE) send the vehicle local position and altitude, respectively.

--- a/en/computer_vision/path_planning_interface.md
+++ b/en/computer_vision/path_planning_interface.md
@@ -1,13 +1,20 @@
 # Path Planning Interface
 
-PX4 uses a number of MAVLink interfaces for integrating path planning services from a companion computer (including obstacle avoidance in missions, [safe landing](../computer_vision/safe_landing.md), and future services):
+PX4 uses a number of MAVLink interfaces for integrating path planning services from a companion computer (including [obstacle avoidance in missions](../computer_vision/obstacle_avoidance.md#mission-mode-avoidance), [safe landing](../computer_vision/safe_landing.md), and future services):
 
 - There are two [MAVLink Path Planning Protocol](https://mavlink.io/en/services/trajectory.html) interfaces:
+
   - [TRAJECTORY_REPRESENTATION_WAYPOINTS](https://mavlink.io/en/messages/common.html#TRAJECTORY_REPRESENTATION_WAYPOINTS): Used by PX4 to send the _desired path_.
     May be used by path planning software to send PX4 a stream of setpoints for the _planned path_.
   - [TRAJECTORY_REPRESENTATION_BEZIER](https://mavlink.io/en/messages/common.html#TRAJECTORY_REPRESENTATION_BEZIER) may (alternatively) be used by path planning software to send PX4 the _planned path_ as a bezier curve.
     The curve indicates the (moving) position setpoint of the vehicle over a given time period.
+
 - The [HEARTBEAT/Connection Protocol](https://mavlink.io/en/services/heartbeat.html) is used for "proof of life" detection.
+
+  ::: info
+  The companion computer must be streaming a [HEARTBEAT](https://mavlink.io/en/messages/common.html#HEARTBEAT) with `type` of [MAV_TYPE_ONBOARD_CONTROLLER](https://mavlink.io/en/messages/common.html#MAV_TYPE_ONBOARD_CONTROLLER) in order to arm while obstacle avoidance is enabled (otherwise the vehicle will fail the prearm check: `Avoidance system not ready`).
+  :::
+
 - [LOCAL_POSITION_NED](https://mavlink.io/en/messages/common.html#LOCAL_POSITION_NED) and [ALTITUDE](https://mavlink.io/en/messages/common.html#ALTITUDE) send the vehicle local position and altitude, respectively.
 
 Path planning is enabled on PX4 in automatic modes (landing, takeoff, hold, mission, return) if [COM_OBS_AVOID=1](../advanced_config/parameter_reference.md#COM_OBS_AVOID).

--- a/en/computer_vision/safe_landing.md
+++ b/en/computer_vision/safe_landing.md
@@ -36,9 +36,7 @@ This covers the common setup for obstacle avoidance and collision prevention, an
 
 The configuration information includes, among other things, how to set up safe landing for different cameras, sizes of vehicles, and the height at which the decision to land or not is taken.
 
-<a id="interface"></a>
-
-## Safe Landing Interface
+## Safe Landing Interface {#interface}
 
 PX4 uses the [Path Planning Interface](../computer_vision/path_planning_interface.md) for integrating path planning services from a companion computer (including [Obstacle Avoidance in missions](../computer_vision/obstacle_avoidance.md#mission_mode), [Safe Landing](../computer_vision/safe_landing.md), and future services).
 


### PR DESCRIPTION
This makes is to help people who have the `Avoidance system not ready` prearm message have an easy way to determine why that  is.

I have inferred the requirement from https://github.com/PX4/PX4-Avoidance/issues/568 and then looked at the source.

FYI, the code is not MAVLink compliant because it hard codes the check on the component id of the companion computer rather than on the type `MAV_TYPE_ONBOARD_CONTROLLER`

Fixes https://github.com/PX4/PX4-Autopilot/issues/22994

(since that is not a bug - it's a feature)