### PR TITLE
Safety.md: make clear that fixed-bank loiter failsafe only applies on VTOL if NAV_FORCE_VT is 0

### DIFF
--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -191,7 +191,7 @@ The failure action is controlled by [COM_POSCTL_NAVL](../advanced_config/paramet
   Switch to _Descend mode_ if a height estimate is available, otherwise enter flight termination.
   _Descend mode_ is a landing mode that does not require a position estimate.
 
-Fixed-wing vehicles and VTOLs in fixed-wing flight additionally have a parameter ([FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)) that defines how long they will loiter (circle with a constant roll angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) at the current altitude) after losing position before attempting to land.
+Fixed-wing planes and VTOLs not configured to land in hover ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT))  have a parameter ([FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)) that defines how long they will loiter (circle with a constant roll angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) at the current altitude) after losing position before attempting to land.
 If VTOLs have are configured to switch to hover for landing ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)) then they will first transition and then descend.
 
 The relevant parameters for all vehicles shown below.

--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -191,7 +191,7 @@ The failure action is controlled by [COM_POSCTL_NAVL](../advanced_config/paramet
   Switch to _Descend mode_ if a height estimate is available, otherwise enter flight termination.
   _Descend mode_ is a landing mode that does not require a position estimate.
 
-Fixed-wing planes and VTOLs not configured to land in hover ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT))  have a parameter ([FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)) that defines how long they will loiter (circle with a constant roll angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) at the current altitude) after losing position before attempting to land.
+Fixed-wing planes, and VTOLs not configured to land in hover ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)), have a parameter ([FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)) that defines how long they will loiter (circle with a constant roll angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) at the current altitude) after losing position before attempting to land.
 If VTOLs have are configured to switch to hover for landing ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)) then they will first transition and then descend.
 
 The relevant parameters for all vehicles shown below.


### PR DESCRIPTION
This is a slightly awkward attempt to make it clearer that this failsafe is only relevant for planes and VTOLs with non-default setting.

We should consider splitting the failsafe docs per vehicle type.