### PR TITLE
Gazebo Harmonic replaces Garden

### DIFF
--- a/en/releases/main.md
+++ b/en/releases/main.md
@@ -50,6 +50,10 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 - [SIH]: The SIH on SITL [custom takeoff location](../sim_sih/index.md#set-custom-takeoff-location) in now set using the normal unscaled GPS position values, where previously the value needed to be multiplied by 1E7.
   ([PX4-Autopilot#23363](https://github.com/PX4/PX4-Autopilot/pull/23363)).
 - [Gazebo]:
+  - Gazebo Harmonic LTS release replaces Gazebo Garden as the version supported by PX4.
+    The default installer scripts (used for CI) and documentation have been updated.
+    This is required because Garden end-of-life is Nov 2024.
+    ([PX4-Autopilot#23603](https://github.com/PX4/PX4-Autopilot/pull/23603))
   - New vehicle model `x500_lidar` — [x500 Quadrotor with 2D Lidar](../sim_gazebo_gz/vehicles.md#x500-quadrotor-with-2d-lidar).
     ([PX4-Autopilot#22418](https://github.com/PX4/PX4-Autopilot/pull/22418), [PX4-gazebo-models#41](https://github.com/PX4/PX4-gazebo-models/pull/41)).
   - New vehicle model `r1_rover` — [Aion Robotics R1 Rover](../sim_gazebo_gz/vehicles.md#differential-rover) ([PX4-Autopilot#22402](https://github.com/PX4/PX4-Autopilot/pull/22402) and [PX4-gazebo-models#21](https://github.com/PX4/PX4-gazebo-models/pull/21)).

--- a/en/ros2/user_guide.md
+++ b/en/ros2/user_guide.md
@@ -464,18 +464,18 @@ Use the following commands to install the correct ROS 2/gz interface packages (n
 :::: tabs
 
 ::: tab humble
-To install the bridge for use with ROS 2 "Humble" and Gazebo Garden (on Ubuntu 22.04):
+To install the bridge for use with ROS 2 "Humble" and Gazebo Harmonic (on Ubuntu 22.04):
 
 ```sh
-sudo apt install ros-humble-ros-gzgarden
+sudo apt install ros-humble-ros-gzharmonic
 ```
 
 :::
 
 ::: tab foxy
-First you will need to [install Gazebo Garden](../sim_gazebo_gz/index.md#installation-ubuntu-linux), as by default Foxy comes with Gazebo Classic 11.
+First you will need to [install Gazebo Garden](../sim_gazebo_gz/index.md#installation-ubuntu-linux), as by default Foxy comes with Gazebo Classic 11. <!-- note, garden is EOL Nov 2024 -->
 
-Then to install the interface packages for use with ROS 2 "Foxy" and Gazebo Garden (Ubuntu 20.04):
+Then to install the interface packages for use with ROS 2 "Foxy" and Gazebo (Ubuntu 20.04):
 
 ```sh
 sudo apt install ros-foxy-ros-gzgarden
@@ -849,16 +849,16 @@ If any are missing, they can be added separately:
 ### ros_gz_bridge not publishing on the \clock topic
 
 If your [ROS2 nodes use the Gazebo clock as time source](../ros2/user_guide.md#ros2-nodes-use-the-gazebo-clock-as-time-source) but the `ros_gz_bridge` node doesn't publish anything on the `/clock` topic, you may have the wrong version installed.
-This might happen if you install ROS 2 Humble with the default "Ignition Fortress" packages, rather than using those for PX4, which uses "Gazebo Garden".
+This might happen if you install ROS 2 Humble with the default "Ignition Fortress" packages, rather than using those for PX4, which uses "Gazebo Harmonic".
 
-The following commands uninstall the default Ignition Fortress topics and install the correct bridge and other interface topics for **Gazebo Garden** with ROS2 **Humble**:
+The following commands uninstall the default Ignition Fortress topics and install the correct bridge and other interface topics for **Gazebo Harmonic** with ROS2 **Humble**:
 
 ```bash
 # Remove the wrong version (for Ignition Fortress)
 sudo apt remove ros-humble-ros-gz
 
 # Install the version for Gazebo Garden
-sudo apt install ros-humble-ros-gzgarden
+sudo apt install ros-humble-ros-gzharmonic
 ```
 
 ## Additional information

--- a/en/ros2/user_guide.md
+++ b/en/ros2/user_guide.md
@@ -47,13 +47,12 @@ This repo is no longer needed, but does contain useful examples.
 
 ## Installation & Setup
 
-The supported ROS 2 platforms for PX4 development are ROS 2 "Humble" on Ubuntu 22.04, and ROS 2 "Foxy" on Ubuntu 20.04.
+The supported and recommended ROS 2 platform for working with PX4 is ROS 2 "Humble" LTS on Ubuntu 22.04.
 
-ROS 2 "Humble" is recommended because it is the current ROS 2 LTS distribution.
-ROS 2 "Foxy" reached end-of-life in May 2023, but is still stable and works with PX4.
-
-::: info
-Ubuntu 20.04 and Foxy are needed if you want to use [Gazebo Classic](../sim_gazebo_classic/index.md).
+::: tip
+If you're working on Ubuntu 20.04 we recommend you update to Ubuntu 22.04.
+In the meantime you can use ROS 2 "Foxy" with [Gazebo Classic](../sim_gazebo_classic/index.md) on Ubuntu 20.04.
+Note that ROS 2 "Foxy" reached end-of-life in May 2023, but is (at time of writing) still stable and works with PX4.
 :::
 
 To setup ROS 2 for use with PX4:

--- a/en/sim_gazebo_classic/index.md
+++ b/en/sim_gazebo_classic/index.md
@@ -36,10 +36,11 @@ Gazebo Classic setup is included in our [standard build instructions](../dev_set
 
 For Ubuntu 22.04 LTS and later, the installation script ([/Tools/setup/ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh)) installs the [Gazebo](../sim_gazebo_gz/index.md) simulator instead.
 
-If you want to use Gazebo Classic on Ubuntu 22.04 you can use the following commands to remove [Gazebo (Garden)](../sim_gazebo_gz/index.md) and then reinstall Gazebo-Classic 11:
+If you want to use Gazebo Classic on Ubuntu 22.04 you can use the following commands to remove [Gazebo](../sim_gazebo_gz/index.md) versions and then reinstall Gazebo-Classic 11:
 
 ```sh
 sudo apt remove gz-garden
+sudo apt remove gz-harmonic
 sudo apt install aptitude
 sudo aptitude install gazebo libgazebo11 libgazebo-dev
 ```

--- a/en/sim_gazebo_classic/index.md
+++ b/en/sim_gazebo_classic/index.md
@@ -36,10 +36,9 @@ Gazebo Classic setup is included in our [standard build instructions](../dev_set
 
 For Ubuntu 22.04 LTS and later, the installation script ([/Tools/setup/ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh)) installs the [Gazebo](../sim_gazebo_gz/index.md) simulator instead.
 
-If you want to use Gazebo Classic on Ubuntu 22.04 you can use the following commands to remove [Gazebo](../sim_gazebo_gz/index.md) versions and then reinstall Gazebo-Classic 11:
+If you want to use Gazebo Classic on Ubuntu 22.04 you can use the following commands to remove [Gazebo](../sim_gazebo_gz/index.md) (Harmonic) and then reinstall Gazebo-Classic 11:
 
 ```sh
-sudo apt remove gz-garden
 sudo apt remove gz-harmonic
 sudo apt install aptitude
 sudo aptitude install gazebo libgazebo11 libgazebo-dev

--- a/en/sim_gazebo_gz/index.md
+++ b/en/sim_gazebo_gz/index.md
@@ -18,16 +18,21 @@ See [Simulation](../simulation/index.md) for general information about simulator
 
 ## Installation (Ubuntu Linux)
 
-Gazebo is installed by default on Ubuntu 22.04 as part of the normal [development environment setup](../dev_setup/dev_env_linux_ubuntu.md#simulation-and-nuttx-pixhawk-targets).
+Gazebo Harmonic is installed by default on Ubuntu 22.04 as part of the normal [development environment setup](../dev_setup/dev_env_linux_ubuntu.md#simulation-and-nuttx-pixhawk-targets).
 
-If you want to use Gazebo on Ubuntu 20.04 you can install it manually, after first following the normal setup process (installing `gz-harmonic` will uninstall Gazebo-Classic!):
+:::info
+The PX4 installation scripts are based on the instructions: [Binary Installation on Ubuntu](https://gazebosim.org/docs/harmonic/install_ubuntu/) (gazebosim.org).
+:::
 
-```sh
-sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-sudo apt-get update
-sudo apt-get install gz-harmonic
-```
+::: warning
+Gazebo Harmonic cannot be installed on Ubuntu 20.04 and earlier.
+
+On Ubuntu 20.04 we recommend use [Gazebo Classic](../sim_gazebo_classic/index.md).
+If you really must use Gazebo then you should update to Ubuntu 22.04.
+
+Until November 2024 it is possible to [install Gazebo Garden](https://gazebosim.org/docs/garden/install_ubuntu/) on Ubuntu 20.04.
+After that date Garden will reach end-of-life and should not be used.
+:::
 
 ## Running the Simulation
 
@@ -167,6 +172,7 @@ This can be ignored:
 ```sh
 [Wrn] [SDFFeatures.cc:843] The geometry element of collision [collision] couldn't be created
 ```
+
 :::
 
 ## Usage/Configuration Options

--- a/en/sim_gazebo_gz/index.md
+++ b/en/sim_gazebo_gz/index.md
@@ -20,13 +20,13 @@ See [Simulation](../simulation/index.md) for general information about simulator
 
 Gazebo is installed by default on Ubuntu 22.04 as part of the normal [development environment setup](../dev_setup/dev_env_linux_ubuntu.md#simulation-and-nuttx-pixhawk-targets).
 
-If you want to use Gazebo on Ubuntu 20.04 you can install it manually, after first following the normal setup process (installing `gz-garden` will uninstall Gazebo-Classic!):
+If you want to use Gazebo on Ubuntu 20.04 you can install it manually, after first following the normal setup process (installing `gz-harmonic` will uninstall Gazebo-Classic!):
 
 ```sh
 sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
-sudo apt-get install gz-garden
+sudo apt-get install gz-harmonic
 ```
 
 ## Running the Simulation
@@ -161,15 +161,12 @@ In other words, use `make px4_sitl gz_x500` instead of `make px4_sitl gz_x500_de
 :::
 
 ::: info
-Baylands throws the following error, which can be ignored:
+Baylands world throws a warning in Gazebo Harmonic because there are so many meshes.
+This can be ignored:
 
 ```sh
-[Err] [SDFFeatures.cc:843] The geometry element of collision [collision] couldn't be created
+[Wrn] [SDFFeatures.cc:843] The geometry element of collision [collision] couldn't be created
 ```
-
-This occurs because Baylands has a lot of meshes.
-However it does not break Gazebo and the error has been downgraded to a warning in Gazebo Harmonic: [gz-physics/pull/531](https://github.com/gazebosim/gz-physics/pull/531).
-You can also replace the error with a warning by [installing gz-garden from source](https://gazebosim.org/docs/garden/install_ubuntu_src).
 :::
 
 ## Usage/Configuration Options


### PR DESCRIPTION
Replaces #3366

This updates documents in line with https://github.com/PX4/PX4-Autopilot/pull/23603

Note that there are questions in https://github.com/PX4/PX4-Autopilot/pull/23603#issuecomment-2316422402
- Foxy can't be used with Harmonic - do we drop Foxy, keep Garden, or do something else?
- What about macOS? Dev instructions don't cover version, so there is no docs change, but we should make sure that it is up to date.
- Do we backport this info.
