### PR TITLE
For rangefinders, add link to modules

### DIFF
--- a/en/sensor/rangefinders.md
+++ b/en/sensor/rangefinders.md
@@ -9,6 +9,12 @@ More detailed setup and configuration information is provided in the topics link
 
 ## Supported Rangefinders
 
+::: tip
+This is a subset of the rangefinders that can be used with PX4.
+[Modules: Distance Sensors](../modules/modules_driver_distance_sensor.md) lists PX4 drivers for other non-CAN rangefinders.
+There may also be other DroneCAN rangefinders than those listed here.
+:::
+
 ### ARK Flow
 
 [ARK Flow](../dronecan/ark_flow.md) is an open-source Time-of-Flight (ToF) and optical flow sensor module, which is capable of measuring distances from 8cm to 30m.
@@ -20,7 +26,7 @@ It supports [DroneCAN](../dronecan/index.md), runs [PX4 DroneCAN Firmware](../dr
 The [VL53L1X](https://holybro.com/products/st-vl53l1x-lidar) is a state-of-the-art, Time-of-Flight (ToF), laser-ranging sensor, enhancing the ST FlightSense™ product family.
 It is the fastest miniature ToF sensor on the market with accurate ranging up to 4 m and fast ranging frequency up to 50 Hz.
 
-It comes with a JST GHR 4 pin connector that is compatible with the I2C port on [Pixhawk 4](../flight_controller/pixhawk4.md), [Pixhawk 5X](../flight_controller/pixhawk5x.md), and other flight controllers that follow the [Pixhawk Connector Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-009%20Pixhawk%20Connector%20Standard.pdf)).
+It comes with a JST GHR 4 pin connector that is compatible with the I2C port on [Pixhawk 4](../flight_controller/pixhawk4.md), [Pixhawk 5X](../flight_controller/pixhawk5x.md), and other flight controllers that follow the [Pixhawk Connector Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-009%20Pixhawk%20Connector%20Standard.pdf).
 
 ### Lidar-Lite
 


### PR DESCRIPTION
The list of rangefinders is a subset of those supported by PX4. While it would be nice if we could get all developers to document their own (after all, it is in their interest) they haven't. THis adds a link to the module page for distance sensors which provides a list of the drivers for some more rangefinders.

There are also probably some CAN ones that wouldn't show, because they wouldn't require their own driver.