### PR TITLE
rover flight modes: Specify speed axis

### DIFF
--- a/en/flight_modes_rover/ackermann.md
+++ b/en/flight_modes_rover/ackermann.md
@@ -18,7 +18,7 @@ Manual modes require stick inputs from the user to drive the vehicle.
 
 The sticks provide the same "high level" control effects over direction and rate of movement in all manual modes:
 
-- `Left stick up/down`: Drive the rover forwards/backwards (controlling forward speed)
+- `Left stick up/down`: Drive the rover forwards/backwards (controlling longitudinal speed)
 - `Right stick left/right`: Make a left/right turn (controlling steering angle ([Manual mode](#manual-mode)) or lateral acceleration ([Acro](#acro-mode) and [Position](#position-mode))).
 
 The manual modes provide progressively increasing levels of autopilot support for maintaining a course, speed, and rate of turn, compensating for external factors such as slopes or uneven terrain.
@@ -31,7 +31,7 @@ The manual modes provide progressively increasing levels of autopilot support fo
 
 ::: details Overview mode mapping to control effect
 
-| Mode                       | Forward speed                                                            | Steering angle/lateral acceleration                                                                                                                                                                     | Required measurements                                       |
+| Mode                       | Longitudinal speed                                                       | Steering angle/lateral acceleration                                                                                                                                                                     | Required measurements                                       |
 | -------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | [Manual](#manual-mode)     | Directly map stick input to motor command.                               | Directly map stick input to steering angle.                                                                                                                                                             | None.                                                       |
 | [Acro](#acro-mode)         | Directly map stick input to motor command.                               | Stick input creates a lateral acceleration setpoint for the control system to regulate.                                                                                                                 | Lateral acceleration.                                       |

--- a/en/flight_modes_rover/ackermann.md
+++ b/en/flight_modes_rover/ackermann.md
@@ -18,7 +18,7 @@ Manual modes require stick inputs from the user to drive the vehicle.
 
 The sticks provide the same "high level" control effects over direction and rate of movement in all manual modes:
 
-- `Left stick up/down`: Drive the rover forwards/backwards (controlling longitudinal speed)
+- `Left stick up/down`: Drive the rover forwards/backwards (controlling speed)
 - `Right stick left/right`: Make a left/right turn (controlling steering angle ([Manual mode](#manual-mode)) or lateral acceleration ([Acro](#acro-mode) and [Position](#position-mode))).
 
 The manual modes provide progressively increasing levels of autopilot support for maintaining a course, speed, and rate of turn, compensating for external factors such as slopes or uneven terrain.
@@ -31,7 +31,7 @@ The manual modes provide progressively increasing levels of autopilot support fo
 
 ::: details Overview mode mapping to control effect
 
-| Mode                       | Longitudinal speed                                                       | Steering angle/lateral acceleration                                                                                                                                                                     | Required measurements                                       |
+| Mode                       | Forward/backwards speed                                                       | Steering angle/lateral acceleration                                                                                                                                                                     | Required measurements                                       |
 | -------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | [Manual](#manual-mode)     | Directly map stick input to motor command.                               | Directly map stick input to steering angle.                                                                                                                                                             | None.                                                       |
 | [Acro](#acro-mode)         | Directly map stick input to motor command.                               | Stick input creates a lateral acceleration setpoint for the control system to regulate.                                                                                                                 | Lateral acceleration.                                       |

--- a/en/flight_modes_rover/differential.md
+++ b/en/flight_modes_rover/differential.md
@@ -18,7 +18,7 @@ Manual modes require stick inputs from the user to drive the vehicle.
 
 The sticks provide the same "high level" control effects over direction and rate of movement in all manual modes:
 
-- `Left stick up/down`: Drive the rover forwards/backwards (controlling longitudinal speed)
+- `Left stick up/down`: Drive the rover forwards/backwards (controlling speed)
 - `Right stick left/right`: Rotate the rover to the left/right (controlling yaw rate).
 
 The manual modes provide progressively increasing levels of autopilot support for maintaining a course, speed, and rate of turn, compensating for external factors such as slopes or uneven terrain.
@@ -32,7 +32,7 @@ The manual modes provide progressively increasing levels of autopilot support fo
 
 ::: details Overview mode mapping to control effect
 
-| Mode                           | Longitudinal speed                                                       | Yaw rate                                                                                                                                                                                          | Required measurements                           |
+| Mode                           | Forwards/backwards speed                                                       | Yaw rate                                                                                                                                                                                          | Required measurements                           |
 | ------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
 | [Manual](#manual-mode)         | Directly map stick input to motor commands.                              | Directly map stick input to motor commands.                                                                                                                                                       | None.                                           |
 | [Acro](#acro-mode)             | Directly map stick input to motor commands.                              | Stick input creates a yaw rate setpoint for the control system to regulate.                                                                                                                       | Yaw rate.                                       |

--- a/en/flight_modes_rover/differential.md
+++ b/en/flight_modes_rover/differential.md
@@ -18,7 +18,7 @@ Manual modes require stick inputs from the user to drive the vehicle.
 
 The sticks provide the same "high level" control effects over direction and rate of movement in all manual modes:
 
-- `Left stick up/down`: Drive the rover forwards/backwards (controlling forward speed)
+- `Left stick up/down`: Drive the rover forwards/backwards (controlling longitudinal speed)
 - `Right stick left/right`: Rotate the rover to the left/right (controlling yaw rate).
 
 The manual modes provide progressively increasing levels of autopilot support for maintaining a course, speed, and rate of turn, compensating for external factors such as slopes or uneven terrain.
@@ -32,7 +32,7 @@ The manual modes provide progressively increasing levels of autopilot support fo
 
 ::: details Overview mode mapping to control effect
 
-| Mode                           | Forward speed                                                            | Yaw rate                                                                                                                                                                                          | Required measurements                           |
+| Mode                           | Longitudinal speed                                                       | Yaw rate                                                                                                                                                                                          | Required measurements                           |
 | ------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
 | [Manual](#manual-mode)         | Directly map stick input to motor commands.                              | Directly map stick input to motor commands.                                                                                                                                                       | None.                                           |
 | [Acro](#acro-mode)             | Directly map stick input to motor commands.                              | Stick input creates a yaw rate setpoint for the control system to regulate.                                                                                                                       | Yaw rate.                                       |

--- a/en/flight_modes_rover/mecanum.md
+++ b/en/flight_modes_rover/mecanum.md
@@ -18,9 +18,9 @@ Manual modes require stick inputs from the user to drive the vehicle.
 
 The sticks provide the same "high level" control effects over direction and rate of movement in all manual modes:
 
-- `Left stick up/down`: Drive the rover forwards/backwards (controlling forward speed)
+- `Left stick up/down`: Drive the rover forwards/backwards (controlling longitudinal speed)
 - `Left stick left/right`: Yaw the rover to the left/right (controlling yaw rate).
-- `Right stick left/right`: Drive the rover left/right (controlling lateral speed)
+- `Right stick left/right`: Drive the rover left/right (controlling lateral speed).
 
 The manual modes provide progressively increasing levels of autopilot support for maintaining a course, speed, and rate of turn, compensating for external factors such as slopes or uneven terrain.
 
@@ -33,7 +33,7 @@ The manual modes provide progressively increasing levels of autopilot support fo
 
 ::: details Overview mode mapping to control effect
 
-| Mode                           | Forward/Lateral speed                                                       | Yaw rate                                                                                                                                                                                          | Required measurements                              |
+| Mode                           | Longitudinal/Lateral speed                                                  | Yaw rate                                                                                                                                                                                          | Required measurements                              |
 | ------------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | [Manual](#manual-mode)         | Directly map stick input to motor commands.                                 | Directly map stick input to motor commands.                                                                                                                                                       | None.                                              |
 | [Acro](#acro-mode)             | Directly map stick input to motor commands.                                 | Stick input creates a yaw rate setpoint for the control system to regulate.                                                                                                                       | Yaw rate.                                          |

--- a/en/flight_modes_rover/mecanum.md
+++ b/en/flight_modes_rover/mecanum.md
@@ -18,9 +18,9 @@ Manual modes require stick inputs from the user to drive the vehicle.
 
 The sticks provide the same "high level" control effects over direction and rate of movement in all manual modes:
 
-- `Left stick up/down`: Drive the rover forwards/backwards (controlling longitudinal speed)
+- `Left stick up/down`: Drive the rover forwards/backwards (controlling speed)
 - `Left stick left/right`: Yaw the rover to the left/right (controlling yaw rate).
-- `Right stick left/right`: Drive the rover left/right (controlling lateral speed).
+- `Right stick left/right`: Drive the rover left/right (controlling speed).
 
 The manual modes provide progressively increasing levels of autopilot support for maintaining a course, speed, and rate of turn, compensating for external factors such as slopes or uneven terrain.
 


### PR DESCRIPTION
Rewording to differentiate between longitudinal (forward/backwards) and lateral (left/right) motion.