### PR TITLE
Clarify arming is powering and props might start

### DIFF
--- a/en/flying/basic_flying_fw.md
+++ b/en/flying/basic_flying_fw.md
@@ -9,12 +9,13 @@ Before you fly for the first time you should read our [First Flight Guidelines](
 ## Arm the Vehicle
 
 Before you can fly the vehicle it must first be [armed](../getting_started/px4_basic_concepts.md#arming-and-disarming).
-This will power all motors and actuators, and start any propellers turning.
+This will power all motors and actuators, and may start propellers turning.
 
 To arm the drone:
 
-- First disengage the [safety switch](../getting_started/px4_basic_concepts.md#safety-switch).
-- Use the arm command for your vehicle - put the throttle stick in the bottom right corner.
+- First disengage the [safety switch](../getting_started/px4_basic_concepts.md#safety-switch) (if present).
+- Use the arm command for your vehicle
+  - Put the throttle stick in the bottom right corner (use the [arming gesture](../advanced_config/prearm_arm_disarm.md#arm_disarm_gestures)).
   - Alternatively configure an [arm/disarm switch](../config/safety.md#arm-disarm-switch).
   - You can also arm in _QGroundControl_ (PX4 does not require a radio control for flying autonomously).
 

--- a/en/flying/basic_flying_mc.md
+++ b/en/flying/basic_flying_mc.md
@@ -9,12 +9,14 @@ Before you fly for the first time you should read our [First Flight Guidelines](
 ## Arm the Vehicle
 
 Before you can fly the vehicle it must first be [armed](../getting_started/px4_basic_concepts.md#arming-and-disarming).
-This will power all motors and actuators and start propellers turning.
+This will power all motors and actuators.
+Unless you're doing a [Throw Launch](../flight_modes_mc/throw_launch.md) the propellers will also start turning.
 
 To arm the drone:
 
-- First disengage the [safety switch](../getting_started/px4_basic_concepts.md#safety-switch).
-- Use the arm command for your vehicle - put the throttle stick in the bottom right corner.
+- First disengage the [safety switch](../getting_started/px4_basic_concepts.md#safety-switch) (if present).
+- Use the arm command for your vehicle:
+  - Put the throttle stick in the bottom right corner (use the [arming gesture](../advanced_config/prearm_arm_disarm.md#arm_disarm_gestures)).
   - Alternatively configure an [arm/disarm switch](../config/safety.md#arm-disarm-switch).
   - You can also arm in _QGroundControl_ (PX4 does not require a radio control for flying autonomously).
 

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -280,7 +280,7 @@ For more information see: [Payloads & Cameras](../payloads/index.md)
 ## Arming and Disarming
 
 A vehicle is said to be _armed_ when all motors and actuators are powered, and _disarmed_ when nothing is powered.
-There is also a _prearmed_ state when only actuators are powered, which is primarily used for testing.
+There is also a _prearmed_ state when only servo actuators are powered, which is primarily used for testing.
 
 A vehicle is usually disarmed on the ground, and must be armed before taking off in the current flight mode.
 

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -280,10 +280,12 @@ For more information see: [Payloads & Cameras](../payloads/index.md)
 ## Arming and Disarming
 
 A vehicle is said to be _armed_ when all motors and actuators are powered, and _disarmed_ when nothing is powered.
-There is also a _prearmed_ state when only actuators are powered.
+There is also a _prearmed_ state when only actuators are powered, which is primarily used for testing.
+
+A vehicle is usually disarmed on the ground, and must be armed before taking off in the current flight mode.
 
 :::warning
-Armed vehicles can be dangerous as propellors will be spinning.
+Armed vehicles are dangerous because propellers can start spinning at any time without further user input, and in many cases will start spinning immediately.
 :::
 
 Arming and disarming are triggered by default using RC stick _gestures_.


### PR DESCRIPTION
This add some clarifications falling out of the discussion in https://github.com/PX4/PX4-Autopilot/pull/23822#issuecomment-2431481264

Essentially on arming the motors may not start turning, but they can do so at any time without user input. This makes that difference clear. For MC it notes that the props will start turning except for during throw launch.


