### PR TITLE
[v1.15] Cherry pick stuff from main

### DIFF
--- a/en/advanced_config/bootloader_update_from_betaflight.md
+++ b/en/advanced_config/bootloader_update_from_betaflight.md
@@ -52,7 +52,7 @@ The button can be released after the board has powered up.
 ### dfu-util
 
 ::: info
-The [Holybro Kakute H7 v2](../flight_controller/kakuteh7v2.md) and mini flight controllers may require that you first run an additional command to erase flash parameters (in order to fix problems with parameter saving):
+The [Holybro Kakute H7 v2](../flight_controller/kakuteh7v2.md), [Holybro Kakute H7](../flight_controller/kakuteh7.md) and [mini](../flight_controller/kakuteh7mini.md) flight controllers may require that you first run an additional command to erase flash parameters (in order to fix problems with parameter saving):
 
 ```
 dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D build/<target>/<target>.bin


### PR DESCRIPTION
This cherry picks some stuff from main back into v1.15

- [Starting release 1.14 Holybro Kakute H7 saves parameters in the flash just like Kakute H7 v2 and mini](feat: Update note about erase flash parameter for Kakute H7 (#3344))