### PR TITLE
Apple Silicon typo

### DIFF
--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -22,7 +22,7 @@ The "base" macOS setup installs the tools needed for building firmware, and incl
 ### Environment Setup
 
 :::details Apple Silicon Macbook users!
-If you have an Apple M1 Macbook, make sure to run the terminal as x86 by setting up an x86 terminal:
+If you have an Apple M1, M2 etc. Macbook, make sure to run the terminal as x86 by setting up an x86 terminal:
 
 1. Locate the Terminal application within the Utilities folder (**Finder > Go menu > Utilities**)
 2. Select _Terminal.app_ and right-click on it, then choose **Duplicate**.

--- a/en/dev_setup/dev_env_mac.md
+++ b/en/dev_setup/dev_env_mac.md
@@ -21,7 +21,7 @@ The "base" macOS setup installs the tools needed for building firmware, and incl
 
 ### Environment Setup
 
-:::details Apple M1 Macbook users!
+:::details Apple Silicon Macbook users!
 If you have an Apple M1 Macbook, make sure to run the terminal as x86 by setting up an x86 terminal:
 
 1. Locate the Terminal application within the Utilities folder (**Finder > Go menu > Utilities**)


### PR DESCRIPTION
As we are4 on Apple M4 series released this year, I think it is better we just mention Apple Silicon instead of M1. 

The docs are old. I need to make a PR to correct everything since I was able to run gz on native Apple Silicon with SITL. 

Let us fix this typo for now. 