### PR TITLE
Add back local editing instructions

### DIFF
--- a/en/contribute/docs.md
+++ b/en/contribute/docs.md
@@ -142,6 +142,17 @@ Build the library locally to test that any changes you have made have rendered p
      This will be something like: `http://localhost:5173/px4_user_guide/`.
    - Stop serving using **CTRL+C** in the terminal prompt.
 
+1. Open previewed pages in your local editor:
+
+   First specify a local text editor file using the `EDITOR` environment variable, before calling `yarn start` to preview the library.
+   For example, on Windows command line you can enable VSCode as your default editor by entering:
+
+   ```sh
+   set EDITOR=code
+   ```
+
+   The **Open in your editor** link at the bottom of each page will then open the current page in the editor (this replaces the _Open in GitHub_ link).
+
 1. You can build the library as it would be done for deployment:
 
    ```sh


### PR DESCRIPTION
Restore local editing instructions originally added in#3494 and then removed for debugging. This works now.