### PR TITLE
Fix up cross/check marks

### DIFF
--- a/en/dev_setup/dev_env.md
+++ b/en/dev_setup/dev_env.md
@@ -10,14 +10,14 @@ The _supported platforms_ for PX4 development are:
 
 The table below shows what PX4 targets you can build on each OS.
 
-| Target                                                                                                                              | Linux (Ubuntu) |   Mac   | Windows |
-| ----------------------------------------------------------------------------------------------------------------------------------- | :------------: | :-----: | :-----: |
-| **NuttX based hardware:** [Pixhawk Series](../flight_controller/pixhawk_series.md), [Crazyflie](../complete_vehicles_mc/crazyflie2.md) |    &check;     | &check; | &check; |
-| **Linux-based hardware:** [Raspberry Pi 2/3](../flight_controller/raspberry_pi_navio2.md)                                           |    &check;     |         |
-| **Simulation:** [Gazebo SITL](../sim_gazebo_gz/index.md)                                                                           |    &check;     | &check; | &check; |
-| **Simulation:** [Gazebo Classic SITL](../sim_gazebo_classic/index.md)                                                              |    &check;     | &check; | &check; |
-| **Simulation:** [ROS with Gazebo Classic](../simulation/ros_interface.md)                                                           |    &check;     |         | &check; |
-| **Simulation:** ROS 2 with Gazebo                                                                                                   |    &check;     |         | &check; |
+| Target                                                                                                                                 | Linux (Ubuntu) | Mac | Windows |
+| -------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :-: | :-----: |
+| **NuttX based hardware:** [Pixhawk Series](../flight_controller/pixhawk_series.md), [Crazyflie](../complete_vehicles_mc/crazyflie2.md) |       ✓        |  ✓  |    ✓    |
+| **Linux-based hardware:** [Raspberry Pi 2/3](../flight_controller/raspberry_pi_navio2.md)                                              |       ✓        |     |         |
+| **Simulation:** [Gazebo SITL](../sim_gazebo_gz/index.md)                                                                               |       ✓        |  ✓  |    ✓    |
+| **Simulation:** [Gazebo Classic SITL](../sim_gazebo_classic/index.md)                                                                  |       ✓        |  ✓  |    ✓    |
+| **Simulation:** [ROS with Gazebo Classic](../simulation/ros_interface.md)                                                              |       ✓        |     |    ✓    |
+| **Simulation:** ROS 2 with Gazebo                                                                                                      |       ✓        |     |    ✓    |
 
 Experienced Docker users can also build with the containers used by our continuous integration system: [Docker Containers](../test_and_ci/docker.md)
 

--- a/en/flight_modes/offboard.md
+++ b/en/flight_modes/offboard.md
@@ -76,7 +76,7 @@ For example, if the `acceleration` field is the first non-zero value, then PX4 r
 | thrust and torque (FRD)  | ✗              | ✗              | ✗                  | ✗              | ✗               | ✓                       | -                     | none              | [VehicleThrustSetpoint](../msg_docs/VehicleThrustSetpoint.md) and [VehicleTorqueSetpoint](../msg_docs/VehicleTorqueSetpoint.md) |
 | direct motors and servos | ✗              | ✗              | ✗                  | ✗              | ✗               | ✗                       | ✓                     | none              | [ActuatorMotors](../msg_docs/ActuatorMotors.md) and [ActuatorServos](../msg_docs/ActuatorServos.md)                             |
 
-where &check; means that the bit is set, &cross; means that the bit is not set and `-` means that the bit is value is irrelevant.
+where ✓ means that the bit is set, ✘ means that the bit is not set and `-` means that the bit is value is irrelevant.
 
 ::: info
 Before using offboard mode with ROS 2, please spend a few minutes understanding the different [frame conventions](../ros2/user_guide.md#ros-2-px4-frame-conventions) that PX4 and ROS 2 use.
@@ -87,6 +87,7 @@ Before using offboard mode with ROS 2, please spend a few minutes understanding 
 - [px4_msgs::msg::TrajectorySetpoint](https://github.com/PX4/PX4-Autopilot/blob/main/msg/TrajectorySetpoint.msg)
 
   - The following input combinations are supported:
+
     - Position setpoint (`position` different from `NaN`). Non-`NaN` values of velocity and acceleration are used as feedforward terms for the inner loop controllers.
     - Velocity setpoint (`velocity` different from `NaN` and `position` set to `NaN`). Non-`NaN` values acceleration are used as feedforward terms for the inner loop controllers.
     - Acceleration setpoint (`acceleration` different from `NaN` and `position` and `velocity` set to `NaN`)

--- a/en/gps_compass/index.md
+++ b/en/gps_compass/index.md
@@ -24,29 +24,29 @@ These have been tested by the PX4 dev team, or which are popular within the PX4 
 
 | Device                                                       |     GPS     |          Compass          | [CAN](../dronecan/index.md) | Buzzer / SafeSw / LED | Notes                       |
 | :----------------------------------------------------------- | :---------: | :-----------------------: | :-------------------------: | :-------------------: | :-------------------------- |
-| [ARK GPS](../dronecan/ark_gps.md)                            |     M9N     |          BMM150           |           &check;           |        &check;        | + Baro, IMU                 |
-| [ARK TESEO GPS](../dronecan/ark_teseo_gps.md)                | Teseo-LIV4F |          BMM150           |           &check;           |        &check;        | + Baro, IMU                 |
-| [Avionics Anonymous UAVCAN GNSS/Mag][avionics_anon_can_gnss] |   SAM-M8Q   |         MMC5983MA         |           &check;           |        &cross;        |                             |
-| [CUAV NEO 3 GPS](../gps_compass/gps_cuav_neo_3.md)           |     M9N     |          IST8310          |                             |        &check;        |                             |
-| [CUAV NEO 3 Pro GPS](../gps_compass/gps_cuav_neo_3pro.md)    |     M9N     |          RM3100           |           &check;           |        &check;        | + Baro                      |
-| [CUAV NEO 3X GPS](../gps_compass/gps_cuav_neo_3x.md)         |     M9N     |          RM3100           |           &check;           | &cross;&check;&check; | + Baro.                     |
-| [CubePilot Here2 GNSS GPS (M8N)][CubePilot Here2]            |     M8N     |         ICM20948          |                             |        &check;        | Superseded by HERE3         |
-| [Emlid Reach M+](https://emlid.com/reach/)                   |   &check;   |          &cross;          |                             |        &cross;        | Supports PPK. RTK expected. |
-| [Holybro DroneCAN M8N GPS](../dronecan/holybro_m8n_gps.md)   |     M8N     |          BMM150           |           &check;           |        &cross;        | + Baro                      |
-| [Holybro Micro M8N GPS][Hb Micro M8N]                        |     M8N     |          IST8310          |                             |        &cross;        |                             |
-| [Holybro Nano Ublox M8 5883 GPS][hb_nano_m8_5883]            |  UBX-M8030  |          QMC5883          |                             |        &cross;        |                             |
-| [Holybro M8N GPS](../gps_compass/gps_holybro_m8n_m9n.md)     |     M8N     |          IST8310          |                             |        &check;        |                             |
-| [Holybro M9N GPS](../gps_compass/gps_holybro_m8n_m9n.md)     |     M9N     |          IST8310          |                             |        &check;        |                             |
-| [Holybro DroneCAN M9N GPS][hb_can_m9n]                       |     M9N     |          BMM150           |           &check;           |        &check;        |                             |
-| [Holybro M10 GPS][hb_m10]                                    |     M10     |          IST8310          |                             |        &check;        |                             |
-| [Hobbyking u-blox Neo-M8N GPS & Compass][hk_ublox_neo_8mn]   |     M8N     |          &check;          |                             |        &cross;        |                             |
-| [LOCOSYS Hawk A1 GNSS receiver][LOCOSYS Hawk A1]             | MC-1612-V2b |         optional          |                             | &cross;&cross;&check; |                             |
-| [LOCOSYS Hawk R1](../gps_compass/rtk_gps_locosys_r1.md)      | MC-1612-V2b |                           |                             | &cross;&cross;&check; |                             |
-| [LOCOSYS Hawk R2](../gps_compass/rtk_gps_locosys_r2.md)      | MC-1612-V2b |          IST8310          |                             | &cross;&cross;&check; |                             |
-| [mRo GPS u-blox Neo-M8N Dual Compass][mro_neo8mn_dual_mag]   |     M8N     |     LIS3MDL, IST8308      |                             |        &cross;        |                             |
-| [RaccoonLab L1 GNSS NEO-M8N][RccnLabGNSS250]                 |   NEO-M8N   |          RM3100           |           &check;           | &cross;&cross;&check; | + Baro                      |
-| [Sky-Drones SmartAP GPS](../gps_compass/gps_smartap.md)      |     M8N     | HMC5983, IST8310, LIS3MDL |                             |        &check;        | + Baro                      |
-| [Zubax GNSS 2](https://zubax.com/products/gnss_2)            |   MAX-M8Q   |          LIS3MDL          |                             |        &cross;        | + Baro                      |
+| [ARK GPS](../dronecan/ark_gps.md)                            |     M9N     |          BMM150           |              ✓              |           ✓           | + Baro, IMU                 |
+| [ARK TESEO GPS](../dronecan/ark_teseo_gps.md)                | Teseo-LIV4F |          BMM150           |              ✓              |           ✓           | + Baro, IMU                 |
+| [Avionics Anonymous UAVCAN GNSS/Mag][avionics_anon_can_gnss] |   SAM-M8Q   |         MMC5983MA         |              ✓              |           ✘           |                             |
+| [CUAV NEO 3 GPS](../gps_compass/gps_cuav_neo_3.md)           |     M9N     |          IST8310          |                             |           ✓           |                             |
+| [CUAV NEO 3 Pro GPS](../gps_compass/gps_cuav_neo_3pro.md)    |     M9N     |          RM3100           |              ✓              |           ✓           | + Baro                      |
+| [CUAV NEO 3X GPS](../gps_compass/gps_cuav_neo_3x.md)         |     M9N     |          RM3100           |              ✓              |          ✘✓✓          | + Baro.                     |
+| [CubePilot Here2 GNSS GPS (M8N)][CubePilot Here2]            |     M8N     |         ICM20948          |                             |           ✓           | Superseded by HERE3         |
+| [Emlid Reach M+](https://emlid.com/reach/)                   |      ✓      |             ✘             |                             |           ✘           | Supports PPK. RTK expected. |
+| [Holybro DroneCAN M8N GPS](../dronecan/holybro_m8n_gps.md)   |     M8N     |          BMM150           |              ✓              |           ✘           | + Baro                      |
+| [Holybro Micro M8N GPS][Hb Micro M8N]                        |     M8N     |          IST8310          |                             |           ✘           |                             |
+| [Holybro Nano Ublox M8 5883 GPS][hb_nano_m8_5883]            |  UBX-M8030  |          QMC5883          |                             |           ✘           |                             |
+| [Holybro M8N GPS](../gps_compass/gps_holybro_m8n_m9n.md)     |     M8N     |          IST8310          |                             |           ✓           |                             |
+| [Holybro M9N GPS](../gps_compass/gps_holybro_m8n_m9n.md)     |     M9N     |          IST8310          |                             |           ✓           |                             |
+| [Holybro DroneCAN M9N GPS][hb_can_m9n]                       |     M9N     |          BMM150           |              ✓              |           ✓           |                             |
+| [Holybro M10 GPS][hb_m10]                                    |     M10     |          IST8310          |                             |           ✓           |                             |
+| [Hobbyking u-blox Neo-M8N GPS & Compass][hk_ublox_neo_8mn]   |     M8N     |             ✓             |                             |           ✘           |                             |
+| [LOCOSYS Hawk A1 GNSS receiver][LOCOSYS Hawk A1]             | MC-1612-V2b |         optional          |                             |          ✘✘✓          |                             |
+| [LOCOSYS Hawk R1](../gps_compass/rtk_gps_locosys_r1.md)      | MC-1612-V2b |                           |                             |          ✘✘✓          |                             |
+| [LOCOSYS Hawk R2](../gps_compass/rtk_gps_locosys_r2.md)      | MC-1612-V2b |          IST8310          |                             |          ✘✘✓          |                             |
+| [mRo GPS u-blox Neo-M8N Dual Compass][mro_neo8mn_dual_mag]   |     M8N     |     LIS3MDL, IST8308      |                             |           ✘           |                             |
+| [RaccoonLab L1 GNSS NEO-M8N][RccnLabGNSS250]                 |   NEO-M8N   |          RM3100           |              ✓              |          ✘✘✓          | + Baro                      |
+| [Sky-Drones SmartAP GPS](../gps_compass/gps_smartap.md)      |     M8N     | HMC5983, IST8310, LIS3MDL |                             |           ✓           | + Baro                      |
+| [Zubax GNSS 2](https://zubax.com/products/gnss_2)            |   MAX-M8Q   |          LIS3MDL          |                             |           ✘           | + Baro                      |
 
 <!-- links to improve layout of table for editing -->
 
@@ -63,9 +63,9 @@ These have been tested by the PX4 dev team, or which are popular within the PX4 
 
 Notes:
 
-- &check; or a specific part number indicate that a features is supported, while &cross; or empty show that the feature is not supported.
+- ✓ or a specific part number indicate that a features is supported, while ✘ or empty show that the feature is not supported.
   "?" indicates "unknown".
-- Where possible and relevant the part name is used (i.e. &check; in the GPS column indicates that a GPS module is present but the part is not known).
+- Where possible and relevant the part name is used (i.e. ✓ in the GPS column indicates that a GPS module is present but the part is not known).
 - The list may omit some discontinued hardware that is still supported (check earlier versions for info about discontinued modules).
   Removed items include:
   - _Here_ GPS

--- a/en/gps_compass/magnetometer.md
+++ b/en/gps_compass/magnetometer.md
@@ -40,13 +40,13 @@ This list contains stand-alone magnetometer modules (without GNSS).
 
 | Device                                                                                                           | Compass | DroneCan |
 | :--------------------------------------------------------------------------------------------------------------- | :-----: | :------: |
-| [Avionics Anonymous UAVCAN Magnetometer](https://www.tindie.com/products/avionicsanonymous/uavcan-magnetometer/) |    ?    |
-| [Holybro DroneCAN RM3100 Compass/Magnetometer](https://holybro.com/products/dronecan-rm3100-compass)             | RM3100  | &check;  |
-| [RaccoonLab DroneCAN/Cyphal Magnetometer RM3100](https://holybro.com/products/dronecan-rm3100-compass)           | RM3100  | &check;  |
+| [Avionics Anonymous UAVCAN Magnetometer](https://www.tindie.com/products/avionicsanonymous/uavcan-magnetometer/) |    ?    |          |
+| [Holybro DroneCAN RM3100 Compass/Magnetometer](https://holybro.com/products/dronecan-rm3100-compass)             | RM3100  |    ✓     |
+| [RaccoonLab DroneCAN/Cyphal Magnetometer RM3100](https://holybro.com/products/dronecan-rm3100-compass)           | RM3100  |    ✓     |
 
 Note:
 
-- &check; or a specific part number indicate that a features is supported, while &cross; or empty show that the feature is not supported.
+- ✓ or a specific part number indicate that a features is supported, while ✘ or empty show that the feature is not supported.
   "?" indicates "unknown".
 - A compass that is not "DroneCAN" can be assumed to be SPI or I2C.
 

--- a/en/gps_compass/rtk_gps.md
+++ b/en/gps_compass/rtk_gps.md
@@ -22,37 +22,37 @@ It also highlights devices that connect via the CAN bus, and those which support
 
 Device | GPS | Compass | [DroneCAN](../dronecan/index.md) | [GPS Yaw](#configuring-gps-as-yaw-heading-source) | PPK
 :--- | :---: | :---:  | :---:  | :---:  | :---:
-[ARK RTK GPS](../dronecan/ark_rtk_gps.md) | F9P  | BMM150 | &check; | [Dual F9P][DualF9P] |
-[ARK MOSAIC-X5 RTK GPS](../dronecan/ark_mosaic__rtk_gps.md) | Mosaic-X5  | IIS2MDC | &check; | [Septentrio Dual Antenna][SeptDualAnt] |
-[CUAV C-RTK GPS](../gps_compass/rtk_gps_cuav_c-rtk.md) | M8P/M8N | &check; | | |
-[CUAV C-RTK2](../gps_compass/rtk_gps_cuav_c-rtk2.md) | F9P |  &check; | | [Dual F9P][DualF9P] |
+[ARK RTK GPS](../dronecan/ark_rtk_gps.md) | F9P  | BMM150 | ✓ | [Dual F9P][DualF9P] |
+[ARK MOSAIC-X5 RTK GPS](../dronecan/ark_mosaic__rtk_gps.md) | Mosaic-X5  | IIS2MDC | ✓ | [Septentrio Dual Antenna][SeptDualAnt] |
+[CUAV C-RTK GPS](../gps_compass/rtk_gps_cuav_c-rtk.md) | M8P/M8N | ✓ | | |
+[CUAV C-RTK2](../gps_compass/rtk_gps_cuav_c-rtk2.md) | F9P |  ✓ | | [Dual F9P][DualF9P] |
 [CUAV C-RTK 9Ps GPS](../gps_compass/rtk_gps_cuav_c-rtk-9ps.md) | F9P | RM3100 | | [Dual F9P][DualF9P] |
-[CUAV C-RTK2 PPK/RTK GNSS](../gps_compass/rtk_gps_cuav_c-rtk.md) | F9P | RM3100 | | | &check;
+[CUAV C-RTK2 PPK/RTK GNSS](../gps_compass/rtk_gps_cuav_c-rtk.md) | F9P | RM3100 | | | ✓
 [CubePilot Here+ RTK GPS](../gps_compass/rtk_gps_hex_hereplus.md) | M8P | HMC5983 | | |
-[CubePilot Here3 CAN GNSS GPS (M8N)](https://www.cubepilot.org/#/here/here3) | M8P | ICM20948 | &check; | |
+[CubePilot Here3 CAN GNSS GPS (M8N)](https://www.cubepilot.org/#/here/here3) | M8P | ICM20948 | ✓ | |
 [Drotek SIRIUS RTK GNSS ROVER (F9P)](https://store-drotek.com/911-sirius-rtk-gnss-rover-f9p.html) | F9P | RM3100 | | [Dual F9P][DualF9P] |
-[DATAGNSS GEM1305 RTK Receiver][DATAGNSS GEM1305 RTK] | TAU951M | &cross; | | &cross; |
-[Femtones MINI2 Receiver](../gps_compass/rtk_gps_fem_mini2.md) | FB672, FB6A0 | &check; | | |
+[DATAGNSS GEM1305 RTK Receiver][DATAGNSS GEM1305 RTK] | TAU951M | ✘ | | ✘ |
+[Femtones MINI2 Receiver](../gps_compass/rtk_gps_fem_mini2.md) | FB672, FB6A0 | ✓ | | |
 [Freefly RTK GPS](../gps_compass/rtk_gps_freefly.md) | F9P | IST8310 | | |
-[Holybro H-RTK ZED-F9P RTK Rover (DroneCAN variant)](../dronecan/holybro_h_rtk_zed_f9p_gps.md) | F9P | RM3100 | &check; | [Dual F9P][DualF9P] |
+[Holybro H-RTK ZED-F9P RTK Rover (DroneCAN variant)](../dronecan/holybro_h_rtk_zed_f9p_gps.md) | F9P | RM3100 | ✓ | [Dual F9P][DualF9P] |
 [Holybro H-RTK ZED-F9P RTK Rover](https://holybro.com/collections/h-rtk-gps/products/h-rtk-zed-f9p-rover) | F9P | RM3100 | | [Dual F9P][DualF9P] |
 [Holybro H-RTK F9P Ultralight](https://holybro.com/products/h-rtk-f9p-ultralight) | F9P | IST8310 | | [Dual F9P][DualF9P]|
 [Holybro H-RTK F9P Helical or Base](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | F9P | IST8310 | | [Dual F9P][DualF9P]|
-[Holybro DroneCAN H-RTK F9P Helical](https://holybro.com/products/dronecan-h-rtk-f9p-helical) | F9P | BMM150 | &check; | [Dual F9P][DualF9P] |
+[Holybro DroneCAN H-RTK F9P Helical](https://holybro.com/products/dronecan-h-rtk-f9p-helical) | F9P | BMM150 | ✓ | [Dual F9P][DualF9P] |
 [Holybro H-RTK F9P Rover Lite](../gps_compass/rtk_gps_holybro_h-rtk-f9p.md) | F9P | IST8310 | | | |
 [Holybro DroneCAN H-RTK F9P Rover](https://holybro.com/products/dronecan-h-rtk-f9p-rover) | F9P | BMM150 | | [Dual F9P][DualF9P] |
 [Holybro H-RTK M8P GNSS](../gps_compass/rtk_gps_holybro_h-rtk-m8p.md) | M8P | IST8310 | |
 [Holybro H-RTK Unicore UM982 GPS](../gps_compass/rtk_gps_holybro_unicore_um982.md) | UM982 | IST8310 | | [Unicore Dual Antenna][UnicoreDualAnt] |
 [LOCOSYS Hawk R1](../gps_compass/rtk_gps_locosys_r1.md) | MC-1612-V2b | | | |
 [LOCOSYS Hawk R2](../gps_compass/rtk_gps_locosys_r2.md) | MC-1612-V2b | IST8310 | | |
-[mRo u-blox ZED-F9 RTK L1/L2 GPS](https://store.mrobotics.io/product-p/m10020d.htm) | F9P | &check; | | [Dual F9P][DualF9P] |
-[RaccoonLab L1/L2 ZED-F9P][RaccoonLab L1/L2 ZED-F9P] | F9P |  RM3100 | &check; | | |
-[RaccoonLab L1/L2 ZED-F9P with external antenna][RaccnLabL1L2ZED-F9P ext_ant] | F9P |  RM3100 | &check; | |
-[Septentrio AsteRx-m3 Pro](../gps_compass/septentrio_asterx-rib.md) | AsteRx | &check; | | [Septentrio Dual Antenna][SeptDualAnt] | &check; |
-[Septentrio mosaic-go](../gps_compass/septentrio_mosaic-go.md)   | mosaic X5 / mosaic H | &check; | | [Septentrio Dual Antenna][SeptDualAnt]  | &check; |
-[SIRIUS RTK GNSS ROVER (F9P)](https://store-drotek.com/911-sirius-rtk-gnss-rover-f9p.html) | F9P |  &check; | | [Dual F9P][DualF9P] |
-[SparkFun GPS-RTK2 Board - ZED-F9P](https://www.sparkfun.com/products/15136) | F9P |  &check; | | [Dual F9P][DualF9P] |
-[Trimble MB-Two](../gps_compass/rtk_gps_trimble_mb_two.md) | F9P | &check; | | &check; | |
+[mRo u-blox ZED-F9 RTK L1/L2 GPS](https://store.mrobotics.io/product-p/m10020d.htm) | F9P | ✓ | | [Dual F9P][DualF9P] |
+[RaccoonLab L1/L2 ZED-F9P][RaccoonLab L1/L2 ZED-F9P] | F9P |  RM3100 | ✓ | | |
+[RaccoonLab L1/L2 ZED-F9P with external antenna][RaccnLabL1L2ZED-F9P ext_ant] | F9P |  RM3100 | ✓ | |
+[Septentrio AsteRx-m3 Pro](../gps_compass/septentrio_asterx-rib.md) | AsteRx | ✓ | | [Septentrio Dual Antenna][SeptDualAnt] | ✓ |
+[Septentrio mosaic-go](../gps_compass/septentrio_mosaic-go.md)   | mosaic X5 / mosaic H | ✓ | | [Septentrio Dual Antenna][SeptDualAnt]  | ✓ |
+[SIRIUS RTK GNSS ROVER (F9P)](https://store-drotek.com/911-sirius-rtk-gnss-rover-f9p.html) | F9P |  ✓ | | [Dual F9P][DualF9P] |
+[SparkFun GPS-RTK2 Board - ZED-F9P](https://www.sparkfun.com/products/15136) | F9P |  ✓ | | [Dual F9P][DualF9P] |
+[Trimble MB-Two](../gps_compass/rtk_gps_trimble_mb_two.md) | F9P | ✓ | | ✓ | |
 
 <!-- links used in above table -->
 
@@ -65,9 +65,9 @@ Device | GPS | Compass | [DroneCAN](../dronecan/index.md) | [GPS Yaw](#configuri
 
 Notes:
 
-- &check; or a specific part number indicate that a features is supported, while &cross; or empty show that the feature is not supported.
+- ✓ or a specific part number indicate that a features is supported, while ✘ or empty show that the feature is not supported.
   "?" indicates "unknown".
-- Where possible and relevant the part name is used (i.e. &check; in the GPS column indicates that a GPS module is present but the part is not known).
+- Where possible and relevant the part name is used (i.e. ✓ in the GPS column indicates that a GPS module is present but the part is not known).
 - Some RTK modules can only be used in a particular role (base or rover), while others can be used interchangeably.
 - The list may omit some discontinued hardware that is still supported.
   For example [CubePilot Here+ RTK GPS](../gps_compass/rtk_gps_hex_hereplus.md) is discontinued and may be removed from the list in a future release.

--- a/en/gps_compass/septentrio_mosaic-go.md
+++ b/en/gps_compass/septentrio_mosaic-go.md
@@ -125,14 +125,14 @@ The web interface also uses easy-to-read quality indicators ideal to monitor the
 
 ## LED Status
 
-| LED Color     | Powered  | SD card mounted | PVT Solution | Logging enabled |
-| ------------- | :------: | :-------------: | :----------: | :-------------: |
-| Red           | &check;️ |                 |              |                 |
-| Green         | &check;️ |    &check;️     |              |                 |
-| Blue          | &check;️ |    &check;️     |   &check;️   |                 |
-| Purple        | &check;️ |                 |   &check;️   |                 |
-| Purple + Blue | &check;️ |    &check;️     |   &check;️   |    &check;️     |
-| Red + Green   | &check;️ |    &check;️     |              |    &check;️     |
+| LED Color     | Powered | SD card mounted | PVT Solution | Logging enabled |
+| ------------- | :-----: | :-------------: | :----------: | :-------------: |
+| Red           |    ✓    |                 |              |                 |
+| Green         |    ✓    |        ✓        |              |                 |
+| Blue          |    ✓    |        ✓        |      ✓       |                 |
+| Purple        |    ✓    |                 |      ✓       |                 |
+| Purple + Blue |    ✓    |        ✓        |      ✓       |        ✓        |
+| Red + Green   |    ✓    |        ✓        |              |        ✓        |
 
 :::tip
 For more detailed information about the mosaic-go and its module, please refer to the [hardware manual](https://web.septentrio.com/l/858493/2022-04-19/xgrrd) or the [Septentrio Support](https://support.septentrio.com/l/858493/2022-04-19/xgrrl) page.


### PR DESCRIPTION
The html cross and  check mark symbols work fine in English tree, but crowdin is escaping them so they render as `&check;` insead of &check; (for example) in translations. This changes to a unicode check symbol that should survive the round trip.