### PR TITLE
Add documentation about adding new SIH airframes

### DIFF
--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -202,6 +202,7 @@ For SIH as SITL (no FC):
    - `param set-default SENS_EN_BAROSIM 1`
    - `param set-default SENS_EN_MAGSIM 1`
 
+For specific examples see the `_sihsim_` airframes in [ROMFS/px4fmu_common/init.d-posix/airframes](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/airframes/) (SIH as SITL) and [ROMFS/px4fmu_common/init.d/airframes](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d/airframes) (SIH on FC).
 
 ## Dynamic Models
 

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -169,7 +169,10 @@ make px4_sitl sihsim_quadx
 
 ### Adding new airframes
 
-When adding new airframes for use in SIH simulation, there are some differences with respect to ususal airframe files. 
+[Adding a new airframe](../dev_airframes/adding_a_new_frame.html) for use in SIH simulation is much the same as for other use cases.
+You still need to configure your vehicle type and [geometry](../config/actuators.md) (`CA_` parameters) and start any other defaults for that vehicle type.
+
+The specific differences for SIH simulation airframes are listed in the sections below.
 
 For all variants of SIH:
 

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -166,6 +166,38 @@ export PX4_HOME_ALT=28.5
 make px4_sitl sihsim_quadx
 ```
 
+
+### Adding new airframes
+
+When adding new airframes for use in SIH simulation, there are some differences with respect to ususal airframe files. 
+
+For all variants of SIH:
+
+  - Set the [physical model parameters](../advanced_config/parameter_reference.md#simulation-in-hardware).
+  - `param set-default SYS_HITL 2` to enable SIH on the next boot.
+  - `param set-default CBRK_SUPPLY_CHK 894281` to disable power valid check.
+  - `param set-default CBRK_IO_SAFETY 22027` to disable IO safety check.
+  - `param set-default EKF2_GPS_DELAY 0` to improve state estimator performance in the otherwise unrealistic scenario instant GPS measurements. 
+
+For SIH on FC: 
+
+  - Airframe file goes in `ROMFS/px4fmu_common/init.d/airframes` and follows the naming template `${ID}_${model_name}.hil`, where `ID` is the `SYS_AUTOSTART_ID` used to select the airframe, and `model_name` is the airframe model name.
+  - Add the model name in `ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt` to generate a corresponding make target. 
+  - Actuators are configured with `HIL_ACT_FUNC*`, rather than `PWM_MAIN_FUNC*` as usual. This is to avoid using the actual actuators in SIH. Similarly, the bitfield for inverting individual actuator output ranges is `HIL_ACT_REV`, rather than `PWM_MAIN_REV`.
+
+For SIH as SITL (no FC):
+
+ - Airframe file goes in `ROMFS/px4fmu_common/init.d-posix/airframes` and follows the naming template `${ID}_sihsim_${model_name}`, where `ID` is the `SYS_AUTOSTART_ID` used to select the airframe, and `model_name` is the airframe model name.
+ - Add the model name in `src/modules/simulation/simulator_sih/CMakeLists.txt` to generate a corresponding make target.
+ - Actuators are configured as usual with `PWM_MAIN_FUNC*` and `PWM_MAIN_REV`.
+ - Additionally, set:
+   - `PX4_SIMULATOR=${PX4_SIMULATOR:=sihsim}`
+   - `PX4_SIM_MODEL=${PX4_SIM_MODEL:=svtol}` (replacing `svtol` with the airframe model name)
+   - `param set-default SENS_EN_GPSSIM 1`
+   - `param set-default SENS_EN_BAROSIM 1`
+   - `param set-default SENS_EN_MAGSIM 1`
+
+
 ## Dynamic Models
 
 The dynamic models for the various vehicles are:

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -26,7 +26,7 @@ The Desktop computer is only used to display the virtual vehicle.
 - SIH for quadrotor is supported from PX4 v1.9.
 - SIH for fixed-wing (airplane) and VTOL tailsitter are supported from PX4 v1.13.
 - SIH as SITL (without hardware) from PX4 v1.14.
-- SIH for Standard VTOL from PX4 v1.16. 
+- SIH for Standard VTOL from PX4 v1.16.
 
 ### Benefits
 
@@ -61,7 +61,7 @@ To set up/start SIH:
    - [SIH plane AERT](../airframes/airframe_reference.md#plane_simulation_sih_plane_aert)
    - [SIH Tailsitter Duo](../airframes/airframe_reference.md#vtol_simulation_sih_tailsitter_duo)
    - [SIH Standard VTOL QuadPlane](../airframes/airframe_reference.md#vtol_simulation_sih_standard_vtol_quadplane)
-  
+
 The autopilot will then reboot.
 The `sih` module is started on reboot, and the vehicle should be displayed on the ground control station map.
 
@@ -166,8 +166,7 @@ export PX4_HOME_ALT=28.5
 make px4_sitl sihsim_quadx
 ```
 
-
-### Adding new airframes
+### Adding New Airframes
 
 [Adding a new airframe](../dev_airframes/adding_a_new_frame.md) for use in SIH simulation is much the same as for other use cases.
 You still need to configure your vehicle type and [geometry](../config/actuators.md) (`CA_` parameters) and start any other defaults for that specific vehicle.
@@ -176,35 +175,34 @@ The specific differences for SIH simulation airframes are listed in the sections
 
 For all variants of SIH:
 
-  - Set all the [Simulation In Hardware](../advanced_config/parameter_reference.md#simulation-in-hardware) parameters (prefixed with `SIH_`) in order to configure the physical model of the vehicle.
-    - Keep in mind that some of these parameters are redundant -- make sure that the `SIH_*` parameters and the `CA_*` parameters describe the same vehicle. Not every vehicle can be simulated with SIH -- there are [four vehicle types](../advanced_config/parameter_reference.md#SIH_VEHICLE_TYPE), each of which has a relatively rigid implementation in [`sih.cpp`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/simulator_sih/sih.cpp). 
-  - `param set-default SYS_HITL 2` to enable SIH on the next boot.
-  - `param set-default CBRK_SUPPLY_CHK 894281` to disable power valid check.
-  - `param set-default CBRK_IO_SAFETY 22027` to disable IO safety check.
-  - `param set-default EKF2_GPS_DELAY 0` to improve state estimator performance (the assumption of instant GPS measurements would normally be unrealistic, but is accurate for SIH).
+- Set all the [Simulation In Hardware](../advanced_config/parameter_reference.md#simulation-in-hardware) parameters (prefixed with `SIH_`) in order to configure the physical model of the vehicle.
+  - Keep in mind that some of these parameters are redundant -- make sure that the `SIH_*` parameters and the `CA_*` parameters describe the same vehicle. Not every vehicle can be simulated with SIH -- there are [four vehicle types](../advanced_config/parameter_reference.md#SIH_VEHICLE_TYPE), each of which has a relatively rigid implementation in [`sih.cpp`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/simulator_sih/sih.cpp).
+- `param set-default SYS_HITL 2` to enable SIH on the next boot.
+- `param set-default CBRK_SUPPLY_CHK 894281` to disable power valid check.
+- `param set-default CBRK_IO_SAFETY 22027` to disable IO safety check.
+- `param set-default EKF2_GPS_DELAY 0` to improve state estimator performance (the assumption of instant GPS measurements would normally be unrealistic, but is accurate for SIH).
 
-For SIH on FC: 
+For SIH on FC:
 
-  - Airframe file goes in `ROMFS/px4fmu_common/init.d/airframes` and follows the naming template `${ID}_${model_name}.hil`, where `ID` is the `SYS_AUTOSTART_ID` used to select the airframe, and `model_name` is the airframe model name.
-  - Add the model name in `ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt` to generate a corresponding make target. 
-  - Actuators are configured with `HIL_ACT_FUNC*`, rather than `PWM_MAIN_FUNC*` as usual.
-    This is to avoid using the actual actuators in SIH.
-    Similarly, the bitfield for inverting individual actuator output ranges is `HIL_ACT_REV`, rather than `PWM_MAIN_REV`.
-  - `param set CBRK_USB_CHK 894281` to disable USB link check.
+- Airframe file goes in `ROMFS/px4fmu_common/init.d/airframes` and follows the naming template `${ID}_${model_name}.hil`, where `ID` is the `SYS_AUTOSTART_ID` used to select the airframe, and `model_name` is the airframe model name.
+- Add the model name in `ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt` to generate a corresponding make target.
+- Actuators are configured with `HIL_ACT_FUNC*`, rather than `PWM_MAIN_FUNC*` as usual.
+  This is to avoid using the actual actuators in SIH.
+  Similarly, the bitfield for inverting individual actuator output ranges is `HIL_ACT_REV`, rather than `PWM_MAIN_REV`.
+- `param set CBRK_USB_CHK 894281` to disable USB link check.
 
 For SIH as SITL (no FC):
 
- - Airframe file goes in `ROMFS/px4fmu_common/init.d-posix/airframes` and follows the naming template `${ID}_sihsim_${model_name}`, where `ID` is the `SYS_AUTOSTART_ID` used to select the airframe, and `model_name` is the airframe model name.
- - Add the model name in `src/modules/simulation/simulator_sih/CMakeLists.txt` to generate a corresponding make target.
- - Actuators are configured as usual with `PWM_MAIN_FUNC*` and `PWM_MAIN_REV`.
- - Additionally, set:
-   - `PX4_SIMULATOR=${PX4_SIMULATOR:=sihsim}`
-   - `PX4_SIM_MODEL=${PX4_SIM_MODEL:=svtol}` (replacing `svtol` with the airframe model name)
- - Enable the simulated sensors. This is only necessary for SIH-as-SITL -- if running SIH on FC, then the simulated sensors are automatically enabled. 
-   - `param set-default SENS_EN_GPSSIM 1`
-   - `param set-default SENS_EN_BAROSIM 1`
-   - `param set-default SENS_EN_MAGSIM 1`
-
+- Airframe file goes in `ROMFS/px4fmu_common/init.d-posix/airframes` and follows the naming template `${ID}_sihsim_${model_name}`, where `ID` is the `SYS_AUTOSTART_ID` used to select the airframe, and `model_name` is the airframe model name.
+- Add the model name in `src/modules/simulation/simulator_sih/CMakeLists.txt` to generate a corresponding make target.
+- Actuators are configured as usual with `PWM_MAIN_FUNC*` and `PWM_MAIN_REV`.
+- Additionally, set:
+  - `PX4_SIMULATOR=${PX4_SIMULATOR:=sihsim}`
+  - `PX4_SIM_MODEL=${PX4_SIM_MODEL:=svtol}` (replacing `svtol` with the airframe model name)
+- Enable the simulated sensors. This is only necessary for SIH-as-SITL -- if running SIH on FC, then the simulated sensors are automatically enabled.
+  - `param set-default SENS_EN_GPSSIM 1`
+  - `param set-default SENS_EN_BAROSIM 1`
+  - `param set-default SENS_EN_MAGSIM 1`
 
 For specific examples see the `_sihsim_` airframes in [ROMFS/px4fmu_common/init.d-posix/airframes](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/airframes/) (SIH as SITL) and [ROMFS/px4fmu_common/init.d/airframes](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d/airframes) (SIH on FC).
 

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -169,7 +169,7 @@ make px4_sitl sihsim_quadx
 
 ### Adding new airframes
 
-[Adding a new airframe](../dev_airframes/adding_a_new_frame.html) for use in SIH simulation is much the same as for other use cases.
+[Adding a new airframe](../dev_airframes/adding_a_new_frame.md) for use in SIH simulation is much the same as for other use cases.
 You still need to configure your vehicle type and [geometry](../config/actuators.md) (`CA_` parameters) and start any other defaults for that vehicle type.
 
 The specific differences for SIH simulation airframes are listed in the sections below.

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -176,7 +176,7 @@ The specific differences for SIH simulation airframes are listed in the sections
 
 For all variants of SIH:
 
-  - Set the [physical model parameters](../advanced_config/parameter_reference.md#simulation-in-hardware).
+  - Set all the [Simulation In Hardware](../advanced_config/parameter_reference.md#simulation-in-hardware) parameters (prefixed with `SIH_`) in order to configure the physical model of the vehicle.
   - `param set-default SYS_HITL 2` to enable SIH on the next boot.
   - `param set-default CBRK_SUPPLY_CHK 894281` to disable power valid check.
   - `param set-default CBRK_IO_SAFETY 22027` to disable IO safety check.

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -170,7 +170,7 @@ make px4_sitl sihsim_quadx
 ### Adding new airframes
 
 [Adding a new airframe](../dev_airframes/adding_a_new_frame.md) for use in SIH simulation is much the same as for other use cases.
-You still need to configure your vehicle type and [geometry](../config/actuators.md) (`CA_` parameters) and start any other defaults for that vehicle type.
+You still need to configure your vehicle type and [geometry](../config/actuators.md) (`CA_` parameters) and start any other defaults for that specific vehicle.
 
 The specific differences for SIH simulation airframes are listed in the sections below.
 

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -166,13 +166,13 @@ export PX4_HOME_ALT=28.5
 make px4_sitl sihsim_quadx
 ```
 
-### Adding New Airframes
+## Adding New Airframes
 
 [Adding a new airframe](../dev_airframes/adding_a_new_frame.md) for use in SIH simulation is much the same as for other use cases.
 You still need to configure your vehicle type and [geometry](../config/actuators.md) (`CA_` parameters) and start any other defaults for that specific vehicle.
 
 ::: warning
-Not every vehicle can be simulated with SIH — there are [four vehicle types](../advanced_config/parameter_reference.md#SIH_VEHICLE_TYPE), each of which has a relatively rigid implementation in [`sih.cpp`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/simulator_sih/sih.cpp).
+Not every vehicle can be simulated with SIH — there are currently [four supported vehicle types](../advanced_config/parameter_reference.md#SIH_VEHICLE_TYPE), each of which has a relatively rigid implementation in [`sih.cpp`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/simulator_sih/sih.cpp).
 :::
 
 The specific differences for SIH simulation airframes are listed in the sections below.
@@ -216,7 +216,7 @@ For SIH as SITL (no FC):
 - Additionally, set:
   - `PX4_SIMULATOR=${PX4_SIMULATOR:=sihsim}`
   - `PX4_SIM_MODEL=${PX4_SIM_MODEL:=svtol}` (replacing `svtol` with the airframe model name)
-- Enable the simulated sensors using [SENS_EN_GPSSIM](../advanced_config/parameter_reference.md#simulation-in-SENS_EN_GPSSIM), [SENS_EN_BAROSIM](../advanced_config/parameter_reference.md#simulation-in-SENS_EN_BAROSIM), [SENS_EN_MAGSIM](../advanced_config/parameter_reference.md#simulation-in-SENS_EN_MAGSIM), and [SENS_EN_ARSPDSIM](../advanced_config/parameter_reference.md#simulation-in-SENS_EN_ARSPDSIM) (this is only needed for SIH-as-SITL):
+- Enable the simulated sensors using [SENS_EN_GPSSIM](../advanced_config/parameter_reference.md#SENS_EN_GPSSIM), [SENS_EN_BAROSIM](../advanced_config/parameter_reference.md#SENS_EN_BAROSIM), [SENS_EN_MAGSIM](../advanced_config/parameter_reference.md#SENS_EN_MAGSIM), and [SENS_EN_ARSPDSIM](../advanced_config/parameter_reference.md#SENS_EN_ARSPDSIM) (this is only needed for SIH-as-SITL):
   - `param set-default SENS_EN_GPSSIM 1`
   - `param set-default SENS_EN_BAROSIM 1`
   - `param set-default SENS_EN_MAGSIM 1`

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -180,7 +180,7 @@ For all variants of SIH:
   - `param set-default SYS_HITL 2` to enable SIH on the next boot.
   - `param set-default CBRK_SUPPLY_CHK 894281` to disable power valid check.
   - `param set-default CBRK_IO_SAFETY 22027` to disable IO safety check.
-  - `param set-default EKF2_GPS_DELAY 0` to improve state estimator performance in the otherwise unrealistic scenario instant GPS measurements. 
+  - `param set-default EKF2_GPS_DELAY 0` to improve state estimator performance (the assumption of instant GPS measurements would normally be unrealistic, but is accurate for SIH).
 
 For SIH on FC: 
 

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -177,6 +177,7 @@ The specific differences for SIH simulation airframes are listed in the sections
 For all variants of SIH:
 
   - Set all the [Simulation In Hardware](../advanced_config/parameter_reference.md#simulation-in-hardware) parameters (prefixed with `SIH_`) in order to configure the physical model of the vehicle.
+    - Keep in mind that some of these parameters are redundant -- make sure that the `SIH_*` parameters and the `CA_*` parameters describe the same vehicle. Not every vehicle can be simulated with SIH -- there are [four vehicle types](../advanced_config/parameter_reference.md#SIH_VEHICLE_TYPE), each of which has a relatively rigid implementation in [`sih.cpp`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/simulator_sih/sih.cpp). 
   - `param set-default SYS_HITL 2` to enable SIH on the next boot.
   - `param set-default CBRK_SUPPLY_CHK 894281` to disable power valid check.
   - `param set-default CBRK_IO_SAFETY 22027` to disable IO safety check.

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -171,13 +171,30 @@ make px4_sitl sihsim_quadx
 [Adding a new airframe](../dev_airframes/adding_a_new_frame.md) for use in SIH simulation is much the same as for other use cases.
 You still need to configure your vehicle type and [geometry](../config/actuators.md) (`CA_` parameters) and start any other defaults for that specific vehicle.
 
+::: warning
+Not every vehicle can be simulated with SIH — there are [four vehicle types](../advanced_config/parameter_reference.md#SIH_VEHICLE_TYPE), each of which has a relatively rigid implementation in [`sih.cpp`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/simulator_sih/sih.cpp).
+:::
+
 The specific differences for SIH simulation airframes are listed in the sections below.
 
 For all variants of SIH:
 
 - Set all the [Simulation In Hardware](../advanced_config/parameter_reference.md#simulation-in-hardware) parameters (prefixed with `SIH_`) in order to configure the physical model of the vehicle.
-  - Keep in mind that some of these parameters are redundant -- make sure that the `SIH_*` parameters and the `CA_*` parameters describe the same vehicle. Not every vehicle can be simulated with SIH -- there are [four vehicle types](../advanced_config/parameter_reference.md#SIH_VEHICLE_TYPE), each of which has a relatively rigid implementation in [`sih.cpp`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/simulation/simulator_sih/sih.cpp).
+
+  ::: tip
+  Make sure that the `SIH_*` parameters and the `CA_*` parameters describe the same vehicle.
+  Note that some of these parameters are redundant!
+  :::
+
 - `param set-default SYS_HITL 2` to enable SIH on the next boot.
+
+  ::: info
+  This also disables input from real sensors.
+  For SIH on the FC (only), it also enables the simulated GPS, barometer, magnetometer, and airspeed sensor.
+
+  For SIH on SITL you will need to explicitly enable these sensors as shown below.
+  :::
+
 - `param set-default CBRK_SUPPLY_CHK 894281` to disable power valid check.
 - `param set-default CBRK_IO_SAFETY 22027` to disable IO safety check.
 - `param set-default EKF2_GPS_DELAY 0` to improve state estimator performance (the assumption of instant GPS measurements would normally be unrealistic, but is accurate for SIH).
@@ -186,8 +203,8 @@ For SIH on FC:
 
 - Airframe file goes in `ROMFS/px4fmu_common/init.d/airframes` and follows the naming template `${ID}_${model_name}.hil`, where `ID` is the `SYS_AUTOSTART_ID` used to select the airframe, and `model_name` is the airframe model name.
 - Add the model name in `ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt` to generate a corresponding make target.
-- Actuators are configured with `HIL_ACT_FUNC*`, rather than `PWM_MAIN_FUNC*` as usual.
-  This is to avoid using the actual actuators in SIH.
+- Actuators are configured with `HIL_ACT_FUNC*` parameters (not the usual `PWM_MAIN_FUNC*` parameters).
+  This is to avoid using the real actuator outputs in SIH.
   Similarly, the bitfield for inverting individual actuator output ranges is `HIL_ACT_REV`, rather than `PWM_MAIN_REV`.
 - `param set CBRK_USB_CHK 894281` to disable USB link check.
 
@@ -199,10 +216,11 @@ For SIH as SITL (no FC):
 - Additionally, set:
   - `PX4_SIMULATOR=${PX4_SIMULATOR:=sihsim}`
   - `PX4_SIM_MODEL=${PX4_SIM_MODEL:=svtol}` (replacing `svtol` with the airframe model name)
-- Enable the simulated sensors. This is only necessary for SIH-as-SITL -- if running SIH on FC, then the simulated sensors are automatically enabled.
+- Enable the simulated sensors using [SENS_EN_GPSSIM](../advanced_config/parameter_reference.md#simulation-in-SENS_EN_GPSSIM), [SENS_EN_BAROSIM](../advanced_config/parameter_reference.md#simulation-in-SENS_EN_BAROSIM), [SENS_EN_MAGSIM](../advanced_config/parameter_reference.md#simulation-in-SENS_EN_MAGSIM), and [SENS_EN_ARSPDSIM](../advanced_config/parameter_reference.md#simulation-in-SENS_EN_ARSPDSIM) (this is only needed for SIH-as-SITL):
   - `param set-default SENS_EN_GPSSIM 1`
   - `param set-default SENS_EN_BAROSIM 1`
   - `param set-default SENS_EN_MAGSIM 1`
+  - `param set-default SENS_EN_ARSPDSIM 1`
 
 For specific examples see the `_sihsim_` airframes in [ROMFS/px4fmu_common/init.d-posix/airframes](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/airframes/) (SIH as SITL) and [ROMFS/px4fmu_common/init.d/airframes](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d/airframes) (SIH on FC).
 

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -189,6 +189,7 @@ For SIH on FC:
   - Actuators are configured with `HIL_ACT_FUNC*`, rather than `PWM_MAIN_FUNC*` as usual.
     This is to avoid using the actual actuators in SIH.
     Similarly, the bitfield for inverting individual actuator output ranges is `HIL_ACT_REV`, rather than `PWM_MAIN_REV`.
+  - `param set CBRK_USB_CHK 894281` to disable USB link check. 
 
 For SIH as SITL (no FC):
 

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -195,8 +195,6 @@ For all variants of SIH:
   For SIH on SITL you will need to explicitly enable these sensors as shown below.
   :::
 
-- `param set-default CBRK_SUPPLY_CHK 894281` to disable power valid check.
-- `param set-default CBRK_IO_SAFETY 22027` to disable IO safety check.
 - `param set-default EKF2_GPS_DELAY 0` to improve state estimator performance (the assumption of instant GPS measurements would normally be unrealistic, but is accurate for SIH).
 
 For SIH on FC:
@@ -206,7 +204,6 @@ For SIH on FC:
 - Actuators are configured with `HIL_ACT_FUNC*` parameters (not the usual `PWM_MAIN_FUNC*` parameters).
   This is to avoid using the real actuator outputs in SIH.
   Similarly, the bitfield for inverting individual actuator output ranges is `HIL_ACT_REV`, rather than `PWM_MAIN_REV`.
-- `param set CBRK_USB_CHK 894281` to disable USB link check.
 
 For SIH as SITL (no FC):
 
@@ -220,7 +217,7 @@ For SIH as SITL (no FC):
   - `param set-default SENS_EN_GPSSIM 1`
   - `param set-default SENS_EN_BAROSIM 1`
   - `param set-default SENS_EN_MAGSIM 1`
-  - `param set-default SENS_EN_ARSPDSIM 1`
+  - `param set-default SENS_EN_ARSPDSIM 1` (if it is a fixed-wing or VTOL airframe with airspeed sensor)
 
 For specific examples see the `_sihsim_` airframes in [ROMFS/px4fmu_common/init.d-posix/airframes](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/airframes/) (SIH as SITL) and [ROMFS/px4fmu_common/init.d/airframes](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d/airframes) (SIH on FC).
 

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -189,7 +189,7 @@ For SIH on FC:
   - Actuators are configured with `HIL_ACT_FUNC*`, rather than `PWM_MAIN_FUNC*` as usual.
     This is to avoid using the actual actuators in SIH.
     Similarly, the bitfield for inverting individual actuator output ranges is `HIL_ACT_REV`, rather than `PWM_MAIN_REV`.
-  - `param set CBRK_USB_CHK 894281` to disable USB link check. 
+  - `param set CBRK_USB_CHK 894281` to disable USB link check.
 
 For SIH as SITL (no FC):
 
@@ -199,9 +199,11 @@ For SIH as SITL (no FC):
  - Additionally, set:
    - `PX4_SIMULATOR=${PX4_SIMULATOR:=sihsim}`
    - `PX4_SIM_MODEL=${PX4_SIM_MODEL:=svtol}` (replacing `svtol` with the airframe model name)
+ - Enable the simulated sensors. This is only necessary for SIH-as-SITL -- if running SIH on FC, then the simulated sensors are automatically enabled. 
    - `param set-default SENS_EN_GPSSIM 1`
    - `param set-default SENS_EN_BAROSIM 1`
    - `param set-default SENS_EN_MAGSIM 1`
+
 
 For specific examples see the `_sihsim_` airframes in [ROMFS/px4fmu_common/init.d-posix/airframes](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/airframes/) (SIH as SITL) and [ROMFS/px4fmu_common/init.d/airframes](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d/airframes) (SIH on FC).
 

--- a/en/sim_sih/index.md
+++ b/en/sim_sih/index.md
@@ -183,7 +183,9 @@ For SIH on FC:
 
   - Airframe file goes in `ROMFS/px4fmu_common/init.d/airframes` and follows the naming template `${ID}_${model_name}.hil`, where `ID` is the `SYS_AUTOSTART_ID` used to select the airframe, and `model_name` is the airframe model name.
   - Add the model name in `ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt` to generate a corresponding make target. 
-  - Actuators are configured with `HIL_ACT_FUNC*`, rather than `PWM_MAIN_FUNC*` as usual. This is to avoid using the actual actuators in SIH. Similarly, the bitfield for inverting individual actuator output ranges is `HIL_ACT_REV`, rather than `PWM_MAIN_REV`.
+  - Actuators are configured with `HIL_ACT_FUNC*`, rather than `PWM_MAIN_FUNC*` as usual.
+    This is to avoid using the actual actuators in SIH.
+    Similarly, the bitfield for inverting individual actuator output ranges is `HIL_ACT_REV`, rather than `PWM_MAIN_REV`.
 
 For SIH as SITL (no FC):
 


### PR DESCRIPTION
This took quite a bit of asking around and reverse engineering. Hopefully this will save the next person a bunch of time. 

@ Reviewers, please read carefully for any inaccurate/misleading info. If unsure but there is someone else who knows this better, please request their review too. 

I am not 100% certain specifically about: 
 - whether `SENS_EN_*` parameters are needed (or just recommended/usual practice) 
 - whether this is the right place to include things like `EKF2_GPS_DELAY` which is also not strictly necessary
 - whether the naming template for SIH on FC is strictly necessary (and appropriate to document here), or just convention.

Thanks for any clarification. 