### PR TITLE
GPS information - DOP vs EPH/EPV

### DIFF
--- a/en/gps_compass/index.md
+++ b/en/gps_compass/index.md
@@ -185,7 +185,7 @@ Some of GNSS terms that are useful for interpreting the data include:
 ### DOP vs EPH/EPV
 
 DOP is a measure of the potential for high accuracy based on satellite positions.
-EPH/EPV are more comprehensive, as they consider both satellite geometry and other error sources like signal noise and atmospheric effects.
+EPH/EPV are more comprehensive: they are direct estimates of the GPS position error and consider both satellite geometry and other error sources like signal noise and atmospheric effects.
 It is possible to have low DOP (good satellite geometry) but still have high EPH/EPV if there is significant signal noise or atmospheric interference.
 
 EPH/EPV values therefore provide a more immediate and practical estimate of the actual GPS accuracy you can expect under current conditions.

--- a/en/gps_compass/index.md
+++ b/en/gps_compass/index.md
@@ -167,6 +167,29 @@ This is documented in [RTK GPS > Configuring GPS as Yaw/Heading Source](../gps_c
 
 Compass calibration for an included compass part is covered in: [Compass Configuration](../config/compass.md).
 
+## GNSS Data Overview
+
+PX4 uses the subset of information that can be provided by most GNSS modules.
+This is written to the [SensorGps](../msg_docs/SensorGps.md) uORB message and used by the estimator as an input to global position estimation.
+It is also streamed via MAVLink using messages such as [GPS_RAW_INT](https://mavlink.io/en/messages/common.html#GPS_RAW_INT) and [GPS2_RAW](https://mavlink.io/en/messages/common.html#GPS2_RAW).
+
+Some of GNSS terms that are useful for interpreting the data include:
+
+- `DOP`: Dilution of position (dimensionless).
+  This is a measure of the geometric quality of satellite positions and their effect on the precision of the GPS receiver's calculations.
+- `EPH`: Standard deviation of horizontal position error (metres).
+  This represents the the uncertainty in the GPS fix latitude and longitude.
+- `EPV`: Standard deviation of vertical position error (metres).
+  This represents the the uncertainty in the GPS fix altitude.
+
+### DOP vs EPH/EPV
+
+DOP is a measure of the potential for high accuracy based on satellite positions.
+EPH/EPV are more comprehensive, as they consider both satellite geometry and other error sources like signal noise and atmospheric effects.
+It is possible to have low DOP (good satellite geometry) but still have high EPH/EPV if there is significant signal noise or atmospheric interference.
+
+EPH/EPV values therefore provide a more immediate and practical estimate of the actual GPS accuracy you can expect under current conditions.
+
 ## Developer Information
 
 - GPS/RTK-GPS


### PR DESCRIPTION
This adds a little information about some of the terminology around GPS information, as discussed in https://discord.com/channels/1022170275984457759/1032055573753118742/1255712384215941130

It is useful to have because there are many questions about this in the community that have popped up over time. It also helps to make clear that PX4 doesn't necessarily get all information that a GPS supplies, or use it. We also point to MAVLink and uORB for the interesting set.

@ryanjAA Look OK to you?