### PR TITLE
Note SBUS compatibility is broader than previously listed

### DIFF
--- a/en/getting_started/rc_transmitter_receiver.md
+++ b/en/getting_started/rc_transmitter_receiver.md
@@ -1,10 +1,10 @@
 # Radio Control Systems
 
-A Radio Control (RC) system can be used to *manually* control your vehicle from a handheld RC controller.
+A Radio Control (RC) system can be used to _manually_ control your vehicle from a handheld RC controller.
 This topic provides an overview of how RC works, how to choose an appropriate radio system for your vehicle, and how to connect it to your flight controller.
 
 :::tip
-PX4 can also be manually controlled using a [Joystick](../config/joystick.md) or gamepad-like controller:  this is different to an RC system!
+PX4 can also be manually controlled using a [Joystick](../config/joystick.md) or gamepad-like controller: this is different to an RC system!
 The [COM_RC_IN_MODE](../advanced_config/parameter_reference.md#COM_RC_IN_MODE) parameter [can be set](../advanced_config/parameters.md) to choose whether RC (default), Joystick, both, or neither, are enabled.
 :::
 
@@ -14,9 +14,9 @@ PX4 does not require a remote control system for autonomous flight modes.
 
 ## How do RC Systems Work?
 
-An *RC system* has a ground-based *remote control unit* that is used by the operator to command the vehicle.
+An _RC system_ has a ground-based _remote control unit_ that is used by the operator to command the vehicle.
 The remote has physical controls that can be used to specify vehicle movement (e.g. speed, direction, throttle, yaw, pitch, roll, etc.) and to enable autopilot [flight modes](../flight_modes/index.md) (e.g. takeoff, land, return to land, mission etc.).
-On *telemetry-enabled* RC systems, the remote control unit can also receive and display information from the vehicle, such as battery level, flight mode, and warnings.
+On _telemetry-enabled_ RC systems, the remote control unit can also receive and display information from the vehicle, such as battery level, flight mode, and warnings.
 
 ![Taranis X9D Transmitter](../../assets/hardware/transmitters/frsky_taranis_x9d_transmitter.jpg)
 
@@ -27,7 +27,7 @@ The flight controller determines how to interpret the commands based on the curr
 <!-- image showing the different parts here would be nice -->
 
 ::: info
-The ground- and vehicle- based radio modules are referred to as the transmitter and receiver respectively (even if they support bidirectional communication) and are collectively referred to as a *transmitter/receiver pair*.
+The ground- and vehicle- based radio modules are referred to as the transmitter and receiver respectively (even if they support bidirectional communication) and are collectively referred to as a _transmitter/receiver pair_.
 The RC controller and it's included radio module are commonly referred to as a "transmitter".
 :::
 
@@ -43,18 +43,18 @@ Ground vehicles need at least two channels (steering + throttle). An 8 or 16 cha
 
 ### Remote Control Units for Aircraft
 
-The most popular *form* of remote control unit for UAVs is shown below.
+The most popular _form_ of remote control unit for UAVs is shown below.
 It has separate control sticks for controlling roll/pitch and for throttle/yaw as shown (i.e. aircraft need at least 4 channels).
 
 ![RC Basic Commands](../../assets/flying/rc_basic_commands.png)
 
 There are numerous possible layouts for the control sticks, switches, etc.
-The more common layouts have been given specific "Mode" numbers. *Mode 1* and *Mode 2* (shown below) differ only in the placement of the throttle.
+The more common layouts have been given specific "Mode" numbers. _Mode 1_ and _Mode 2_ (shown below) differ only in the placement of the throttle.
 
 ![Mode1-Mode2](../../assets/concepts/mode1_mode2.png)
 
 ::: info
-The choice of mode is largely one of taste (*Mode 2* is more popular).
+The choice of mode is largely one of taste (_Mode 2_ is more popular).
 :::
 
 ## Remote Control Units for Ground Vehicles
@@ -64,7 +64,6 @@ Commonly transmitters set these values using a wheel and trigger, two single-axi
 
 There is nothing to stop you using more channels/control mechanisms, and these can be very useful for engaging additional actuators and autopilot modes.
 
-
 ## Choosing RC System Components
 
 You will need to select a transmitter/receiver pair that are compatible with each other.
@@ -73,12 +72,11 @@ In addition, receivers have to be [compatible with PX4](#compatible_receivers) a
 Compatible radio systems are often sold together.
 For example, [FrSky Taranis X9D and FrSky X8R](https://hobbyking.com/en_us/frsky-2-4ghz-accst-taranis-x9d-plus-and-x8r-combo-digital-telemetry-radio-system-mode-2.html?___store=en_us) are a popular combination.
 
-
 ### Transmitter/Receiver Pairs
 
-One of the most popular RC units is the *FrSky Taranis X9D*.
-It has an internal transmitter module can be used with the recommended *FrSky X4R-SB* (S-BUS, low delay) or *X4R* (PPM-Sum, legacy) receivers out of the box.
-It also has a custom radio transmitter module slot and customizable open source OpenTX Firmware. 
+One of the most popular RC units is the _FrSky Taranis X9D_.
+It has an internal transmitter module can be used with the recommended _FrSky X4R-SB_ (S-BUS, low delay) or _X4R_ (PPM-Sum, legacy) receivers out of the box.
+It also has a custom radio transmitter module slot and customizable open source OpenTX Firmware.
 
 ::: info
 This remote control unit can display vehicle telemetry when used with [FrSky](../peripherals/frsky_telemetry.md) or [TBS Crossfire](../telemetry/crsf_telemetry.md) radio modules.
@@ -86,27 +84,31 @@ This remote control unit can display vehicle telemetry when used with [FrSky](..
 
 Other popular transmitter/receiver pairs
 
-* Turnigy remote using, for example, the FrSky transmitter/receiver modules.
-* Futaba Transmitters and compatible Futaba S-Bus receivers.
-* Long range ~900MHz, low latency: "Team Black Sheep Crossfire" or "Crossfire Micro" set with a compatible remote (e.g. Taranis)
-* Long Range ~433MHz: ImmersionRC EzUHF set with a compatible remote (e.g. Taranis)
+- Turnigy remote using, for example, the FrSky transmitter/receiver modules.
+- Futaba Transmitters and compatible Futaba S-Bus receivers.
+- Long range ~900MHz, low latency: "Team Black Sheep Crossfire" or "Crossfire Micro" set with a compatible remote (e.g. Taranis)
+- Long Range ~433MHz: ImmersionRC EzUHF set with a compatible remote (e.g. Taranis)
 
-
-<a id="compatible_receivers"></a>
-
-### PX4-Compatible Receivers
+### PX4-Compatible Receivers {#compatible_receivers}
 
 In addition to the transmitter/receiver pairs being compatible, the receiver must also be compatible with PX4 and the flight controller hardware.
 
-*PX4* and *Pixhawk* have been validated with:
+_PX4_ and _Pixhawk_ have been validated with:
 
 - All Spektrum DSM RC receivers
-- All Futaba S.BUS and S.BUS2 RC receivers
-- All FrSky PPM and S.Bus models
-- Graupner HoTT
-- All PPM models from other manufacturers
-- TBS Crossfire/Express LRS Receivers using [CRSF Telemetry](../telemetry/crsf_telemetry.md) (UART connection). 
+- All Futaba S.BUS and S.BUS2 RC receivers.
+- All FrSky S.BUS and PPM models
+- S.BUS and S.BUS2 RC receivers from Futaba, FrSky, TBS Crossfire with SBUS as output protocol, Herelink, Futaba SBUS remote.
+  Receivers from other vendors are likely to work but have not been tested.
 
+  ::: info
+  There is no detailed specification of the protocol, which historically resulted in slight incompatibilities.
+  The receivers we have tested all now appear to be compatible, but it is possible that others may not be.
+  :::
+
+- All PPM models (from any manufacturer)
+- Graupner HoTT
+- TBS Crossfire/Express LRS Receivers using [CRSF Telemetry](../telemetry/crsf_telemetry.md) (UART connection).
 
 ## Connecting Receivers
 
@@ -117,7 +119,7 @@ As general guidance, receivers connect to the flight controller using the port a
 - Graupner HoTT receivers: SUMD output must connect to a **SPKT/DSM** input (as above).
 - PPM-Sum and S.BUS receivers must connect directly to the **RC** ground, power and signal pins.
   This is typically labeled: `RC IN`, `RCIN` or `RC`, but has in some FCs has been labeled `PPM RC` or `PPM`.
-- PPM receivers that have an individual wire for each channel must connect to the RCIN channel *via* a PPM encoder [like this one](http://www.getfpv.com/radios/radio-accessories/holybro-ppm-encoder-module.html) (PPM-Sum receivers use a single signal wire for all channels).
+- PPM receivers that have an individual wire for each channel must connect to the RCIN channel _via_ a PPM encoder [like this one](http://www.getfpv.com/radios/radio-accessories/holybro-ppm-encoder-module.html) (PPM-Sum receivers use a single signal wire for all channels).
 - TBS Crossfire/Express LRS Receivers using [CRSF Telemetry](../telemetry/crsf_telemetry.md) connect via a spare UART.
 
 Flight controllers usually include appropriate cables for connecting common receiver types.
@@ -132,23 +134,23 @@ See the manufacturer's flight controller setup guide for additional information.
 
 ## Binding Transmitter/Receiver
 
-Before you can calibrate/use a radio system you must *bind* the receiver and transmitter so that they communicate only with each other.
+Before you can calibrate/use a radio system you must _bind_ the receiver and transmitter so that they communicate only with each other.
 The process for binding a transmitter and receiver pair is hardware specific (see your manual for instructions).
 
-If you are using a *Spektrum* receiver, you can put it into bind mode using *QGroundControl*: [Radio Setup > Spectrum Bind](../config/radio.md#spectrum-bind).
+If you are using a _Spektrum_ receiver, you can put it into bind mode using _QGroundControl_: [Radio Setup > Spectrum Bind](../config/radio.md#spectrum-bind).
 
 ## Set Signal-Loss Behaviour
 
 RC receivers have different ways of indicating signal loss:
+
 - Output nothing (automatically detected by PX4)
 - Output a low throttle value (you can [configure PX4 to detect this](../config/radio.md#rc-loss-detection)).
 - Output the last received signal (PX4 cannot handle this case!)
 
 Choose a receiver that can emit nothing (preferred) when RC is lost, or a low throttle value.
-This behaviour may require hardware configuration of the receiver (check the manual). 
+This behaviour may require hardware configuration of the receiver (check the manual).
 
 For more information see [Radio Control Setup > RC Loss Detection](../config/radio.md#rc-loss-detection).
-
 
 ## Related Topics
 

--- a/en/getting_started/rc_transmitter_receiver.md
+++ b/en/getting_started/rc_transmitter_receiver.md
@@ -108,7 +108,8 @@ _PX4_ and _Pixhawk_ have been validated with:
 - Spektrum DSM
 - Graupner HoTT
 
-Receivers from other vendors using one of the supported protocols are likely to work but have not been tested.
+Receivers from other vendors that use a supported protocol are likely to work but have not been tested.
+
 
   ::: info
   Differences between receiver models and no detailed specification of protocols historically resulted in incompatibilities.

--- a/en/getting_started/rc_transmitter_receiver.md
+++ b/en/getting_started/rc_transmitter_receiver.md
@@ -95,20 +95,25 @@ In addition to the transmitter/receiver pairs being compatible, the receiver mus
 
 _PX4_ and _Pixhawk_ have been validated with:
 
-- All Spektrum DSM RC receivers
-- All Futaba S.BUS and S.BUS2 RC receivers.
-- All FrSky S.BUS and PPM models
-- S.BUS and S.BUS2 RC receivers from Futaba, FrSky, TBS Crossfire with SBUS as output protocol, Herelink, Futaba SBUS remote.
-  Receivers from other vendors are likely to work but have not been tested.
+- PPM sum receivers
+- S.BUS and S.BUS2 receivers from
+  - Futaba
+  - FrSky S.BUS and PPM models
+  - TBS Crossfire with SBUS as output protocol
+  - Herelink
+- TBS Crossfire with (CRSF protocol)
+- Express LRS with (CRSF protocol)
+- TBS Ghost with (GHST protocol)
+- Spektrum DSM
+- Graupner HoTT
+
+Receivers from other vendors using one of the supported protocols are likely to work but have not been tested.
 
   ::: info
-  There is no detailed specification of the protocol, which historically resulted in slight incompatibilities.
+  Differences between receiver models and no detailed specification of protocols historically resulted in incompatibilities.
   The receivers we have tested all now appear to be compatible, but it is possible that others may not be.
   :::
 
-- All PPM models (from any manufacturer)
-- Graupner HoTT
-- TBS Crossfire/Express LRS Receivers using [CRSF Telemetry](../telemetry/crsf_telemetry.md) (UART connection).
 
 ## Connecting Receivers
 

--- a/en/getting_started/rc_transmitter_receiver.md
+++ b/en/getting_started/rc_transmitter_receiver.md
@@ -101,8 +101,9 @@ _PX4_ and _Pixhawk_ have been validated with:
   - FrSky S.BUS and PPM models
   - TBS Crossfire with SBUS as output protocol
   - Herelink
-- TBS Crossfire with (CRSF protocol)
-- Express LRS with (CRSF protocol)
+- TBS Crossfire with ([CRSF protocol](../telemetry/crsf_telemetry.md))
+- Express LRS with ([CRSF protocol](../telemetry/crsf_telemetry.md))
+
 - TBS Ghost with (GHST protocol)
 - Spektrum DSM
 - Graupner HoTT

--- a/en/getting_started/rc_transmitter_receiver.md
+++ b/en/getting_started/rc_transmitter_receiver.md
@@ -96,7 +96,8 @@ In addition to the transmitter/receiver pairs being compatible, the receiver mus
 _PX4_ and _Pixhawk_ have been validated with:
 
 - PPM sum receivers
-- S.BUS and S.BUS2 receivers from
+- S.BUS and S.BUS2 receivers from:
+
   - Futaba
   - FrSky S.BUS and PPM models
   - TBS Crossfire with SBUS as output protocol
@@ -111,10 +112,10 @@ _PX4_ and _Pixhawk_ have been validated with:
 Receivers from other vendors that use a supported protocol are likely to work but have not been tested.
 
 
-  ::: info
-  Differences between receiver models and no detailed specification of protocols historically resulted in incompatibilities.
-  The receivers we have tested all now appear to be compatible, but it is possible that others may not be.
-  :::
+::: info
+Historically there were differences and incompatibilities between receiver models, largely due to a lack of detailed specification of protocols.
+The receivers we have tested all now appear to be compatible, but it is possible that others may not be.
+:::
 
 
 ## Connecting Receivers


### PR DESCRIPTION
From https://discuss.px4.io/t/px4-compatible-rx/41855/2 , SBUS protocol has no spec, which resulted in historical incompatibilities, which current tested receivers appear to have resolved. 

This update notes that SBUS from a specific set of vendors have been tested, but is likely to be broadly supported. 
Note, I also ran prettier, I'll markup the touched part below.