### PR TITLE
Flight modes dev guide updates

### DIFF
--- a/en/concept/flight_modes.md
+++ b/en/concept/flight_modes.md
@@ -43,7 +43,8 @@ PX4 ROS 2 modes should be considered for all other cases.
 They have the following benefits:
 
 - Easier to implement as there is no need to deal with low-level embedded constraints and requirements (such as restricted stack sizes).
-- Easier to maintain as the integration API is small, well defined, and stable (porting custom PX4 modes on the flight controller between PX4 versions is much harder).
+- Easier to maintain as the integration API is small, well defined, and stable.
+- Porting custom PX4 modes on the flight controller between PX4 versions can be much harder, as often flight modes use interfaces that are considered internal, and allowed to change. 
 - Process termination of a ROS 2 mode results in a fallback to an internal flight mode (while termination of an internal mode may well crash the vehicle).
 - They can override existing modes to provide more advanced features.
   You can even override a safety-critical mode with a better versions: if the ROS 2 mode crashes the original mode will be engaged.

--- a/en/concept/flight_modes.md
+++ b/en/concept/flight_modes.md
@@ -160,8 +160,6 @@ FW vehicles support the following standard modes (in addition to the ones that a
 | [MAV_STANDARD_MODE_ORBIT][MAV_STANDARD_MODE_ORBIT]                 | [FW Hold mode](../flight_modes_fw/hold.md)         | AUTO_LOITER   |
 
 [MAV_STANDARD_MODE_CRUISE]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_CRUISE
-[MAV_STANDARD_MODE_ALTITUDE_HOLD]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ALTITUDE_HOLD
-[MAV_STANDARD_MODE_ORBIT]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ORBIT
 
 VTOL vehicles also support the following standard modes (in addition to the ones that are supported by all vehicles):
 

--- a/en/concept/flight_modes.md
+++ b/en/concept/flight_modes.md
@@ -120,7 +120,7 @@ This protocol allows:
 - Discovery of all modes supported by a system from both PX4 and ROS 2 ([MAV_CMD_REQUEST_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE) and [AVAILABLE_MODES](https://mavlink.io/en/messages/common.html#AVAILABLE_MODES)).
 - Discovery of the current mode ([CURRENT_MODE](https://mavlink.io/en/messages/common.html#CURRENT_MODE)).
 - Setting of standard modes using [MAV_CMD_DO_SET_STANDARD_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_STANDARD_MODE) (recommended)
-- Setting of custom modes using [SET_MODE](https://mavlink.io/en/messages/common.html#SET_MODE) (using information from `AVAILABLE_MODES`). At time of writing [MAV_CMD_DO_SET_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_MODE) is not supported).
+- Setting of custom modes using [SET_MODE](https://mavlink.io/en/messages/common.html#SET_MODE) (using information from `AVAILABLE_MODES`). At time of writing [MAV_CMD_DO_SET_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_MODE) is not supported.
 - Notification when the set of modes changes ([AVAILABLE_MODES_MONITOR](https://mavlink.io/en/messages/common.html#AVAILABLE_MODES_MONITOR))
 
 PX4 advertises support for the following standard flight modes, which means that you can start them by calling [MAV_CMD_DO_SET_STANDARD_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_STANDARD_MODE) and the appropriate enum values:
@@ -153,11 +153,11 @@ MC vehicles support the following standard modes (in addition to the ones that a
 
 FW vehicles support the following standard modes (in addition to the ones that are supported by all vehicles):
 
-| Standard Mode                                                      | PX4 Mode                                             | Internal Mode |
-| ------------------------------------------------------------------ | ---------------------------------------------------- | ------------- |
-| [MAV_STANDARD_MODE_CRUISE][MAV_STANDARD_MODE_CRUISE]               | [FW Position mode](../flight_modes_fw/position.html) | POSCTL        |
-| [MAV_STANDARD_MODE_ALTITUDE_HOLD][MAV_STANDARD_MODE_ALTITUDE_HOLD] | [FW Altitude mode](../flight_modes_fw/altitude.md)   | ALTCTL        |
-| [MAV_STANDARD_MODE_ORBIT][MAV_STANDARD_MODE_ORBIT]                 | [FW Hold mode](../flight_modes_fw/hold.md)           | AUTO_LOITER   |
+| Standard Mode                                                      | PX4 Mode                                           | Internal Mode |
+| ------------------------------------------------------------------ | -------------------------------------------------- | ------------- |
+| [MAV_STANDARD_MODE_CRUISE][MAV_STANDARD_MODE_CRUISE]               | [FW Position mode](../flight_modes_fw/position.md) | POSCTL        |
+| [MAV_STANDARD_MODE_ALTITUDE_HOLD][MAV_STANDARD_MODE_ALTITUDE_HOLD] | [FW Altitude mode](../flight_modes_fw/altitude.md) | ALTCTL        |
+| [MAV_STANDARD_MODE_ORBIT][MAV_STANDARD_MODE_ORBIT]                 | [FW Hold mode](../flight_modes_fw/hold.md)         | AUTO_LOITER   |
 
 [MAV_STANDARD_MODE_CRUISE]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_CRUISE
 [MAV_STANDARD_MODE_ALTITUDE_HOLD]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ALTITUDE_HOLD

--- a/en/concept/flight_modes.md
+++ b/en/concept/flight_modes.md
@@ -44,7 +44,7 @@ They have the following benefits:
 
 - Easier to implement as there is no need to deal with low-level embedded constraints and requirements (such as restricted stack sizes).
 - Easier to maintain as the integration API is small, well defined, and stable (porting custom PX4 modes on the flight controller between PX4 versions is much harder).
-- Crashing the app does not crash the vehicle.
+- Process termination of a ROS 2 mode results in a fallback to an internal flight mode (while termination of an internal mode may well crash the vehicle).
 - They can override existing modes to provide more advanced features.
   You can even override a safety-critical mode with a better versions: if the ROS 2 mode crashes the original mode will be engaged.
 - High-level functionality is available, including a better-feature programming environment, and many useful Linux and ROS libraries.

--- a/en/concept/flight_modes.md
+++ b/en/concept/flight_modes.md
@@ -1,14 +1,19 @@
 # Flight Modes (Developers)
 
-_Flight Modes_ define how the autopilot responds to user input and controls vehicle movement.
+Flight modes are special operational states that control how the autopilot responds to user input and controls vehicle movement.
 They are loosely grouped into _manual_, _assisted_ and _auto_ modes, based on the level/type of control provided by the autopilot.
 The pilot transitions between flight modes using switches on the remote control or with a ground control station.
 
+Flight modes can be implemented in the PX4 flight stack running on the flight controller, or as PX4 ROS 2 modes running on a companion computer.
+From an external perspective (MAVLink/GCS), the origin of a mode is indistinguishable.
+
+This topic links to documentation for the supported modes, compares PX4 FC and ROS2 modes, provides implementation hints, and provides an overview of PX4 modes can be used with MAVLink.
+
+## Supported Flight Modes
+
 Not all flight modes are available (or makes sense), on all vehicle types, and some modes behave differently on different vehicle types.
 
-## PX4 Flight Modes
-
-User-facing flight mode documentation can be found in:
+Flight mode documentation for the modes running on the flight controller are listed below:
 
 - [Flight Modes (Multicopter)](../flight_modes_mc/index.md)
 - [Flight Modes (Fixed-Wing)](../flight_modes_fw/index.md)
@@ -17,40 +22,94 @@ User-facing flight mode documentation can be found in:
 - [Drive Modes (Ackermann Rover)](../flight_modes_rover/ackermann.md)
 - [Basic Configuration > Flight Modes](../config/flight_mode.md)
 
-## ROS 2 Flight Modes
+::: info
+At time of writing there are no PX4 ROS 2 flight modes that are considered "supported as an integral part of the PX4 open source offering".
+:::
 
-Point to the ROS 2 docs.
+## PX4 FC Modes vs PX4 ROS2 Flight Modes
 
-## Choosing between PX4 and ROS 2 flight Modes
+With some exceptions it is possible to write a mode in either the FC and companion computer.
+The main considerations are listed below.
 
-<!-- Format  -->
+ROS 2 modes cannot be used in the following cases:
 
-- if low-level access and or strict timing or high update rate requirements (e.g. direct motor controls on an MC) -> PX4
-- if vehicle has no companion -> PX4
-- if not want to or can use ROS for whatever reason -> PX4
-- if safety-critical (like RTL) -> PX4 (but you might still want to have a fancier RTL replacement on the ROS side)
+- Modes that need to run on vehicles that don't have a companion computer.
+- Modes that require low-level access, strict timing, and/or high update rate requirements.
+  For example, a multicopter mode that implements direct motor control.
+- Safety critical modes, such as [Return mode](../flight_modes_mc/return.md).
+- When you can't use ROS (for any reason).
 
-for the rest: ROS. Specifically, reasons for ROS:
+PX4 ROS 2 modes should be considered for all other cases.
+They have the following benefits:
 
-- easier to implement (no need to deal with low-level embedded constraints and requirements, like stack sizes).
-- Easier to maintain (no need to rebase custom PX4 changes).
+- Easier to implement as there is no need to deal with low-level embedded constraints and requirements (such as restricted stack sizes).
+- Easier to maintain as the integration API is small, well defined, and stable (porting custom PX4 modes on the flight controller between PX4 versions is much harder).
 - Crashing the app does not crash the vehicle.
-- High-level functionality is available (e.g. dynamic data structures, or many (ROS) libraries).
+- They can override existing modes to provide more advanced features.
+  You can even override a safety-critical mode with a better versions: if the ROS 2 mode crashes the original mode will be engaged.
+- High-level functionality is available, including a better-feature programming environment, and many useful Linux and ROS libraries.
 - More available compute to do more advanced processing (e.g. computer vision).
 
-## Flight mode restrictions
+Note that there are some negatives to keep in mind:
 
-Some flight modes make sense only under specific pre-flight and in-flight conditions (e.g. GPS lock).
-The system will not allow transitions to those modes until the right conditions are met.
+- There is no CI environment for testing ROS 2 applications with PX4 in CI (it is easier to automate testing of PX4 flight modes running on the FC).
+- The [PX4 ROS 2 Control Interface](../ros2/px4_ros2_control_interface.md) that is used to define the modes is experimental
+- There is no formal "PX4 companion computer flight stack", so there is nowhere to contribute PX4 ROS2 modes such that they are become a part of the standard offering available to all users.
 
-- Flight mode restrictions in PX4: https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/commander/ModeUtil/mode_requirements.cpp#L46
-- Flight mode restrictions in ROS 2 - point to ROS 2 docs.
+## PX4 ROS 2 Flight Modes (Companion)
 
+[PX4 ROS 2 Control Interface](../ros2/px4_ros2_control_interface.md) documents how to create flight modes running on a companion computer.
 
-## PX4 Flight Modes
+## PX Flight Modes (FC)
 
-Something here about what they are, how they related to [Flight Tasks](../concept/flight_tasks.md), where they are located.
-How they are added.
+The specific control behaviour of a flight mode at any time is determined by a [Flight Task](../concept/flight_tasks.md).
+A flight mode might define one or more tasks that define variations of the mode behavior.
+The actual behaviour that is used is normally defined in a parameter, and selected in [src/modules/flight_mode_manager/FlightModeManager.cpp](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/flight_mode_manager/FlightModeManager.cpp#L266-L285)
+
+### Flight mode restrictions
+
+Some flight modes only make sense only under specific pre-flight and in-flight conditions.
+For example, a manual control mode should not be used unless the system has a manual controller.
+
+PX4 modes can specify these conditions as _restrictions_.
+The types of restrictions are listed in the [FailsafeFlags](../msg_docs/FailsafeFlags.md) uORB topic under "Per mode requirements" (duplicated below)
+
+```text
+# Per-mode requirements
+mode_req_angular_velocity
+mode_req_attitude
+mode_req_local_alt
+mode_req_local_position
+mode_req_local_position_relaxed
+mode_req_global_position
+mode_req_mission
+mode_req_offboard_signal
+mode_req_home_position
+mode_req_wind_and_flight_time_compliance # if set, mode cannot be entered if wind or flight time limit exceeded
+mode_req_prevent_arming    # if set, cannot arm while in this mode
+mode_req_manual_control
+mode_req_other             # other requirements, not covered above (for external modes)
+```
+
+If the condition of restriction is not met:
+
+- arming is not allowed, while the mode is selected
+- when already armed, the mode cannot be selected
+- when armed and the mode is selected, the relevant failsafe is triggered (e.g. RC loss for the manual control requirement).
+  Check [Safety (Failsafe) Configuration](../config/safety.md) for how to configure failsafe behavior.
+
+This is the corresponding flow diagram for the manual control flag (`mode_req_manual_control`):
+
+![Mode requirements diagram](../../assets/middleware/ros2/px4_ros2_interface_lib/mode_requirements_diagram.png)
+
+The requirements for all modes are set in `getModeRequirements()` in [src/modules/commander/ModeUtil/mode_requirements.cpp](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/commander/ModeUtil/mode_requirements.cpp#L46).
+When adding a new mode you will need to add appropriate requirements in that method.
+
+::: tip
+Readers may note that this image is from [PX4 ROS2 Control Interface > Failsafes and mode requirements](../ros2/px4_ros2_control_interface.md#failsafes-and-mode-requirements).
+The requirements and concepts are essentially the same (though defined in different places).
+The main difference is that ROS 2 modes _infer_ the correct requirements to use, while modes in PX4 source code must explicitly specify them.
+:::
 
 ## MAVLink Integration
 
@@ -58,41 +117,66 @@ How they are added.
 
 PX4 implements the MAVLink [Standard Modes Protocol](https://mavlink.io/en/services/standard_modes.md) from PX4 v1.15, with a corresponding implementation in QGroundControl Daily builds (and future release builds).
 
+Modes can be "standard" or "custom".
+The standard modes ([MAV_STANDARD_MODE](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE)) are those that are common to most flight stacks with broadly the same behaviour, whereas custom modes are flight-stack specific.
+
 This protocol allows:
 
 - Discovery of all modes supported by a system from both PX4 and ROS 2 ([MAV_CMD_REQUEST_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE) and [AVAILABLE_MODES](https://mavlink.io/en/messages/common.html#AVAILABLE_MODES)).
 - Discovery of the current mode ([CURRENT_MODE](https://mavlink.io/en/messages/common.html#CURRENT_MODE)).
 - Setting of standard modes using [MAV_CMD_DO_SET_STANDARD_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_STANDARD_MODE) (recommended)
-- Setting of custom modes using [SET_MODE](https://mavlink.io/en/messages/common.html#SET_MODE) (using information from `AVAILABLE_MODES`). At time of writing [MAV_CMD_DO_SET_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_MODE) is not supported.
+- Setting of custom modes using [SET_MODE](https://mavlink.io/en/messages/common.html#SET_MODE) (using information from `AVAILABLE_MODES`). At time of writing [MAV_CMD_DO_SET_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_MODE) is not supported).
 - Notification when the set of modes changes ([AVAILABLE_MODES_MONITOR](https://mavlink.io/en/messages/common.html#AVAILABLE_MODES_MONITOR))
 
-Modes can be "standard" or "custom".
-The standard modes ([MAV_STANDARD_MODE](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE)) are those that are common to most flight stacks with broadly the same behaviour, whereas custom modes are flight-stack specific.
+PX4 advertises support for the following standard flight modes, which means that you can start them by calling [MAV_CMD_DO_SET_STANDARD_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_STANDARD_MODE) and the appropriate enum values:
 
-PX4 advertises support for the standard flight modes that are relevant for almost all vehicle types:
+All vehicle types:
 
-- [MAV_STANDARD_MODE_SAFE_RECOVERY](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_SAFE_RECOVERY) - PX4 [Return mode](../flight_modes/return.md) (`vehicle_status_s::NAVIGATION_STATE_AUTO_RTL`)
-- [MAV_STANDARD_MODE_MISSION](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_MISSION) - PX4 [Mission mode](../flight_modes_mc/mission.md) (vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION)
-- [MAV_STANDARD_MODE_LAND](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_LAND) - PX4 [Land mode](../flight_modes_mc/land.md) (vehicle_status_s::NAVIGATION_STATE_AUTO_LAND)
-- [MAV_STANDARD_MODE_TAKEOFF](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_TAKEOFF) - PX4 [Takeoff mode](../flight_modes_mc/takeoff.md) (vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF)
+| Standard Mode                                                      | PX4 Mode                                      | Internal Mode |
+| ------------------------------------------------------------------ | --------------------------------------------- | ------------- |
+| [MAV_STANDARD_MODE_SAFE_RECOVERY][MAV_STANDARD_MODE_SAFE_RECOVERY] | [Return mode](../flight_modes/return.md)      | AUTO_RTL      |
+| [MAV_STANDARD_MODE_MISSION][MAV_STANDARD_MODE_MISSION]             | [Mission mode](../flight_modes_mc/mission.md) | AUTO_MISSION  |
+| [MAV_STANDARD_MODE_LAND][MAV_STANDARD_MODE_LAND]                   | [Land mode](../flight_modes_mc/land.md)       | AUTO_LAND     |
+| [MAV_STANDARD_MODE_TAKEOFF][MAV_STANDARD_MODE_TAKEOFF]             | [Takeoff mode](../flight_modes_mc/takeoff.md) | AUTO_TAKEOFF  |
 
-MC vehicles also support the following standard modes:
+[MAV_STANDARD_MODE_SAFE_RECOVERY]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_SAFE_RECOVERY
+[MAV_STANDARD_MODE_MISSION]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_MISSION
+[MAV_STANDARD_MODE_LAND]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_LAND
+[MAV_STANDARD_MODE_TAKEOFF]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_TAKEOFF
 
-- [MAV_STANDARD_MODE_POSITION_HOLD](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_POSITION_HOLD) - PX4 [MC Position mode](../flight_modes_mc/position.md) (vehicle_status_s::NAVIGATION_STATE_POSCTL)
-- [MAV_STANDARD_MODE_ALTITUDE_HOLD](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ALTITUDE_HOLD) - PX4 [MC Altitude mode](../flight_modes_mc/altitude.md) (vehicle_status_s::NAVIGATION_STATE_ALTCTL)
-- [MAV_STANDARD_MODE_ORBIT](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ORBIT) - PX4 [FW Orbit mode](../flight_modes_mc/orbit.md) (vehicle_status_s::NAVIGATION_STATE_POSCTL)
+MC vehicles support the following standard modes (in addition to the ones that are supported by all vehicles):
 
-FW vehicles also support the following standard modes:
+| Standard Mode                                                      | PX4 Mode                                           | Internal Mode |
+| ------------------------------------------------------------------ | -------------------------------------------------- | ------------- |
+| [MAV_STANDARD_MODE_POSITION_HOLD][MAV_STANDARD_MODE_POSITION_HOLD] | [MC Position mode](../flight_modes_mc/position.md) | POSCTL        |
+| [MAV_STANDARD_MODE_ALTITUDE_HOLD][MAV_STANDARD_MODE_ALTITUDE_HOLD] | [MC Altitude mode](../flight_modes_mc/altitude.md) | ALTCTL        |
+| [MAV_STANDARD_MODE_ORBIT][MAV_STANDARD_MODE_ORBIT]                 | [FW Orbit mode](../flight_modes_mc/orbit.md)       | POSCTL        |
 
-- [MAV_STANDARD_MODE_CRUISE](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_CRUISE) - PX4 [FW Position mode](../flight_modes_fw/position.html) (vehicle_status_s::NAVIGATION_STATE_POSCTL)
-- [MAV_STANDARD_MODE_ALTITUDE_HOLD](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ALTITUDE_HOLD) - PX4 [FW Altitude mode](../flight_modes_fw/altitude.md) (vehicle_status_s::NAVIGATION_STATE_ALTCTL)
-- [MAV_STANDARD_MODE_ORBIT](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ORBIT) - PX4 [FW Hold mode](../flight_modes_fw/hold.md) (vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER)
+[MAV_STANDARD_MODE_POSITION_HOLD]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_POSITION_HOLD
+[MAV_STANDARD_MODE_ORBIT]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ORBIT
+[MAV_STANDARD_MODE_ALTITUDE_HOLD]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ALTITUDE_HOLD
 
-VTOL vehicles also support the following standard modes:
+FW vehicles support the following standard modes (in addition to the ones that are supported by all vehicles):
 
-- [MAV_STANDARD_MODE_ALTITUDE_HOLD](https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ALTITUDE_HOLD) - PX4 [FW Altitude mode](../flight_modes_fw/altitude.md) (vehicle_status_s::NAVIGATION_STATE_ALTCTL)
+| Standard Mode                                                      | PX4 Mode                                             | Internal Mode |
+| ------------------------------------------------------------------ | ---------------------------------------------------- | ------------- |
+| [MAV_STANDARD_MODE_CRUISE][MAV_STANDARD_MODE_CRUISE]               | [FW Position mode](../flight_modes_fw/position.html) | POSCTL        |
+| [MAV_STANDARD_MODE_ALTITUDE_HOLD][MAV_STANDARD_MODE_ALTITUDE_HOLD] | [FW Altitude mode](../flight_modes_fw/altitude.md)   | ALTCTL        |
+| [MAV_STANDARD_MODE_ORBIT][MAV_STANDARD_MODE_ORBIT]                 | [FW Hold mode](../flight_modes_fw/hold.md)           | AUTO_LOITER   |
 
-  Note that VTOL vehicles could also support `MAV_STANDARD_MODE_CRUISE` (FW) or `MAV_STANDARD_MODE_POSITION_HOLD` (MC) and `MAV_STANDARD_MODE_ORBIT` in respective modes, but this has not been implemented.
+[MAV_STANDARD_MODE_CRUISE]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_CRUISE
+[MAV_STANDARD_MODE_ALTITUDE_HOLD]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ALTITUDE_HOLD
+[MAV_STANDARD_MODE_ORBIT]: https://mavlink.io/en/messages/common.html#MAV_STANDARD_MODE_ORBIT
+
+VTOL vehicles also support the following standard modes (in addition to the ones that are supported by all vehicles):
+
+| Standard Mode                                                      | PX4 Mode                                           | Internal Mode |
+| ------------------------------------------------------------------ | -------------------------------------------------- | ------------- |
+| [MAV_STANDARD_MODE_ALTITUDE_HOLD][MAV_STANDARD_MODE_ALTITUDE_HOLD] | [FW Altitude mode](../flight_modes_fw/altitude.md) | ALTCTL        |
+
+::: info
+Note that VTOL vehicles could also support `MAV_STANDARD_MODE_CRUISE` (FW) or `MAV_STANDARD_MODE_POSITION_HOLD` (MC) and `MAV_STANDARD_MODE_ORBIT` in respective modes, but this has not been implemented.
+:::
 
 When implementing a mapping to a standard mode, see [src/lib/modes/standard_modes.hpp](https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/modes/standard_modes.hpp), and in particular the implementation of `getNavStateFromStandardMode()`.
 
@@ -105,7 +189,7 @@ When implementing a mapping to a standard mode, see [src/lib/modes/standard_mode
 
 -->
 
-### Other Mode Mechanisms
+### Other MAVLink Mode-changing Commands
 
 <!--
 Check these are supported
@@ -117,14 +201,15 @@ This can be more convenient that just starting the mode, in particular when the 
 
 The following are supported:
 
-PX4 supports
-[MAV_CMD_NAV_TAKEOFF](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_TAKEOFF)
-MAV_CMD_NAV_RETURN_TO_LAUNCH - Put into return mode. Equivalent to ....
-MAV_CMD_NAV_LAND
-MAV_CMD_DO_FOLLOW_REPOSITION
-MAV_CMD_DO_FOLLOW
-MAV_CMD_DO_ORBIT - Orbit in MC mode only.
-MAV_CMD_NAV_VTOL_TAKEOFF
-MAV_CMD_DO_REPOSITION
-MAV_CMD_DO_PAUSE_CONTINUE - Pauses a mission by putting the vehicle into Hold/Loiter
-[MAV_CMD_MISSION_START](https://mavlink.io/en/messages/common.html#MAV_CMD_MISSION_START)
+PX4 supports:
+
+- [MAV_CMD_NAV_TAKEOFF](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_TAKEOFF)
+- [MAV_CMD_NAV_RETURN_TO_LAUNCH](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_RETURN_TO_LAUNCH) - Put into return mode. Equivalent to ....
+- [MAV_CMD_NAV_LAND](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND)
+- [MAV_CMD_DO_FOLLOW_REPOSITION](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FOLLOW_REPOSITION)
+- [MAV_CMD_DO_FOLLOW](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FOLLOW)
+- [MAV_CMD_DO_ORBIT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_ORBIT) - Orbit in MC mode only.
+- [MAV_CMD_NAV_VTOL_TAKEOFF](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_VTOL_TAKEOFF)
+- [MAV_CMD_DO_REPOSITION](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_REPOSITION)
+- [MAV_CMD_DO_PAUSE_CONTINUE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_PAUSE_CONTINUE) - Pauses a mission by putting the vehicle into Hold/Loiter
+- [MAV_CMD_MISSION_START](https://mavlink.io/en/messages/common.html#MAV_CMD_MISSION_START)

--- a/en/concept/flight_modes.md
+++ b/en/concept/flight_modes.md
@@ -60,7 +60,7 @@ Note that there are some negatives to keep in mind:
 
 [PX4 ROS 2 Control Interface](../ros2/px4_ros2_control_interface.md) documents how to create flight modes running on a companion computer.
 
-## PX Flight Modes (FC)
+## PX4 Flight Modes (FC)
 
 The specific control behaviour of a flight mode at any time is determined by a [Flight Task](../concept/flight_tasks.md).
 A flight mode might define one or more tasks that define variations of the mode behavior.

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -16,13 +16,12 @@ Drones are more formally referred to as Unmanned Aerial Vehicles (UAV), Unmanned
 The term Unmanned Aerial System (UAS) typically refers to a UAV and all of the other components of a complete system, including a ground control station and/or radio controller, and any other systems used to control the drone, capture, and process data.
 :::
 
-
 ## Drone Types
 
 There are many different vehicle frames (types), and within the types there are many variations.
 Some of the types, along with the use cases for which they are most suited are listed below.
 
-- [Multicopters](../frames_multicopter/index.md) — Multi-rotors offer precision hovering and vertical takeoff, at the cost of shorter and generally slower flight. 
+- [Multicopters](../frames_multicopter/index.md) — Multi-rotors offer precision hovering and vertical takeoff, at the cost of shorter and generally slower flight.
   They are the most popular type of flying vehicle, in part because they are easy to assemble, and PX4 has modes that make them easy to fly and very suitable as a camera platform.
 - [Helicopters](../frames_helicopter/index.md) — Helicopters similar benefits to Multicopters but are mechanically more complex and more efficient.
   They are also much harder to fly.
@@ -37,7 +36,6 @@ Some of the types, along with the use cases for which they are most suited are l
   They can't travel as fast as most aircraft, but can carry heavier payloads, and don't use much power when still.
 - **Boats** — Water-surface vehicles.
 - [Submersibles](../frames_sub/index.md) — Underwater vehicles.
-
 
 For more information see:
 
@@ -54,7 +52,6 @@ The flight stack provides essential stabilisation and safety features, and usual
 
 Some autopilots also include a general-purpose computing system that can provide "higher level" command and control, and that can support more advanced networking, computer vision, and other features.
 This might be implemented as a separate [companion computer](#offboard-companion-computer), but in future it is increasingly likely to be a fully integrated component.
-
 
 ## PX4 Flight Stack
 
@@ -128,6 +125,7 @@ The following sensors are recommended:
 - A [GNSS/GPS](../gps_compass/index.md) or other source of global position is needed to enable all automatic modes, and some manual/assisted modes.
 
   Typically a module that combines a GNSS and Compass is used, as an external compass can be made less susceptible to electromomagnetic interference than the internal compass in the flight controller.
+
 - [Airspeed sensors](../sensor/airspeed.md) are highly recommended for fixed-wing and VTOL-vehicles.
 - [Distance Sensors \(Rangefinders\)](../sensor/rangefinders.md) are highly recommended for all vehicle types, as they allow smoother and more robust landings, and enable features such as terrain following on multicopters.
 - [Optical Flow Sensors](../sensor/optical_flow.md) can be used with distance sensors on multcopters and VTOL to support navigation in GNSS-denied environments.
@@ -316,7 +314,8 @@ A detailed overview of arming and disarming configuration can be found here: [Pr
 
 ## Flight Modes
 
-Flight modes provide different types/levels of vehicle automation and autopilot assistance to the user (pilot).
+Flight modes are special operational states that provide different types/levels of vehicle automation and autopilot assistance to the user (pilot).
+
 _Autonomous modes_ are fully controlled by the autopilot, and require no pilot/remote control input.
 These are used, for example, to automate common tasks like takeoff, returning to the home position, and landing.
 Other autonomous modes execute pre-programmed missions, follow a GPS beacon, or accept commands from an offboard computer or ground station.
@@ -329,7 +328,7 @@ while others are impossible to flip and will hold position/course against wind.
 Not all flight modes are available on all vehicle types, and some modes can only be used when specific conditions have been met (e.g. many modes require a global position estimate).
 :::
 
-An overview of the available flight modes for each vehicle can be found below:
+An overview of the flight modes implemented within PX4 for each vehicle can be found below:
 
 - [Flight Modes (Multicopter)](../flight_modes_mc/index.md)
 - [Flight Modes (Fixed-Wing)](../flight_modes_fw/index.md)
@@ -338,6 +337,11 @@ An overview of the available flight modes for each vehicle can be found below:
 - [Drive Modes (Ackermann Rover)](../flight_modes_rover/ackermann.md)
 
 Instructions for how to set up your remote control switches to enable different flight modes is provided in [Flight Mode Configuration](../config/flight_mode.md).
+
+PX4 also supports flight modes implemented in [ROS 2](../ros2/index.md) using the [PX4 ROS 2 Control Interface](../ros2/px4_ros2_control_interface.md).
+These are indistinguishable from PX4 internal modes, and can be used to override internal modes with a more advanced version, or to create entirely new functionality.
+Note that these depend on ROS 2 and can therefore only run on systems that have a [companion computer](#offboard-companion-computer).
+At time of writing there are no ROS 2 flight modes that are considered an integral part of the PX4 open source offering.
 
 ## Safety Settings (Failsafe)
 

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -62,7 +62,7 @@ Some of PX4's key features are:
 - Supports many different vehicle frames/types, including: [multicopters](../frames_multicopter/index.md), [fixed-wing aircraft](../frames_plane/index.md) (planes), [VTOLs](../frames_vtol/index.md) (hybrid multicopter/fixed-wing), [ground vehicles](../frames_rover/index.md), and [underwater vehicles](../frames_sub/index.md).
 - Great choice of drone components for [flight controller](#flight-controller), [sensors](#sensors), [payloads](#payloads), and other peripherals.
 - Flexible and powerful [flight modes](#flight-modes) and [safety features](#safety-settings-failsafe).
-- Robust and deep integration with [companion computers](#offboard-companion-computer) and [robotics APIs](../robotics/index.md) such as [ROS 2](../ros2/user_guide.md) and [MAVSDK](http://mavsdk.mavlink.io)).
+- Robust and deep integration with [companion computers](#offboard-companion-computer) and [robotics APIs](../robotics/index.md) such as [ROS 2](../ros2/user_guide.md) and [MAVSDK](http://mavsdk.mavlink.io).
 
 PX4 is a core part of a broader drone platform that includes the [QGroundControl](#qgc) ground station, [Pixhawk hardware](https://pixhawk.org/), and [MAVSDK](http://mavsdk.mavlink.io) for integration with companion computers, cameras and other hardware using the MAVLink protocol.
 PX4 is supported by the [Dronecode Project](https://www.dronecode.org/).
@@ -314,7 +314,7 @@ A detailed overview of arming and disarming configuration can be found here: [Pr
 
 ## Flight Modes
 
-Flight modes are special operational states that provide different types/levels of vehicle automation and autopilot assistance to the user (pilot).
+Modes are special operational states that provide different types/levels of vehicle automation and autopilot assistance to the user (pilot).
 
 _Autonomous modes_ are fully controlled by the autopilot, and require no pilot/remote control input.
 These are used, for example, to automate common tasks like takeoff, returning to the home position, and landing.
@@ -325,7 +325,7 @@ Different manual modes enable different flight characteristics - for example, so
 while others are impossible to flip and will hold position/course against wind.
 
 :::tip
-Not all flight modes are available on all vehicle types, and some modes can only be used when specific conditions have been met (e.g. many modes require a global position estimate).
+Not all modes are available on all vehicle types, and some modes can only be used when specific conditions have been met (e.g. many modes require a global position estimate).
 :::
 
 An overview of the flight modes implemented within PX4 for each vehicle can be found below:
@@ -338,10 +338,9 @@ An overview of the flight modes implemented within PX4 for each vehicle can be f
 
 Instructions for how to set up your remote control switches to enable different flight modes is provided in [Flight Mode Configuration](../config/flight_mode.md).
 
-PX4 also supports flight modes implemented in [ROS 2](../ros2/index.md) using the [PX4 ROS 2 Control Interface](../ros2/px4_ros2_control_interface.md).
+PX4 also supports external modes implemented in [ROS 2](../ros2/index.md) using the [PX4 ROS 2 Control Interface](../ros2/px4_ros2_control_interface.md).
 These are indistinguishable from PX4 internal modes, and can be used to override internal modes with a more advanced version, or to create entirely new functionality.
 Note that these depend on ROS 2 and can therefore only run on systems that have a [companion computer](#offboard-companion-computer).
-At time of writing there are no ROS 2 flight modes that are considered an integral part of the PX4 open source offering.
 
 ## Safety Settings (Failsafe)
 
@@ -378,10 +377,10 @@ For a VTOL Tailsitter the heading is relative to the multirotor configuration (i
 
 It is important to know the vehicle heading direction in order to align the autopilot with the vehicle vector of movement.
 Multicopters have a heading even when they are symmetrical from all sides!
-Usually manufacturers use a colored props or colored arms to indicate the heading.
+Usually manufacturers use a coloured props or coloured arms to indicate the heading.
 
 ![Frame Heading TOP](../../assets/concepts/frame_heading_top.png)
 
-In our illustrations we will use red coloring for the front propellers of multicopter to show heading.
+In our illustrations we will use red colouring for the front propellers of multicopter to show heading.
 
 You can read in depth about heading in [Flight Controller Orientation](../config/flight_controller_orientation.md)

--- a/en/ros2/px4_ros2_control_interface.md
+++ b/en/ros2/px4_ros2_control_interface.md
@@ -22,6 +22,9 @@ They can even replace the default modes in PX4 with enhanced ROS 2 versions, fal
 The library also provides classes for sending different types of setpoints, ranging from high-level navigation tasks all the way down to direct actuator controls.
 These classes abstract the internal setpoints used by PX4, and that can therefore be used to provide a consistent ROS 2 interface for future PX4 and ROS releases.
 
+PX4 ROS 2 modes are easier to implement and maintain than PX4 internal modes, and provide more resources for developers in terms of processing power and pre-existing  libraries.
+Unless the mode is safety-critical, requires strict timing or very high update rates, or your vehicle doesn't have a companion computer, you should [consider using PX4 ROS 2 modes in preference to PX4 internal modes](../concept/flight_modes.md#px4-fc-modes-vs-px4-ros2-flight-modes).
+
 ## Overview
 
 This diagram provides a conceptual overview of how the control interface modes and mode executors interact with PX4.

--- a/en/ros2/px4_ros2_control_interface.md
+++ b/en/ros2/px4_ros2_control_interface.md
@@ -22,8 +22,8 @@ They can even replace the default modes in PX4 with enhanced ROS 2 versions, fal
 The library also provides classes for sending different types of setpoints, ranging from high-level navigation tasks all the way down to direct actuator controls.
 These classes abstract the internal setpoints used by PX4, and that can therefore be used to provide a consistent ROS 2 interface for future PX4 and ROS releases.
 
-PX4 ROS 2 modes are easier to implement and maintain than PX4 internal modes, and provide more resources for developers in terms of processing power and pre-existing  libraries.
-Unless the mode is safety-critical, requires strict timing or very high update rates, or your vehicle doesn't have a companion computer, you should [consider using PX4 ROS 2 modes in preference to PX4 internal modes](../concept/flight_modes.md#px4-fc-modes-vs-px4-ros2-flight-modes).
+PX4 ROS 2 modes are easier to implement and maintain than PX4 internal modes, and provide more resources for developers in terms of processing power and pre-existing libraries.
+Unless the mode is safety-critical, requires strict timing or very high update rates, or your vehicle doesn't have a companion computer, you should [consider using PX4 ROS 2 modes in preference to PX4 internal modes](../concept/flight_modes.md#internal-vs-external-modes).
 
 ## Overview
 


### PR DESCRIPTION
This updates the flight mode "dev" guide - https://docs.px4.io/main/en/concept/flight_modes.html

- Removes the diagram
- Removes info about specific modes - links to other docs.
- Adds info about Standard modes and mavlink integration

Lots still to do. This is draft.

Fixes #3564