### PR TITLE
Gimbal control in missions - addressing

### DIFF
--- a/en/advanced/gimbal_control.md
+++ b/en/advanced/gimbal_control.md
@@ -81,7 +81,7 @@ The values may also be provided in gimbal documentation.
 For example [MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW) is supported in [multicopter mission mode](../flight_modes_mc/mission.md).
 
 In theory you can address commands to a particular gimbal, specifying its component id using the "Gimbal device id" parameter.
-However at time of writing (December 2024) this is [not supported](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/input_mavlink.cpp#L889): all mission commands are sent to the gimbal with id defined in the parameter [MNT_MAV_COMPID](../advanced_config/parameter_reference.md#MNT_MAV_COMPID), which is set by default to [MAV_COMP_ID_GIMBAL (154)](https://mavlink.io/en/messages/common.html#MAV_COMP_ID_GIMBAL).
+However at time of writing (December 2024) this is [not supported](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/input_mavlink.cpp#L889): all mission commands are sent to the gimbal managed by the PX4 gimbal manager (if this is a MAVLink gimbal, it will be the gimbal with component id defined in the parameter [MNT_MAV_COMPID](../advanced_config/parameter_reference.md#MNT_MAV_COMPID), which is set by default to [MAV_COMP_ID_GIMBAL (154)](https://mavlink.io/en/messages/common.html#MAV_COMP_ID_GIMBAL)).
 
 Gimbal movement is not immediate.
 To ensure that the gimbal has time to move into position before the mission progresses to the next item (if gimbal feedback is not provided or lost), you should set [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT) to be greater than the time taken for the gimbal to traverse its full range.

--- a/en/advanced/gimbal_control.md
+++ b/en/advanced/gimbal_control.md
@@ -80,6 +80,9 @@ The values may also be provided in gimbal documentation.
 [Gimbal Manager commands](https://mavlink.io/en/services/gimbal_v2.html#gimbal-manager-messages) may be used in missions if supported by the vehicle type.
 For example [MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW) is supported in [multicopter mission mode](../flight_modes_mc/mission.md).
 
+In theory you can address commands to a particular gimbal, specifying its component id using the "Gimbal device id" parameter.
+However at time of writing (December 2024) this is [not supported](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/input_mavlink.cpp#L889): all mission commands are sent to the gimbal with id defined in the parameter [MNT_MAV_COMPID](../advanced_config/parameter_reference.md#MNT_MAV_COMPID), which is set by default to [MAV_COMP_ID_GIMBAL (154)](https://mavlink.io/en/messages/common.html#MAV_COMP_ID_GIMBAL).
+
 Gimbal movement is not immediate.
 To ensure that the gimbal has time to move into position before the mission progresses to the next item (if gimbal feedback is not provided or lost), you should set [MIS_COMMAND_TOUT](../advanced_config/parameter_reference.md#MIS_COMMAND_TOUT) to be greater than the time taken for the gimbal to traverse its full range.
 After this timeout the mission will proceed to the next item.


### PR DESCRIPTION
This adds back the text I removed in https://github.com/PX4/PX4-user_guide/pull/3495 , in order to allow me to merge it as correct, even if incomplete.

This is the bit that requires testing - specifically, we want to confirm:
- Does PX4 detect the mavlink gimbal at id  in param [MNT_MAV_COMPID](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#MNT_MAV_COMPID) or ANY/first mavlink gimbal device?
- And does it address to that id or to any.
- What happens with mission items and gimbal device addresses.

Note, see https://github.com/PX4/PX4-user_guide/pull/3514#issuecomment-2550061784 - I think that how this behaves can be inferred from the docs. Probably no testing required. Would be good for PX4 to do a little more work though!

@julianoes This is something you have added to your list to test in https://github.com/PX4/PX4-user_guide/pull/3495#pullrequestreview-2497689801