### PR TITLE
fix typo in vehicles.md

### DIFF
--- a/en/sim_gazebo_gz/vehicles.md
+++ b/en/sim_gazebo_gz/vehicles.md
@@ -109,7 +109,7 @@ The sensor information is written to the [ObstacleDistance](../msg_docs/Obstacle
 This model has a [gimbal](../advanced/gimbal_control.md) attached to the front with angular ranges of
 
 - roll: [- $\frac{\pi}{4}$, $\frac{\pi}{4}$]
-- pitch: [- $frac{3\pi}{4}$, $\frac{\pi}{4}$]
+- pitch: [- $\frac{3\pi}{4}$, $\frac{\pi}{4}$]
 - yaw: infinite rotation
 
 The gimbal joints uses position control with a kinematic chain ZXY.


### PR DESCRIPTION
It looks like the text "frac" is rendered instead of the interpreting the next chars as frac.