### PR TITLE
Fixed vertiq.md documentation links that were 404'd

### DIFF
--- a/en/peripherals/vertiq.md
+++ b/en/peripherals/vertiq.md
@@ -6,7 +6,7 @@ With closed loop velocity control for the fastest response times available, clas
 
 ![Vertiq Module Lineup](../../assets/peripherals/esc_vertiq/vertiq_esc_lineup.jpg)
 
-All Vertiq modules support traditional [PWM input, DShot, OneShot, and Multishot communication protocols](https://iqmotion.readthedocs.io/en/latest/manual/manual_hobby.html). Vertiq's larger modules also support [DroneCAN control](https://iqmotion.readthedocs.io/en/latest/manual/manual_dronecan.html).
+All Vertiq modules support traditional [PWM input, DShot, OneShot, and Multishot communication protocols](https://iqmotion.readthedocs.io/en/latest/communication_protocols/hobby_protocol.html). Vertiq's larger modules also support [DroneCAN control](https://iqmotion.readthedocs.io/en/latest/communication_protocols/dronecan_protocol.html).
 
 ## Where to Buy
 
@@ -24,17 +24,17 @@ All Vertiq datasheets can be found at [vertiq.co](https://www.vertiq.co/).
 ## Firmware Setup
 
 The best tool to configure your Vertiq module is Vertiq's IQ Control Center application.
-You can find instructions for installation in [Getting Started with Speed Modules Using IQ Control Center](https://iqmotion.readthedocs.io/en/latest/tutorials/testing_with_control_center.html).
+You can find instructions for installation in [Getting Started with Speed Modules Using IQ Control Center](https://iqmotion.readthedocs.io/en/latest/control_center_docs/speed_module_getting_started.html).
 
 To get started with traditional PWM input or DShot with your flight controller, please see [PWM and DSHOT Control with a Flight Controller](https://iqmotion.readthedocs.io/en/latest/tutorials/pwm_control_flight_controller.html).
 
-To get started with DroneCAN with your flight controller, please see [DroneCAN Integration with a PX4 Flight Controller](https://iqmotion.readthedocs.io/en/latest/tutorials/dronecan_px4_flight_controller.html).
+To get started with DroneCAN with your flight controller, please see [DroneCAN Integration with a PX4 Flight Controller](https://iqmotion.readthedocs.io/en/latest/tutorials/dronecan_flight_controller.html).
 
 ## Flight Controller Setup
 
 ### DroneCAN Configuration
 
-Instructions for integrating the motor/ESC using with DroneCAN can be found in [Flight Controller Configuration](https://iqmotion.readthedocs.io/en/latest/tutorials/dronecan_px4_flight_controller.html#flight-controller-configuration) (in _DroneCAN Integration with a PX4 Flight Controller_).
+Instructions for integrating the motor/ESC using with DroneCAN can be found in [Flight Controller Configuration](https://iqmotion.readthedocs.io/en/latest/tutorials/dronecan_flight_controller.html#dronecan-integration-with-a-px4-flight-controller) (in _DroneCAN Integration with a PX4 Flight Controller_).
 
 These instructions walk you through setting the correct parameters for enabling the flight controller's DroneCAN drivers, setting the correct configuration parameters for communication with Vertiq modules on the DroneCAN bus, ESC configuration, and testing that your flight controller can properly control your modules over DroneCAN.
 


### PR DESCRIPTION
We updated our docs organization so now these links need to be updated if possible