### PR TITLE
docs_deploy.yml - attempt to always amend rather than append

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -89,5 +89,5 @@ jobs:
           git config --global user.name "${{ secrets.PX4BUILDBOT_USER }}"
           git config --global user.email "${{ secrets.PX4BUILDBOT_EMAIL }}"
           git add ${BRANCH_NAME}
-          git commit -a -m "PX4 docs build update (vitepress) `date`"
+          git commit --amend -m "PX4 docs build update (vitepress) `date`"
           git push origin main


### PR DESCRIPTION
This attempts to amend changes rather than append them. Idea is that the repo docs.prx4.io won't grow other than with new docs we add - it will keep no history.

What happens now is that it gets bigger and bigger with relatively constrained changes.