### PR TITLE
Position loss failsafe configurable delay removed (COM_POS_FS_DELAY)

### DIFF
--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -196,10 +196,9 @@ If VTOLs have are configured to switch to hover for landing ([NAV_FORCE_VT](../a
 
 The relevant parameters for all vehicles shown below.
 
-| Parameter                                                                                                   | Description                                                                                               |
-| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| <a id="COM_POS_FS_DELAY"></a>[COM_POS_FS_DELAY](../advanced_config/parameter_reference.md#COM_POS_FS_DELAY) | Delay after loss of position before the failsafe is triggered.                                            |
-| <a id="COM_POSCTL_NAVL"></a>[COM_POSCTL_NAVL](../advanced_config/parameter_reference.md#COM_POSCTL_NAVL)    | Position control navigation loss response during mission. Values: 0 - assume use of RC, 1 - Assume no RC. |
+| Parameter | Description |
+| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | |
+| <a id="COM_POSCTL_NAVL"></a>[COM_POSCTL_NAVL](../advanced_config/parameter_reference.md#COM_POSCTL_NAVL) | Position control navigation loss response during mission. Values: 0 - assume use of RC, 1 - Assume no RC. |
 
 Parameters that only affect Fixed-wing vehicles:
 

--- a/en/releases/main.md
+++ b/en/releases/main.md
@@ -29,9 +29,11 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ### Common
 
-- [Battery level estimation improvements](../config/battery.md) ([PX4-Autopilot#23205](https://github.com/PX4/PX4-Autopilot/pull/23205)).
+- [Battery level estimation improvements](../config/battery.md). ([PX4-Autopilot#23205](https://github.com/PX4/PX4-Autopilot/pull/23205)).
   - [Voltage-based estimation with load compensation](../config/battery.md#voltage-based-estimation-with-load-compensation) now uses a real-time estimate of the internal resistance of the battery to compensate voltage drops under load (with increased current), providing a better capacity estimate than with the raw measured voltage.
   - Thrust-based load compensation has been removed (along with the `BATn_V_LOAD_DROP` parameters, where `n` is the battery number).
+- The [Position (GNSS) loss failsafe](../config/safety.md#position-gnss-loss-failsafe) configurable delay (`COM_POS_FS_DELAY`) has been removed.
+  The failsafe will now trigger 1 second after position has been lost. ([PX4-Autopilot#24063](https://github.com/PX4/PX4-Autopilot/pull/24063)).
 
 ### Control
 


### PR DESCRIPTION
This is docs fix for https://github.com/PX4/PX4-Autopilot/pull/24063