### PR TITLE
Typo in PWM outputs!

### DIFF
--- a/en/flight_controller/pixhawk6c_mini.md
+++ b/en/flight_controller/pixhawk6c_mini.md
@@ -68,7 +68,7 @@ The Pixhawk® 6C Mini is perfect for developers at corporate research labs, star
 
 ### **Interfaces**
 
-- 16- PWM servo outputs (8 from IO, 6 from FMU)
+- 14- PWM servo outputs (8 from IO, 6 from FMU)
 - 3 general purpose serial ports
   - `TELEM1` - Full flow control, separate 1A current limit
   - `TELEM2` - Full flow control


### PR DESCRIPTION
Pixhawk 6C mini has 14 total outputs. 