### PR TITLE
Release: 1.15 explicitly call out dynamic modes api

### DIFF
--- a/en/releases/1.15.md
+++ b/en/releases/1.15.md
@@ -21,7 +21,8 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 - Major improvements to navigation
 - New and updated hardware support
-- Experimental [PX4 ROS 2 Interface Library](../ros2/px4_ros2_interface_lib.md) that simplifies controlling PX4 from ROS 2.
+- Dynamic Modes API
+- <Badge type="warning" text="Experimental"/>[PX4 ROS 2 Interface Library](../ros2/px4_ros2_interface_lib.md) that simplifies controlling PX4 from ROS 2.
 
 ## Upgrade Guide
 
@@ -50,9 +51,9 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 - `SYS_MC_EST_GROUP` has been removed and there are now dedicated parameters [EKF2_EN](../advanced_config/parameter_reference.md#EKF2_EN), [ATT_EN](../advanced_config/parameter_reference.md#ATT_EN), and [LPE_EN](../advanced_config/parameter_reference.md#LPE_EN) for [Switching State Estimators](../advanced/switching_state_estimators.md) ([PX4-Autopilot#22567](https://github.com/PX4/PX4-Autopilot/pull/22567))
   - Most setups should enable [EKF2_EN](../advanced_config/parameter_reference.md#EKF2_EN) (the default).
-- **[Experimental]** Zenoh Pico support ([PX4-Autopilot#22017](https://github.com/PX4/PX4-Autopilot/pull/22017))
 - **[Bootloader]** add force-erase option and bootloader version ([PX4-Autopilot#22777](https://github.com/PX4/PX4-Autopilot/pull/22777))
 - **[uORB]** Allow for more than 255 uORB messages ([PX4-Autopilot#21923](https://github.com/PX4/PX4-Autopilot/pull/21923))
+- **[Feature]** <Badge type="warning" text="Experimental"/> Zenoh Pico support ([PX4-Autopilot#22017](https://github.com/PX4/PX4-Autopilot/pull/22017))
 - **[Feature]** Improve mission resume, e.g. replay gimbal and camera commands of a survey ([PX4-Autopilot#21710](https://github.com/PX4/PX4-Autopilot/pull/21710))
 - **[Feature]** Resume mission with flight speed from previous mission items ([PX4-Autopilot#21714](https://github.com/PX4/PX4-Autopilot/pull/21714))
 - **[Feature]** Warn user when navigation failure is imminent ([PX4-Autopilot#21876](https://github.com/PX4/PX4-Autopilot/pull/21876))
@@ -152,9 +153,14 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ### ROS 2
 
-- [PX4 ROS 2 Interface Library](../ros2/px4_ros2_interface_lib.md)<Badge type="warning" text="Experimental"/>: A new C++ library that simplifies controlling PX4 from ROS 2 ([PX4-Autopilot#20707](https://github.com/PX4/PX4-Autopilot/pull/20707))
+- **[Feature]** Dynamic Modes API ([PX4-Autopilot#20707](https://github.com/PX4/PX4-Autopilot/pull/20707))
+- **[Feature]** **[[PX4 ROS 2 Interface Library](../ros2/px4_ros2_interface_lib.md)]**<Badge type="warning" text="Experimental"/>: A new C++ library that simplifies controlling PX4 from ROS 2
   - Supports adding flight modes in ROS 2 that are peers of the PX4 modes running on the flight controller.
-- Multicopter Go-to Interface ([PX4-Autopilot#22375](https://github.com/PX4/PX4-Autopilot/pull/22375))
+  - Modes behave the same as an FMU-internal modes
+  - Propagated to GCS and selectable by users
+  - Interface for arming checks and mode requirements
+  - Integrated into the failsafe state machine
+- **[Feature]** Multicopter Go-to Interface ([PX4-Autopilot#22375](https://github.com/PX4/PX4-Autopilot/pull/22375))
 
 ## Platform Changes
 


### PR DESCRIPTION
Make a distinction between the ROS 2 Interface library, which is a separate library, and the PX4 dynamic modes API, which is an internal addition to PX4