### PR TITLE
typo: update px4_basic_concepts.md

### DIFF
--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -83,7 +83,7 @@ You can download it (for free) from [here](http://qgroundcontrol.com/downloads/)
 
 ![QGC Main Screen](../../assets/concepts/qgc_fly_view.png)
 
-QGroundControl communicates with the drone using a telmetry radio (a bidirectional data link), which allows you to get real-time flight and safety information, and to control the vehicle, camera, and other payloads using a point-and-click interface.
+QGroundControl communicates with the drone using a telemetry radio (a bidirectional data link), which allows you to get real-time flight and safety information, and to control the vehicle, camera, and other payloads using a point-and-click interface.
 On hardware that supports them, you can also manually fly the vehicle using joystick controllers.
 QGC can also be used to visually plan, execute, and monitor autonomous missions, set geofences, and much more.
 

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -273,7 +273,7 @@ Flight controllers that do not include an SD Card slot may:
 Payloads are equipment carried by the vehicle to meet user or mission objectives, such as cameras in surveying missions, instruments used in for inspections such as radiation detectors, and cargo that needs to be delivered.
 PX4 supports many cameras and a wide range of payloads.
 
-Payloads are connected to [Fight Controller outputs](#outputs-motors-servos-actuators), and can be triggered automatically in missions, or manually from an RC Controller or Joystick, or from a Ground Station (via MAVLink/MAVSDK commands).
+Payloads are connected to [Flight Controller outputs](#outputs-motors-servos-actuators), and can be triggered automatically in missions, or manually from an RC Controller or Joystick, or from a Ground Station (via MAVLink/MAVSDK commands).
 
 For more information see: [Payloads & Cameras](../payloads/index.md)
 


### PR DESCRIPTION
Fixes typos in `en/getting_started/px4_basic_concepts.md`