### PR TITLE
add page for statistical flight log analysis

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -752,6 +752,7 @@
     - [Binary Size Profiling](debug/binary_size_profiling.md)
     - [Logging](dev_log/logging.md)
     - [Flight Log Analysis](dev_log/flight_log_analysis.md)
+      - [Statistical Analysis](dev_log/flight_log_analysis_statistical.md)
     - [ULog File Format](dev_log/ulog_file_format.md)
     - [Log Encryption](dev_log/log_encryption.md)
   - [Advanced Topics](advanced/index.md)

--- a/en/_sidebar.md
+++ b/en/_sidebar.md
@@ -741,6 +741,7 @@
     - [Binary Size Profiling](/debug/binary_size_profiling.md)
     - [Logging](/dev_log/logging.md)
     - [Flight Log Analysis](/dev_log/flight_log_analysis.md)
+      - [Statistical Analysis](/dev_log/flight_log_analysis_statistical.md)
     - [ULog File Format](/dev_log/ulog_file_format.md)
     - [Log Encryption](dev_log/log_encryption.md)
   - [Advanced Topics](/advanced/index.md)

--- a/en/dev_log/flight_log_analysis.md
+++ b/en/dev_log/flight_log_analysis.md
@@ -5,3 +5,4 @@ Information about collecting and analysing flight logs is covered in:
 - [Flight Reporting](../getting_started/flight_reporting.md) - How to download a log and report/discuss issues about a flight.
 - [Log Analysis using Flight Review](../log/flight_review.md) - How to analyse many common vehicle problems using the [Flight Review](https://logs.px4.io/) online tool.
 - [Flight Log Analysis](../log/flight_log_analysis.md) - Introduction to flight analysis and links to a number of analysis tools.
+- [Statistical Analysis](flight_log_analysis_statistical.md) - How to download public flight logs from Flight Review.

--- a/en/dev_log/flight_log_analysis.md
+++ b/en/dev_log/flight_log_analysis.md
@@ -5,4 +5,4 @@ Information about collecting and analysing flight logs is covered in:
 - [Flight Reporting](../getting_started/flight_reporting.md) - How to download a log and report/discuss issues about a flight.
 - [Log Analysis using Flight Review](../log/flight_review.md) - How to analyse many common vehicle problems using the [Flight Review](https://logs.px4.io/) online tool.
 - [Flight Log Analysis](../log/flight_log_analysis.md) - Introduction to flight analysis and links to a number of analysis tools.
-- [Statistical Analysis](flight_log_analysis_statistical.md) - How to download public flight logs from Flight Review.
+- [Statistical Analysis](flight_log_analysis_statistical.md) - Information & resources for statistical analysis (including Flight Review logs).

--- a/en/dev_log/flight_log_analysis_statistical.md
+++ b/en/dev_log/flight_log_analysis_statistical.md
@@ -1,0 +1,18 @@
+# Statistical Flight Log Analysis
+
+Flight Review hosts a large set of publicly available log files.
+These can be used for example for statistical analysis or machine learning.
+
+The dataset contains a set of different:
+- vehicle types
+- PX4 versions (including development versions)
+- boards
+- flight modes
+
+The logs are accessible on [logs.px4.io/browse](https://logs.px4.io/browse) and are licensed under [CC-BY PX4](https://creativecommons.org/licenses/by/4.0/).
+
+Log files can also be downloaded in bulk with the [download_logs.py](https://github.com/PX4/flight_review/blob/main/app/download_logs.py) script.
+The script allows to filter by different attributes (like flight modes, airframe name or type). Use the `--help` flag for a full list.
+The newest logs will be downloaded first, and downloads can be interrupted and resumed later on.
+
+There are different parsing libraries, for example [pyulog](../log/flight_log_analysis.md#pyulog) can be used to read logs with Python.

--- a/en/dev_log/flight_log_analysis_statistical.md
+++ b/en/dev_log/flight_log_analysis_statistical.md
@@ -1,9 +1,13 @@
 # Statistical Flight Log Analysis
 
-Flight Review hosts a large set of publicly available log files.
-These can be used for example for statistical analysis or machine learning.
+This topic contains information and resources related to statistical flight log analysis.
+
+## Flight Review Public Logs
+
+[Flight Review](../log/flight_log_analysis.md#flight-review-online-tool) hosts a large set of publicly available log files that can be used for statistical analysis, machine learning, or other purposes.
 
 The dataset contains a set of different:
+
 - vehicle types
 - PX4 versions (including development versions)
 - boards
@@ -12,7 +16,8 @@ The dataset contains a set of different:
 The logs are accessible on [logs.px4.io/browse](https://logs.px4.io/browse) and are licensed under [CC-BY PX4](https://creativecommons.org/licenses/by/4.0/).
 
 Log files can also be downloaded in bulk with the [download_logs.py](https://github.com/PX4/flight_review/blob/main/app/download_logs.py) script.
-The script allows to filter by different attributes (like flight modes, airframe name or type). Use the `--help` flag for a full list.
+The script allows to filter by different attributes (like flight modes, airframe name or type).
+Use the `--help` flag for a full list.
 The newest logs will be downloaded first, and downloads can be interrupted and resumed later on.
 
 There are different parsing libraries, for example [pyulog](../log/flight_log_analysis.md#pyulog) can be used to read logs with Python.


### PR DESCRIPTION
The question for license for public flight logs came up on https://discuss.px4.io/t/license-for-the-dataset/42819, and in the process of [clarifying that](https://github.com/PX4/flight_review/pull/302), I thought it makes sense to add a short page about the option for statistical log analysis to the docs.