### PR TITLE
Mission command timeout

### DIFF
--- a/en/advanced/gimbal_control.md
+++ b/en/advanced/gimbal_control.md
@@ -75,6 +75,18 @@ For example, you might have the following settings to assign the gimbal roll, pi
 The PWM values to use for the disarmed, maximum and minimum values can be determined in the same way as other servo, using the [Actuator Test sliders](../config/actuators.md#actuator-testing) to confirm that each slider moves the appropriate axis, and changing the values so that the gimbal is in the appropriate position at the disarmed, low and high position in the slider.
 The values may also be provided in gimbal documentation.
 
+## Gimbal Control in Missions
+
+[Gimbal Manager commands](https://mavlink.io/en/services/gimbal_v2.html#gimbal-manager-messages) may be used in missions if supported by the vehicle type.
+For example [MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW) is supported in [multicopter mission mode](../flight_modes_mc/mission.md).
+
+In theory you can address commands to a particular gimbal, specifying its component id using the "Gimbal device id" parameter.
+However at time of writing (December 2024) this is [not supported](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/input_mavlink.cpp#L889): all commands are sent to the gimbal with id [MAV_COMP_ID_GIMBAL (154)](https://mavlink.io/en/messages/common.html#MAV_COMP_ID_GIMBAL)
+
+Gimbal movement is not immediate.
+To ensure that the gimbal has time to move into position before the mission progresses to the next item (if gimbal feedback is not provided or lost), you should set [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT) to be greater than the time taken for the gimbal to traverse its full range.
+After this timeout the mission will proceed to the next item.
+
 ## SITL
 
 The [Gazebo Classic](../sim_gazebo_classic/index.md) simulation [Typhoon H480 model](../sim_gazebo_classic/vehicles.md#typhoon-h480-hexrotor) comes with a preconfigured simulated gimbal.

--- a/en/advanced/gimbal_control.md
+++ b/en/advanced/gimbal_control.md
@@ -80,9 +80,6 @@ The values may also be provided in gimbal documentation.
 [Gimbal Manager commands](https://mavlink.io/en/services/gimbal_v2.html#gimbal-manager-messages) may be used in missions if supported by the vehicle type.
 For example [MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW) is supported in [multicopter mission mode](../flight_modes_mc/mission.md).
 
-In theory you can address commands to a particular gimbal, specifying its component id using the "Gimbal device id" parameter.
-However at time of writing (December 2024) this is [not supported](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/input_mavlink.cpp#L889): all mission commands are sent to the gimbal with id defined in the parameter [MNT_MAV_COMPID](../advanced_config/parameter_reference.md#MNT_MAV_COMPID), which is set by default to [MAV_COMP_ID_GIMBAL (154)](https://mavlink.io/en/messages/common.html#MAV_COMP_ID_GIMBAL).
-
 Gimbal movement is not immediate.
 To ensure that the gimbal has time to move into position before the mission progresses to the next item (if gimbal feedback is not provided or lost), you should set [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT) to be greater than the time taken for the gimbal to traverse its full range.
 After this timeout the mission will proceed to the next item.

--- a/en/advanced/gimbal_control.md
+++ b/en/advanced/gimbal_control.md
@@ -81,7 +81,7 @@ The values may also be provided in gimbal documentation.
 For example [MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW) is supported in [multicopter mission mode](../flight_modes_mc/mission.md).
 
 In theory you can address commands to a particular gimbal, specifying its component id using the "Gimbal device id" parameter.
-However at time of writing (December 2024) this is [not supported](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/input_mavlink.cpp#L889): all commands are sent to the gimbal with id [MAV_COMP_ID_GIMBAL (154)](https://mavlink.io/en/messages/common.html#MAV_COMP_ID_GIMBAL)
+However at time of writing (December 2024) this is [not supported](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/input_mavlink.cpp#L889): all mission commands are sent to the gimbal with id defined in the parameter [MNT_MAV_COMPID](../advanced_config/parameter_reference.md#MNT_MAV_COMPID), which is set by default to [MAV_COMP_ID_GIMBAL (154)](https://mavlink.io/en/messages/common.html#MAV_COMP_ID_GIMBAL).
 
 Gimbal movement is not immediate.
 To ensure that the gimbal has time to move into position before the mission progresses to the next item (if gimbal feedback is not provided or lost), you should set [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT) to be greater than the time taken for the gimbal to traverse its full range.

--- a/en/flight_modes_fw/mission.md
+++ b/en/flight_modes_fw/mission.md
@@ -177,7 +177,6 @@ Rally Points
 
 ::: info
 Please add an issue report or PR if you find a missing/incorrect message.
-::: info:
 
 - PX4 parses the above messages, but they are not necessary _acted_ on. For example, some messages are vehicle-type specific.
 - PX4 does not support local frames for mission commands (e.g. [MAV_FRAME_LOCAL_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_NED)).
@@ -185,6 +184,18 @@ Please add an issue report or PR if you find a missing/incorrect message.
 - The list may become out of date as messages are added.
   You can check the current set by inspecting the code.
   Support is `MavlinkMissionManager::parse_mavlink_mission_item` in [/src/modules/mavlink/mavlink_mission.cpp](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_mission.cpp).
+
+:::
+
+## Mission Command Timeouts
+
+Some mission commands/items can take time to complete, such as a gripper opening and closing, a winch extending or retracting, or a gimbal moving to point at a region of interest.
+
+Where provided PX4 may use sensor feedback from the hardware to determine when the action has completed and then move to the next mission item.
+If not provided, or if the feedback is lost, a mission command timeout can be used to ensure that these kinds of actions will progress to the next mission item rather than blocking progression.
+
+The timeout is set using the [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT) parameter.
+This should be set to be a small amount greater than the time required for the longest long-running action in the mission to complete.
 
 ## Rounded turns: Inter-Waypoint Trajectory
 

--- a/en/flight_modes_mc/mission.md
+++ b/en/flight_modes_mc/mission.md
@@ -19,7 +19,7 @@ The mission is typically created and uploaded with a Ground Control Station (GCS
 ## Description
 
 Missions are usually created in a ground control station (e.g. [QGroundControl](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/plan_view/plan_view.html)) and uploaded prior to launch.
-They may also be created by a developer API, and/or uploaded in flight.
+They may also be created by a MAVLink API such as [MAVSDK](../robotics/mavsdk.md), and/or uploaded in flight.
 
 Individual [mission commands](#mission-commands) are handled in a way that is appropriate to multicopter flight characteristics (for example loiter is implemented as _hover_ ).
 
@@ -190,6 +190,16 @@ Please add an issue report or PR if you find a missing/incorrect message.
   Support is `MavlinkMissionManager::parse_mavlink_mission_item` in [/src/modules/mavlink/mavlink_mission.cpp](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_mission.cpp).
 
 :::
+
+## Mission Command Timeouts
+
+Some mission commands/items can take time to complete, such as a gripper opening and closing, a winch extending or retracting, or a gimbal moving to point at a region of interest.
+
+Where provided PX4 may use sensor feedback from the hardware to determine when the action has completed and then move to the next mission item.
+If not provided, or if the feedback is lost, a mission command timeout can be used to ensure that these kinds of actions will progress to the next mission item rather than blocking progression.
+
+The timeout is set using the [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT) parameter.
+This should be set to be a small amount greater than the time required for the longest long-running action in the mission to complete.
 
 ## Rounded turns: Inter-Waypoint Trajectory
 

--- a/en/flight_modes_vtol/mission.md
+++ b/en/flight_modes_vtol/mission.md
@@ -30,6 +30,16 @@ In fixed-wing mode there are the following exceptions:
 - [MAV_CMD_NAV_LAND](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND) is transformed into [MAV_CMD_NAV_VTOL_LAND](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_VTOL_LAND) unless [NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT) is set to `0` (disabled).
 - [MAV_CMD_NAV_TAKEOFF](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_TAKEOFF) is not supported.
 
+## Mission Command Timeouts
+
+Some mission commands/items can take time to complete, such as a gripper opening and closing, a winch extending or retracting, or a gimbal moving to point at a region of interest.
+
+Where provided PX4 may use sensor feedback from the hardware to determine when the action has completed and then move to the next mission item.
+If not provided, or if the feedback is lost, a mission command timeout can be used to ensure that these kinds of actions will progress to the next mission item rather than blocking progression.
+
+The timeout is set using the [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT) parameter.
+This should be set to be a small amount greater than the time required for the longest long-running action in the mission to complete.
+
 ## Mission Takeoff
 
 Plan a VTOL mission takeoff by adding a `VTOL Takeoff` mission item to the map.

--- a/en/flying/package_delivery_mission.md
+++ b/en/flying/package_delivery_mission.md
@@ -88,7 +88,7 @@ So if you land, release the cargo, then have an RTL waypoint, the vehicle will i
 A gripper can be [manually controlled using a joystick button](../peripherals/gripper.md#qgc-joystick-configuration) (if configured) in any mode, including during a mission.
 
 Note however that if you manually command the gripper to close while a package delivery mission is opening the gripper, the gripper won't be able to finish the open action.
-The mission will resume after the payload delivery mission item timeout ([MIS_PD_TO](../advanced_config/parameter_reference.md#MIS_PD_TO) expires, even if it has not released the package.
+The mission will resume after the mission command timeout ([MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT)) expires, even if it has not released the package.
 
 #### Auto-disarming is Disabled in Missions
 

--- a/en/peripherals/gripper.md
+++ b/en/peripherals/gripper.md
@@ -75,7 +75,7 @@ To set the actuation timeout:
 
    - Run the `payload_deliverer` test in the QGC [MAVLink Shell](../debug/mavlink_shell.md):
 
-     ```
+     ```sh
      > payload_deliverer gripper_test
      ```
 
@@ -88,20 +88,21 @@ To set the actuation timeout:
 
 1. Set [PD_GRIPPER_TO](../advanced_config/parameter_reference.md#PD_GRIPPER_TO) to whichever of the gripper open and close time is larger.
 
-### Mission Delivery Timeout
+### Mission Command Timeout
 
 When running a [Payload Delivery Mission](../flying/package_delivery_mission.md) it is important that the mission is not halted in the case where the gripper does not report that it has opened (or closed).
-This might happen if a gripper feedback sensor was damaged or UORB dropped the gripper actuator timout message.
+This might happen if a gripper does not have a feedback sensor, if the feedback sensor was damaged, or if UORB dropped the gripper actuator timeout message.
 
 ::: info
 Gripper state feedback from a sensor is not actually supported yet, but it may be in future.
 :::
 
-The mission-delivery timout provides an additional safeguard, continuing the mission if the gripper's successful actuation acknowledgement is not received.
+The mission command timeout provides an additional safeguard, continuing the mission if the gripper's successful actuation acknowledgement is not received.
+This timeout is also used to provide a sufficient delay for other commands to complete in the case where sensor feedback is not provided or received, such as for winch deployment/retraction, and gimbal movement to a mission-commanded orientation.
 
 To set the timeout:
 
-1. Set [MIS_PD_TO](../advanced_config/parameter_reference.md#MIS_PD_TO) to a value greater than the [gripper actuation timeout](#gripper-actuation-timeout).
+1. Set [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT) to a value greater than the [gripper actuation timeout](#gripper-actuation-timeout).
 
 ## QGC Joystick Configuration
 

--- a/en/releases/main.md
+++ b/en/releases/main.md
@@ -37,7 +37,11 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 - [Log Encryption](../dev_log/log_encryption.md) now generates an encrypted log that contains the public-key-encrypted symmetric key that can be used to decrypt it, instead of putting the key into a separate file.
   This makes log decryption much easier, as there is no need to download or identify a separate key file.
   ([PX4-Autopilot#24024](https://github.com/PX4/PX4-Autopilot/pull/24024)).
-  
+- The generic mission command timeout [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.html#MIS_COMMAND_TOUT) parameter replaces the delivery-specific `MIS_PD_TO` parameter.
+  Mission commands that may take some time to complete, such as those for controlling gimbals, winches, and grippers, will progress to the next item when either feedback is received or the timeout expires.
+  This is often used to provide a minimum delay for hardware that does not provide completion feedback, so that it can reach the commanded state before the mission progresses.
+  ([PX4-Autopilot#23960](https://github.com/PX4/PX4-Autopilot/pull/23960)).
+
 ### Control
 
 - TBD

--- a/en/releases/main.md
+++ b/en/releases/main.md
@@ -37,7 +37,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 - [Log Encryption](../dev_log/log_encryption.md) now generates an encrypted log that contains the public-key-encrypted symmetric key that can be used to decrypt it, instead of putting the key into a separate file.
   This makes log decryption much easier, as there is no need to download or identify a separate key file.
   ([PX4-Autopilot#24024](https://github.com/PX4/PX4-Autopilot/pull/24024)).
-- The generic mission command timeout [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.html#MIS_COMMAND_TOUT) parameter replaces the delivery-specific `MIS_PD_TO` parameter.
+- The generic mission command timeout [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT) parameter replaces the delivery-specific `MIS_PD_TO` parameter.
   Mission commands that may take some time to complete, such as those for controlling gimbals, winches, and grippers, will progress to the next item when either feedback is received or the timeout expires.
   This is often used to provide a minimum delay for hardware that does not provide completion feedback, so that it can reach the commanded state before the mission progresses.
   ([PX4-Autopilot#23960](https://github.com/PX4/PX4-Autopilot/pull/23960)).


### PR DESCRIPTION
Some hardware can take time to reach the state commanded by a corresponding mission item, such as gimbals, grippers, winches.

Ideally you'd trigger transition to the next step on feedback from a sensor on the hardware, but many grippers etc don't have that, and in any case it is possible you will miss it. So for grippers the `MIS_PD_TO` timeout was created - it basically ensures that if you miss feedback (or if there is none) the mission will wait this amount of time before progressing.

https://github.com/PX4/PX4-Autopilot/pull/23960 renames `MIS_PD_TO`  with `MIS_COMMAND_TOUT`, which applies to all of these long running mission items - it also uses this delay to give the gimbal time to move into position on a mission item. 

This provides the corresponding docs.

- https://github.com/PX4/PX4-Autopilot/pull/23960