### PR TITLE
Update user_guide.md

### DIFF
--- a/en/ros2/user_guide.md
+++ b/en/ros2/user_guide.md
@@ -464,10 +464,10 @@ Use the following commands to install the correct ROS 2/gz interface packages (n
 :::: tabs
 
 ::: tab humble
-To install the bridge for use with ROS 2 "Humble" and Gazebo Garden (on Ubuntu 22.04):
+To install the bridge for use with ROS 2 "Humble" and Gazebo Harmonic (on Ubuntu 22.04):
 
 ```sh
-sudo apt install ros-humble-ros-gzgarden
+sudo apt install ros-humble-ros-gz
 ```
 
 :::


### PR DESCRIPTION
The gazebo-ros bridge installation step it says:
To install the bridge for use with ROS 2 "Humble" and Gazebo Garden (on Ubuntu 22.04): sudo apt install ros-humble-ros-gzgarden

However the installed developer environment for Ubuntu 22.04 is not gazebo garden it is gazebo harmonic, so version is wrong