### PR TITLE
Improve Optical flow docs

### DIFF
--- a/en/sensor/optical_flow.md
+++ b/en/sensor/optical_flow.md
@@ -3,7 +3,7 @@
 _Optical Flow_ uses a downward facing camera and a downward facing distance sensor for velocity estimation.
 It can be used to determine speed when navigating without GNSS — in buildings, underground, or in any other GNSS-denied environment.
 
-The video below shows PX4 holding position using the  [Ark Flow](#ark-flow) sensor for velocity estimation in [Position Mode](../flight_modes_mc/position.md):
+The video below shows PX4 holding position using the [Ark Flow](#ark-flow) sensor for velocity estimation in [Position Mode](../flight_modes_mc/position.md):
 
 <lite-youtube videoid="aPQKgUof3Pc" title="ARK Flow with PX4 Optical Flow Position Hold"/>
 
@@ -22,7 +22,7 @@ The sensor(s) can be connected via MAVLink, I2C or any other bus that supports t
 
 ::: info
 If connected to PX4 via MAVLink the Optical Flow camera sensor must publish the [OPTICAL_FLOW_RAD](https://mavlink.io/en/messages/common.html#OPTICAL_FLOW_RAD) message, and the distance sensor must publish the [DISTANCE_SENSOR](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR) message.
-The information is written to the corresponding uORB topics: [DistanceSensor](../msg_docs/DistanceSensor.md) and [ObstacleDistance](../en/msg_docs/ObstacleDistance.md).
+The information is written to the corresponding uORB topics: [DistanceSensor](../msg_docs/DistanceSensor.md) and [ObstacleDistance](../msg_docs/ObstacleDistance.md).
 :::
 
 The output of the flow when moving in different directions must be as follows:

--- a/en/sensor/optical_flow.md
+++ b/en/sensor/optical_flow.md
@@ -1,20 +1,28 @@
 # Optical Flow
 
 _Optical Flow_ uses a downward facing camera and a downward facing distance sensor for velocity estimation.
+It can be used to determine speed when navigating without GNSS — in buildings, underground, or in any other GNSS-denied environment.
+
+The video below shows PX4 holding position using the  [Ark Flow](#ark-flow) sensor for velocity estimation in [Position Mode](../flight_modes_mc/position.md):
 
 <lite-youtube videoid="aPQKgUof3Pc" title="ARK Flow with PX4 Optical Flow Position Hold"/>
 
-_Video: PX4 holding position using the ARK Flow sensor for velocity estimation (in [Position Mode](../flight_modes_mc/position.md))._
-
 <!-- ARK Flow with PX4 Optical Flow Position Hold: 20210605 -->
+
+The image below shows an optical flow setup with a separate flow sensor ([PX4Flow](../sensor/px4flow.md)) and distance sensor ([Lidar-Lite](../sensor/lidar_lite.md)):
+
+![Optical flow lidar attached](../../assets/hardware/sensors/optical_flow/flow_lidar_attached.jpg)
 
 ## Setup
 
-An Optical Flow setup requires a downward facing camera and a [distance sensor](../sensor/rangefinders.md) (preferably a LiDAR).
-These can be connected via MAVLink, I2C or any other bus that supports the peripheral.
+An Optical Flow setup requires a downward facing camera and a downward facing [distance sensor](../sensor/rangefinders.md) (preferably a LiDAR).
+These can be combined in a single product, such as the [Ark Flow](#ark-flow), or they may be separate sensors.
+
+The sensor(s) can be connected via MAVLink, I2C or any other bus that supports the peripheral.
 
 ::: info
-If connected to PX4 via MAVLink the Optical Flow device must publish to the [OPTICAL_FLOW_RAD](https://mavlink.io/en/messages/common.html#OPTICAL_FLOW_RAD) topic, and the distance sensor must publish to the [DISTANCE_SENSOR](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR) topic.
+If connected to PX4 via MAVLink the Optical Flow camera sensor must publish the [OPTICAL_FLOW_RAD](https://mavlink.io/en/messages/common.html#OPTICAL_FLOW_RAD) message, and the distance sensor must publish the [DISTANCE_SENSOR](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR) message.
+The information is written to the corresponding uORB topics: [DistanceSensor](../msg_docs/DistanceSensor.md) and [ObstacleDistance](../en/msg_docs/ObstacleDistance.md).
 :::
 
 The output of the flow when moving in different directions must be as follows:
@@ -27,10 +35,6 @@ The output of the flow when moving in different directions must be as follows:
 | Left             | + X             |
 
 For pure rotations the `integrated_xgyro` and `integrated_x` (respectively `integrated_ygyro` and `integrated_y`) have to be the same.
-
-An popular setup is the [PX4Flow](../sensor/px4flow.md) and [Lidar-Lite](../sensor/lidar_lite.md), as shown below.
-
-![Optical flow lidar attached](../../assets/hardware/sensors/optical_flow/flow_lidar_attached.jpg)
 
 Sensor data from the optical flow device is fused with other velocity data sources.
 The approach used for fusing sensor data and any offsets from the center of the vehicle must be configured in the [estimator](#estimators).
@@ -66,11 +70,9 @@ The offsets are calculated relative to the vehicle orientation and center as sho
 
 ![Optical Flow offsets](../../assets/hardware/sensors/optical_flow/px4flow_offset.png)
 
-Optical Flow based navigation is enabled by both the availableestimators: EKF2 and LPE (deprecated).
+Optical Flow based navigation is enabled by both [EKF2](#ekf2) and LPE (deprecated).
 
-<a id="ekf2"></a>
-
-### Extended Kalman Filter (EKF2)
+### Extended Kalman Filter (EKF2) {#ekf2}
 
 For optical flow fusion using EKF2, set [EKF2_OF_CTRL](../advanced_config/parameter_reference.md#EKF2_OF_CTRL).
 
@@ -81,3 +83,5 @@ If your optical flow sensor is offset from the vehicle centre, you can set this 
 | <a id="EKF2_OF_POS_X"></a>[EKF2_OF_POS_X](../advanced_config/parameter_reference.md#EKF2_OF_POS_X) | X position of optical flow focal point in body frame (default is 0.0m). |
 | <a id="EKF2_OF_POS_Y"></a>[EKF2_OF_POS_Y](../advanced_config/parameter_reference.md#EKF2_OF_POS_Y) | Y position of optical flow focal point in body frame (default is 0.0m). |
 | <a id="EKF2_OF_POS_Z"></a>[EKF2_OF_POS_Z](../advanced_config/parameter_reference.md#EKF2_OF_POS_Z) | Z position of optical flow focal point in body frame (default is 0.0m). |
+
+See [Using the ECL EKF > Optical flow](../advanced_config/tuning_the_ecl_ekf.md#optical-flow) for more information.


### PR DESCRIPTION
This fixes some bugs in the optical flow docs.
Specifically:
- A few typos
- Referring to (deprecated) PX4 Flow as part of a popular setup
- Add link to EKF tuning section.