### PR TITLE
Throw launch - notes/links and mention lockdown

### DIFF
--- a/en/flight_modes_mc/throw_launch.md
+++ b/en/flight_modes_mc/throw_launch.md
@@ -12,9 +12,9 @@ This feature was introduced in PX4 v1.15.
 :::
 
 This feature allows a multicopter to be started by arming it from a fixed position and then throwing it into the air.
-The vehicle then turns on the motors and operates according to its current mode.
+The vehicle turns on the motors only after the launch is detected, and then operates according to its current mode.
 
-When throw launch is enabled, arming the vehicle does not cause the propellers to spin.
+When throw launch is enabled, the vehicle is initially armed in a "lockdown" state, in which the propellers do not spin.
 The propellors will not activate until the vehicle is thrown or is disarmed, and the arming tone will continue playing during this time.
 The vehicle will not automatically disarm after arming, and must be manually disarmed if you choose not to throw it.
 
@@ -97,3 +97,9 @@ The following parameters can be used to enable and configure throw launch:
 ## See Also
 
 - [Takeoff Mode (Fixed-Wing) > Catapult/Hand Launch](../flight_modes_fw/takeoff.md#catapult-hand-launch).
+
+<!--
+Notes:
+https://github.com/PX4/PX4-Autopilot/pull/23822
+https://github.com/PX4/PX4-Autopilot/blob/371a99c3221dd09dce0b218c45df405188d96cfd/src/modules/commander/Commander.cpp#L1894-L1896 - lockdown setting
+-->


### PR DESCRIPTION
This adds some information about the lockdown state to the Throw launch, along with a hidden link to https://github.com/PX4/PX4-Autopilot/pull/23822#issuecomment-2421669935 which caused me to make this change.

The document was correct before this. I'm adding the information because it spells out that the vehicle actually is armed but in a special state. That doesn't matter so much "technically", but I don't want to waste developer time by asking this again if it comes up in another discuss post.