### PR TITLE
Update bootloader update from betaflight guide for Holybro Kakute H7

### DIFF
--- a/en/advanced_config/bootloader_update_from_betaflight.md
+++ b/en/advanced_config/bootloader_update_from_betaflight.md
@@ -52,7 +52,7 @@ The button can be released after the board has powered up.
 ### dfu-util
 
 ::: info
-The [Holybro Kakute H7 v2](../flight_controller/kakuteh7v2.md) and mini flight controllers may require that you first run an additional command to erase flash parameters (in order to fix problems with parameter saving):
+The [Holybro Kakute H7 v2](../flight_controller/kakuteh7v2.md), [Holybro Kakute H7](../flight_controller/kakuteh7.md) and [mini](../flight_controller/kakuteh7mini.md) flight controllers may require that you first run an additional command to erase flash parameters (in order to fix problems with parameter saving):
 
 ```
 dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D build/<target>/<target>.bin


### PR DESCRIPTION
Starting from release `1.14`, the Holybro Kakute H7 board saves parameters in the Flash just like Kakute H7 v2 and mini (see PR https://github.com/PX4/PX4-Autopilot/pull/20113).

Therefore, the list of devices that may require complete flash erase should be updated.

---

I found the complete flash erase procedure to be mandatory in order to get a Holybro Kakute H7 v1.3 working with PX4 v1.14.3

