### PR TITLE
Update Lightware Lidar Docs

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -237,7 +237,7 @@
       - [TFSlot Airspeed Sensor](sensor/airspeed_tfslot.md)
     - [Barometers](sensor/barometer.md)
     - [Distance Sensors \(Rangefinders\)](sensor/rangefinders.md)
-      - [Lightware SFxx Lidar](sensor/sfxx_lidar.md)
+      - [Lightware Lidars (SF/LW)](sensor/sfxx_lidar.md)
       - [Ainstein US-D1 Standard Radar Altimeter](sensor/ulanding_radar.md)
       - [LeddarOne Lidar](sensor/leddar_one.md)
       - [Benewake TFmini Lidar](sensor/tfmini.md)

--- a/en/sensor/sfxx_lidar.md
+++ b/en/sensor/sfxx_lidar.md
@@ -21,7 +21,7 @@ The following models are supported by PX4, and can be connected to either the I2
 The following models are no longer available from the manufacturer.
 
 | Model                                                                                              | Range | Bus           |
-| -------------------------------------------------------------------------------------------------- | ----- | ------------- |
+| -------------------------------------------------------------------------------------------------- | ----- | ------------- | --------------------------------------------------------------- |
 | [SF02](http://documents.lightware.co.za/SF02%20-%20Laser%20Rangefinder%20Manual%20-%20Rev%208.pdf) | 50    | Serial        |
 | [SF10/A](http://documents.lightware.co.za/SF10%20-%20Laser%20Altimeter%20Manual%20-%20Rev%206.pdf) | 25    | Serial or I2C |
 | [SF10/B](http://documents.lightware.co.za/SF10%20-%20Laser%20Altimeter%20Manual%20-%20Rev%206.pdf) | 50    | Serial or I2C |
@@ -32,14 +32,14 @@ The following models are no longer available from the manufacturer.
 
 Check the tables above to confirm that which models can be connected to the I2C port.
 
-### Lidar Configuration
+### Lidar Configuration (SF11/C)
 
-This hardware does not ship with Pixhawk I2C compatibility enabled by default.
+The SF11/C hardware (only) does not ship with Pixhawk I2C compatibility enabled by default.
 To enable support, you have to download [LightWare Studio](https://lightwarelidar.com/pages/lightware-studio) and got to **Parameters > Communication** and tick mark **I2C compatibility mode (Pixhawk)**
 
 ![LightWare SF11/C Lidar-I2C Config](../../assets/hardware/sensors/lidar_lightware/lightware_studio_i2c_config.jpg)
 
-<a id="i2c_hardware_setup"></a>
+This step is not required for the other supported Lightware rangefinders.
 
 ### Hardware
 


### PR DESCRIPTION
This step seems to not be necessary any more. Never had to do it on the LW20/C, and also checked lightware studio, and there isn't event the option for a "pixhawk compatability mode" any more. 

Cant say anything about the other lightware sensors like the SF11/C in the screenshot.
Does someone have one of these to test?
