### PR TITLE
Better informs users that you aren't tied to our installation scripts…

### DIFF
--- a/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/en/dev_setup/dev_env_linux_ubuntu.md
@@ -12,6 +12,10 @@ The environment includes:
 The build toolchain for other flight controllers, simulators, and working with ROS are discussed in the [Other Targets](#other-targets) section below.
 :::
 
+::: tip
+You can manually install Gazebo on Ubuntu 20.04 or Gazebo Classic on Ubuntu 22.04 (say) by following the instructions in [Gazebo > Installation](../sim_gazebo_gz/index.md#installation-ubuntu-linux) and [Gazebo Classic > Installation](../sim_gazebo_classic/index.md#installation), respectively.
+:::
+
 ## Simulation and NuttX (Pixhawk) Targets
 
 Use the [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) script to set up a development environment that allows you to build for simulators and/or the [NuttX/Pixhawk](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) toolchain.
@@ -49,9 +53,6 @@ These notes are provided "for information only":
 
 - This setup is supported by the PX4 Dev Team.
   The instructions may also work on other Debian Linux based systems.
-- The script installs [Gazebo](../sim_gazebo_gz/index.md) "Garden" on Ubuntu 22.04, [Gazebo Classic](../sim_gazebo_classic/index.md) 11 on Ubuntu 20.04, and Gazebo Classic 9 on Ubuntu 18.04.
-- If you want to use Gazebo on Ubuntu 20.04 you can add it manually.
-  See [Gazebo > Installation](../sim_gazebo_gz/index.md#installation-ubuntu-linux).
 - You can verify the NuttX installation by confirming the `gcc` version as shown:
 
   ```sh

--- a/en/sim_gazebo_classic/index.md
+++ b/en/sim_gazebo_classic/index.md
@@ -28,15 +28,15 @@ See [Simulation](../simulation/index.md) for general information about simulator
 
 ## Installation
 
-Gazebo Classic 9 or 11 setup is included in our [standard build instructions](../dev_setup/dev_env.md) for Linux, macOS, and Windows.
-Additional installation instructions can be found on [gazebosim.org](http://gazebosim.org/tutorials?cat=guided_b&tut=guided_b1).
-
 ::: info
 If you plan to use PX4 with ROS you **should follow the** [ROS Instructions](../simulation/ros_interface.md) to install both ROS and Gazebo Classic (and thereby avoid installation conflicts).
 :::
 
-::: info
-The following commands can be used to remove [Gazebo (Garden)](../sim_gazebo_gz/index.md) and reinstall Gazebo-Classic 11:
+Gazebo Classic setup is included in our [standard build instructions](../dev_setup/dev_env.md) for macOS, Ubuntu 18.04 and 20.04, and Windows on WSL2 for the same hosts.
+
+For Ubuntu 22.04 LTS and later, the installation script ([/Tools/setup/ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh)) installs the [Gazebo](../sim_gazebo_gz/index.md) simulator instead.
+
+If you want to use Gazebo Classic on Ubuntu 22.04 you can use the following commands to remove [Gazebo (Garden)](../sim_gazebo_gz/index.md) and then reinstall Gazebo-Classic 11:
 
 ```sh
 sudo apt remove gz-garden
@@ -45,7 +45,12 @@ sudo aptitude install gazebo libgazebo11 libgazebo-dev
 ```
 
 Note that `aptitude` is needed because it can resolve dependency conflicts (by removing certain packages) that `apt` is unable to handle.
+
+::: tip
+You could also modify the installation script to install Gazebo Classic on later versions before it is run for the first time.
 :::
+
+Additional installation instructions can be found on [gazebosim.org](http://gazebosim.org/tutorials?cat=guided_b&tut=guided_b1).
 
 ## Running the Simulation
 
@@ -65,13 +70,13 @@ The supported vehicles and `make` commands are listed below (click links to see 
 For the full list of build targets run `make px4_sitl list_vmd_make_targets` (and filter on those that start with `gazebo-classic_`).
 :::
 
-| Vehicle                                                                                                                                   | Command                                                   |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Vehicle                                                                                                                            | Command                                                   |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
 | [Quadrotor](../sim_gazebo_classic/vehicles.md#quadrotor-default)                                                                   | `make px4_sitl gazebo-classic`                            |
 | [Quadrotor with Optical Flow](../sim_gazebo_classic/vehicles.md#quadrotor-with-optical-flow)                                       | `make px4_sitl gazebo-classic_iris_opt_flow`              |
 | [Quadrotor with Depth Camera](../sim_gazebo_classic/vehicles.md#quadrotor-with-depth-camera) (forward-facing)                      | `make px4_sitl gazebo-classic_iris_depth_camera`          |
 | [Quadrotor with Depth Camera](../sim_gazebo_classic/vehicles.md#quadrotor-with-depth-camera) (downward-facing)                     | `make px4_sitl gazebo-classic_iris_downward_depth_camera` |
-| [3DR Solo (Quadrotor)](../sim_gazebo_classic/vehicles.md#3dr-solo-quadrotor)                                                      | `make px4_sitl gazebo-classic_solo`                       |
+| [3DR Solo (Quadrotor)](../sim_gazebo_classic/vehicles.md#3dr-solo-quadrotor)                                                       | `make px4_sitl gazebo-classic_solo`                       |
 | <a id="typhoon_h480"></a>[Typhoon H480 (Hexrotor)](../sim_gazebo_classic/vehicles.md#typhoon-h480-hexrotor) (with video streaming) | `make px4_sitl gazebo-classic_typhoon_h480`               |
 | [Standard Plane](../sim_gazebo_classic/vehicles.md#standard-plane)                                                                 | `make px4_sitl gazebo-classic_plane`                      |
 | [Standard Plane (with catapult launch)](../sim_gazebo_classic/vehicles.md#standard-plane-with-catapult-launch)                     | `make px4_sitl gazebo-classic_plane_catapult`             |
@@ -79,7 +84,7 @@ For the full list of build targets run `make px4_sitl list_vmd_make_targets` (an
 | [Tailsitter VTOL](../sim_gazebo_classic/vehicles.md#tailsitter-vtol)                                                               | `make px4_sitl gazebo-classic_tailsitter`                 |
 | [Ackerman UGV (Rover)](../sim_gazebo_classic/vehicles.md#ackermann-ugv)                                                            | `make px4_sitl gazebo-classic_rover`                      |
 | [Differential UGV (Rover)](../sim_gazebo_classic/vehicles.md#differential-ugv)                                                     | `make px4_sitl gazebo-classic_r1_rover`                   |
-| [HippoCampus TUHH (UUV: Unmanned Underwater Vehicle)](../sim_gazebo_classic/vehicles.md#unmanned-underwater-vehicle-uuv-submarine)                                       | `make px4_sitl gazebo-classic_uuv_hippocampus`            |
+| [HippoCampus TUHH (UUV: Unmanned Underwater Vehicle)](../sim_gazebo_classic/vehicles.md#unmanned-underwater-vehicle-uuv-submarine) | `make px4_sitl gazebo-classic_uuv_hippocampus`            |
 | [Boat (USV: Unmanned Surface Vehicle)](../sim_gazebo_classic/vehicles.md#hippocampus-tuhh-uuv)                                     | `make px4_sitl gazebo-classic_boat`                       |
 | [Cloudship (Airship)](../sim_gazebo_classic/vehicles.md#airship)                                                                   | `make px4_sitl gazebo-classic_cloudship`                  |
 


### PR DESCRIPTION
The installation scripts install Gazebo and Gazebo Classic in specific versions on specific versions of Ubuntu. This simplifies instructions and tooling but complicates things for users who have a particular version of Ubuntu and want to use the other Gazebo.

So this basically "better highlights" that you can manually install Gazebo/remove Gazebo Classic, and visa versa.

This came out of discussion with @MaEtUgR 
