### PR TITLE
setuptools 71+ causes errors building px4_msgs. Update user guide to have users install working version

### DIFF
--- a/en/ros2/user_guide.md
+++ b/en/ros2/user_guide.md
@@ -132,7 +132,7 @@ To install ROS 2 and its dependencies:
 1. Some Python dependencies must also be installed (using **`pip`** or **`apt`**):
 
    ```sh
-   pip install --user -U empy==3.3.4 pyros-genmsg setuptools
+   pip install --user -U empy==3.3.4 pyros-genmsg setuptools==70.3.0
    ```
 
 ### Setup Micro XRCE-DDS Agent & Client


### PR DESCRIPTION
Update user guide to install pre setuptools 71 releases. setuptools 71+ causes the following errors building px4_msgs and px4_ros_com on fresh Ubuntu 22.04 + ROS2 Humble env:

```
File "/home/chase/.local/lib/python3.10/site-packages/setuptools/_core_metadata.py", line 290, in _distribution_fullname
    canonicalize_version(version, strip_trailing_zero=False),
TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
```

downgrading to `setuptools==70.3.0` fixed that step for me.