### PR TITLE
Fix typo in mavros_installation.md

### DIFF
--- a/en/ros/mavros_installation.md
+++ b/en/ros/mavros_installation.md
@@ -24,7 +24,7 @@ They cover the _ROS Melodic and Noetic_ releases.
 
 :::: tabs
 
-::: tab ROS Noetic (Ubuntu 22.04)
+::: tab ROS Noetic (Ubuntu 20.04)
 
 If you're working with [ROS Noetic](http://wiki.ros.org/noetic) on Ubuntu 20.04:
 


### PR DESCRIPTION
Says: "ROS Noetic (Ubuntu 22.04)", should be "ROS Noetic (Ubuntu 20.04)" as focal fossa is the officially supported distro