### PR TITLE
Offboard control Python links

### DIFF
--- a/en/ros2/offboard_control.md
+++ b/en/ros2/offboard_control.md
@@ -7,7 +7,7 @@ While simple, it shows the main principles of how to use offboard control and ho
 
 It has been tested on Ubuntu 20.04 with ROS 2 Foxy and PX4 v1.14.
 
-:::warning
+::: warning
 _Offboard_ control is dangerous.
 If you are operating on a real vehicle be sure to have a way of gaining back manual control in case something goes wrong.
 :::
@@ -213,3 +213,7 @@ void OffboardControl::publish_vehicle_command(uint16_t command, float param1, fl
 [VehicleCommand](../msg_docs/VehicleCommand.md) is one of the simplest and most powerful ways to command PX4, and by subscribing to [VehicleCommandAck](../msg_docs/VehicleCommandAck.md) you can also confirm that setting a particular command was successful.
 The param and command fields map to [MAVLink commands](https://mavlink.io/en/messages/common.html#mav_commands) and their parameter values.
 :::
+
+## See Also
+
+- [Python ROS2 offboard examples with PX4](https://github.com/Jaeyoung-Lim/px4-offboard) (Jaeyoung-Lim/px4-offboard).

--- a/en/ros2/user_guide.md
+++ b/en/ros2/user_guide.md
@@ -655,7 +655,12 @@ int main(int argc, char *argv[])
 
 ### Offboard Control
 
-For a complete reference example on how to use Offboard control with PX4, see: [ROS 2 Offboard control example](../ros2/offboard_control.md).
+[ROS 2 Offboard control example](../ros2/offboard_control.md) provides a complete C++ reference example of how to use [offboard control](../flight_modes/offboard.md) of PX4 with ROS2.
+
+[Python ROS2 offboard examples with PX4](https://github.com/Jaeyoung-Lim/px4-offboard) (Jaeyoung-Lim/px4-offboard) provides a similar example for Python, and includes the scripts:
+
+- `offboard_control.py`: Example of offboard position control using position setpoints
+- `visualizer.py`: Used for visualizing vehicle states in Rviz
 
 ## Using Flight Controller Hardware
 


### PR DESCRIPTION
Add links to examples of offboard Python.

Ideally we'd provide some worked examples in the docs for working with Python. We don't have offers to contribute those, but we do have some reasonable links to resources which we can add. If @Jaeyoung-Lim or someone else wants to add an in doc page for that, would be great, but this is better than nothing.

Fixes #1675