### PR TITLE
Fix superexpo calculation graph links

### DIFF
--- a/en/flight_modes_mc/acro.md
+++ b/en/flight_modes_mc/acro.md
@@ -54,9 +54,11 @@ This roll and pitch input stick response can be tuned using the [MC_ACRO_EXPO](#
 ::: info
 The mathematical relationship is:
 
-$$\mathrm{y} = r(f \cdot x^3 + x(1-f)) (1-g)/(1-g |x|)$$, where `f = MC_ACRO_EXPO` or `MC_ACRO_EXPO_Y`, `g = MC_ACRO_SUPEXPO` or `MC_ACRO_SUPEXPOY`,and `r` is the maximum rate.
+$$\mathrm{y} = r(f \cdot x^3 + x(1-f)) (1-g)/(1-g |x|)$$
 
-You can experiment with the relationships [here](https://www.desmos.com/calculator/yty5kgurmc).
+Where `f = MC_ACRO_EXPO` or `MC_ACRO_EXPO_Y`, `g = MC_ACRO_SUPEXPO` or `MC_ACRO_SUPEXPOY`, and `r` is the maximum rate.
+
+You can experiment with the relationships graphically using the [PX4 SuperExpo calculator](https://www.desmos.com/calculator/yty5kgurmc).
 :::
 
 ## Parameters


### PR DESCRIPTION
Fixes layout issue that stopped proper rendering of link for the expo calculator

Is a follow on to #3310