### PR TITLE
Rover docs update

### DIFF
--- a/en/config_rover/ackermann.md
+++ b/en/config_rover/ackermann.md
@@ -36,8 +36,9 @@ For this mode to work properly the [Basic Setup](#basic-setup) must've already b
 
 The basic setup already covers the minimum setup required to use the rover in [Manual mode](../flight_modes_rover/ackermann.md#manual-mode).
 
-However, this mode is also affected by the steering slew rate and acceleration/deceleration limits.
-This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
+This mode is also affected by (optional) acceleration/deceleration limits.
+As configuration of these limits becomes mandatory for subsequent modes, we do this setup here.
+
 Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
 
 1. [RA_WHEEL_BASE](#RA_WHEEL_BASE) [m]: Measure the distance from the back to the front wheels.
@@ -128,7 +129,7 @@ To set up [Acro mode](../flight_modes_rover/ackermann.md#acro-mode) configure th
 2. [RO_YAW_RATE_P](#RO_YAW_RATE_P) [-]: Proportional gain of the closed loop yaw rate controller.
    The closed loop acceleration control will compare the yaw rate setpoint with the measured yaw rate and adapt the motor commands based on the error between them.
    The proportional gain is multiplied with this error and that value is added to the motor command.
-   This way disturbances like uneven grounds or external forces can be compensated.
+   This compensates for disturbances such as uneven ground and external forces.
 
    :::tip
    To tune this parameter:
@@ -143,7 +144,7 @@ To set up [Acro mode](../flight_modes_rover/ackermann.md#acro-mode) configure th
    The integral gain accumulates the error between the desired and actual yaw rate scaled by the integral gain over time and that value is added to the motor command.
 
    ::: tip
-   An integrator might not be neccessary at this stage, but it will become important for subsequent modes.
+   An integrator might not be necessary at this stage, but it will become important for subsequent modes.
    :::
 
 The rover is now ready to drive in [Acro mode](../flight_modes_rover/ackermann.md#acro-mode).
@@ -171,7 +172,7 @@ Therefore you only need to tune the closed loop gains:
    Increase/Decrease the parameter until you are satisfied with the setpoint tracking.
    :::
 
-::: tip
+::: info
 For the closed loop yaw control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
 Since the yaw and yaw rate controllers are cascaded, there only needs to be one integrator which is in the yaw rate controller. If you observe a steady state error in the yaw setpoint increase the [RO_YAW_RATE_I](#RO_YAW_RATE_I) parameter.
 :::
@@ -272,9 +273,10 @@ The required parameter configuration is discussed in the following sections.
 1. [RO_DECEL_LIM](#RO_DECEL_LIM) [m/s^2] and [RO_JERK_LIM](#RO_JERK_LIM) [m/s^3] are used to calculate a speed trajectory such that the rover reaches the next waypoint with the correct [cornering speed](#cornering-speed).
 
    ::: tip
-   Plan a mission for the rover to drive a square and observe how it slows down when approaching a waypoint.
-   If the rover decelerates too quickly decrease the [RO_DECEL_LIM](#RO_DECEL_LIM) parameter, if it starts slowing down too early increase the parameter.
-   If you observe a jerking motion as the rover slows down, decrease the [RO_JERK_LIM](#RO_JERK_LIM) parameter otherwise increase it as much as possible as it can interfere with the tuning of [RO_DECEL_LIM](#RO_DECEL_LIM).
+   Plan a mission for the rover to drive a square and observe how it slows down when approaching a waypoint:
+
+   - If the rover decelerates too quickly decrease the [RO_DECEL_LIM](#RO_DECEL_LIM) parameter, if it starts slowing down too early increase the parameter.
+   - If you observe a jerking motion as the rover slows down, decrease the [RO_JERK_LIM](#RO_JERK_LIM) parameter otherwise increase it as much as possible as it can interfere with the tuning of [RO_DECEL_LIM](#RO_DECEL_LIM).
 
    These two parameters have to be tuned as a pair, repeat until you are satisfied with the behaviour.
    :::

--- a/en/config_rover/ackermann.md
+++ b/en/config_rover/ackermann.md
@@ -36,7 +36,8 @@ For this mode to work properly the [Basic Setup](#basic-setup) must've already b
 
 The basic setup already covers the minimum setup required to use the rover in [Manual mode](../flight_modes_rover/ackermann.md#manual-mode).
 
-However, this mode is also affected by the steering slew rate and acceleration/deceleration limits. This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
+However, this mode is also affected by the steering slew rate and acceleration/deceleration limits.
+This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
 Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
 
 1. [RA_WHEEL_BASE](#RA_WHEEL_BASE) [m]: Measure the distance from the back to the front wheels.
@@ -47,7 +48,8 @@ Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and
 3. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: Drive the rover at full throttle and set this parameter to the observed value of the ground speed.
 
    :::info
-   This parameter is also used for the feed-forward term of the speed control. It will be further tuned in the configuration of [Position mode](#position-mode).
+   This parameter is also used for the feed-forward term of the speed control.
+   It will be further tuned in the configuration of [Position mode](#position-mode).
    :::
 
 4. (Optional) [RO_ACCEL_LIM](#RO_ACCEL_LIM) [m/s^2]: Maximum acceleration you want to allow for your rover.
@@ -125,7 +127,8 @@ To set up [Acro mode](../flight_modes_rover/ackermann.md#acro-mode) configure th
 
 2. [RO_YAW_RATE_P](#RO_YAW_RATE_P) [-]: Proportional gain of the closed loop yaw rate controller.
    The closed loop acceleration control will compare the yaw rate setpoint with the measured yaw rate and adapt the motor commands based on the error between them.
-   The proportional gain is multiplied with this error and that value is added to the motor command. This way disturbances like uneven grounds or external forces can be compensated.
+   The proportional gain is multiplied with this error and that value is added to the motor command.
+   This way disturbances like uneven grounds or external forces can be compensated.
 
    :::tip
    To tune this parameter:
@@ -292,8 +295,10 @@ The degree to which corner cutting is allowed can be tuned, or disabled, with th
 The corner cutting effect is a tradeoff between how close you get to the waypoint and the smoothness of the trajectory.
 :::
 
-1. [NAV_ACC_RAD](#NAV_ACC_RAD) [m]: Default acceptance radius. This is also used as a lower bound for the acceptance radius scaling.
-2. [RA_ACC_RAD_MAX](#RA_ACC_RAD_MAX) [m]: The maximum the acceptance radius can be scaled to. Set equal to [NAV_ACC_RAD](#NAV_ACC_RAD) to disable the corner cutting effect.
+1. [NAV_ACC_RAD](#NAV_ACC_RAD) [m]: Default acceptance radius
+   This is also used as a lower bound for the acceptance radius scaling.
+2. [RA_ACC_RAD_MAX](#RA_ACC_RAD_MAX) [m]: The maximum the acceptance radius can be scaled to.
+   Set equal to [NAV_ACC_RAD](#NAV_ACC_RAD) to disable the corner cutting effect.
 3. [RA_ACC_RAD_GAIN](#RA_ACC_RAD_GAIN) [-]: This tuning parameter is a multiplicand on the [calculated ideal acceptance radius](#corner-cutting-logic) to account for dynamic effects.
 
    :::tip

--- a/en/config_rover/ackermann.md
+++ b/en/config_rover/ackermann.md
@@ -44,15 +44,15 @@ Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and
 
    ![Geometric parameters](../../assets/airframes/rover/rover_ackermann/geometric_parameters.png)
 
-3. [RA_MAX_THR_SPEED](#RA_MAX_THR_SPEED) [m/s]: Drive the rover at full throttle and set this parameter to the observed value of the ground speed.
+3. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: Drive the rover at full throttle and set this parameter to the observed value of the ground speed.
 
    :::info
    This parameter is also used for the feed-forward term of the speed control. It will be further tuned in the configuration of [Position mode](#position-mode).
    :::
 
-4. [RA_MAX_ACCEL](#RA_MAX_ACCEL) [m/s^2]: Maximum acceleration you want to allow for your rover.
+4. (Optional) [RO_ACCEL_LIM](#RO_ACCEL_LIM) [m/s^2]: Maximum acceleration you want to allow for your rover.
 
-   <a id="RA_MAX_ACCEL_CONSIDERATIONS"></a>
+   <a id="RO_ACCEL_LIM_CONSIDERATIONS"></a>
 
    :::tip
    Your rover has a maximum possible acceleration which is determined by the maximum torque the motor can supply.
@@ -61,34 +61,34 @@ Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and
    One approach to determine an appropriate value is:
 
    1. From a standstill, give the rover full throttle until it reaches the maximum speed.
-   1. Disarm the rover and plot the `measured_forward_speed` from [RoverAckermannStatus](../msg_docs/RoverAckermannStatus.md).
-   1. Divide the maximum speed by the time it took to reach it and set this as the value for [RA_MAX_ACCEL](#RA_MAX_ACCEL).
+   1. Disarm the rover and plot the `measured_speed_body_x` from [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md).
+   1. Divide the maximum speed by the time it took to reach it and set this as the value for [RO_ACCEL_LIM](#RO_ACCEL_LIM).
 
    Some RC rovers have enough torque to lift up if the maximum acceleration is not limited.
    If that is the case:
 
-   1. Set [RA_MAX_ACCEL](#RA_MAX_ACCEL) to a low value, give the rover full throttle from a standstill and observe its behaviour.
-   1. Increase [RA_MAX_ACCEL](#RA_MAX_ACCEL) until the rover starts to lift up during the acceleration.
-   1. Set [RA_MAX_ACCEL](#RA_MAX_ACCEL) to the highest value that does not cause the rover to lift up.
+   1. Set [RO_ACCEL_LIM](#RO_ACCEL_LIM) to a low value, give the rover full throttle from a standstill and observe its behaviour.
+   1. Increase [RO_ACCEL_LIM](#RO_ACCEL_LIM) until the rover starts to lift up during the acceleration.
+   1. Set [RO_ACCEL_LIM](#RO_ACCEL_LIM) to the highest value that does not cause the rover to lift up.
       :::
 
-5. [RA_MAX_DECEL](#RA_MAX_DECEL) [m/s^2]: Maximum deceleration you want to allow for your rover.
+5. (Optional) [RO_DECEL_LIM](#RO_DECEL_LIM) [m/s^2]: Maximum deceleration you want to allow for your rover.
 
    :::tip
-   The same [considerations](#RA_MAX_ACCEL_CONSIDERATIONS) as in the configuration of [RA_MAX_ACCEL](#RA_MAX_ACCEL) apply.
+   The same [considerations](#RO_ACCEL_LIM_CONSIDERATIONS) as in the configuration of [RO_ACCEL_LIM](#RO_ACCEL_LIM) apply.
    :::
 
    :::info
    This parameter is also used for the calculation of the speed setpoint during [Auto modes](#auto-modes).
    :::
 
-6. (Optional) [RA_MAX_STR_RATE](#RA_MAX_STR_RATE) [deg/s]: Maximum steering rate you want to allow for your rover.
+6. (Optional) [RA_STR_RATE_LIM](#RA_STR_RATE_LIM) [deg/s]: Maximum steering rate you want to allow for your rover.
 
    :::tip
    This value depends on your rover and use case.
    For bigger rovers there might be a mechanical limit that is easy to identify by steering the rover at a standstill and increasing
-   [RA_MAX_STR_RATE](#RA_MAX_STR_RATE) until you observe the steering rate to no longer be limited by the parameter.
-   For smaller rovers you might observe the steering to be too aggressive. Set [RA_MAX_STR_RATE](#RA_MAX_STR_RATE) to a low value and steer the rover at a standstill.
+   [RA_STR_RATE_LIM](#RA_STR_RATE_LIM) until you observe the steering rate to no longer be limited by the parameter.
+   For smaller rovers you might observe the steering to be too aggressive. Set [RA_STR_RATE_LIM](#RA_STR_RATE_LIM) to a low value and steer the rover at a standstill.
    Increase the parameter until you reach the maximum steering rate you are comfortable with.
    :::
 
@@ -104,64 +104,90 @@ For this mode to work properly [Manual mode](#acro-mode) must've already been co
 
 To set up [Acro mode](../flight_modes_rover/ackermann.md#acro-mode) configure the following [parameters](../advanced_config/parameters.md) in QGroundControl:
 
-1. [RA_MAX_LAT_ACCEL](#RA_MAX_LAT_ACCEL): Maximum lateral acceleration you want to allow for your rover.
+1. [RO_YAW_RATE_LIM](#RO_YAW_RATE_LIM): Maximum yaw rate you want to allow for your rover.
 
    :::tip
-   Limiting the lateral acceleration is necessary if the rover is prone rolling over, loosing traction at high speeds or if passenger comfort is important.
+   Limiting the yaw rate is necessary if the rover is prone rolling over, loosing traction at high speeds or if passenger comfort is important.
    Small rovers especially can be prone to rolling over when steering aggressively at high speeds.
 
    If this is the case:
 
-   1. In [Acro mode](../flight_modes_rover/ackermann.md#acro-mode), set [RA_MAX_LAT_ACCEL](#RA_MAX_LAT_ACCEL) to a small value and drive the rover at full throttle and with the right stick all the way to the left or right.
-   1. Increase [RA_MAX_LAT_ACCEL](#RA_MAX_LAT_ACCEL) until the wheels of the rover start to lift up.
-   1. Set [RA_MAX_LAT_ACCEL](#RA_MAX_LAT_ACCEL) to the highest value that does not cause the rover to lift up.
+   1. In [Acro mode](../flight_modes_rover/ackermann.md#acro-mode), set [RO_YAW_RATE_LIM](#RO_YAW_RATE_LIM) to a small value and drive the rover at full throttle and with the right stick all the way to the left or right.
+   1. Increase [RO_YAW_RATE_LIM](#RO_YAW_RATE_LIM) until the wheels of the rover start to lift up.
+   1. Set [RO_YAW_RATE_LIM](#RO_YAW_RATE_LIM) to the highest value that does not cause the rover to lift up.
 
-   If you see no need to limit the lateral acceleration, set this parameter to the maximum lateral acceleration the rover can achieve:
+   If you see no need to limit the yaw rate, set this parameter to the maximum yaw rate the rover can achieve:
 
    1. In [Manual mode](#manual-mode) drive the rover at full throttle and with the maximum steering angle.
-   2. Plot the `measured_lateral_acceleration` from [RoverAckermannStatus](../msg_docs/RoverAckermannStatus.md) and enter the highest observed value for [RA_MAX_LAT_ACCEL](#RA_MAX_LAT_ACCEL).
+   2. Plot the `measured_yaw_rate` from [RoverRateStatus](../msg_docs/RoverRateStatus.md) and enter the highest observed value for [RO_YAW_RATE_LIM](#RO_YAW_RATE_LIM).
 
    :::
 
-2. [RA_LAT_ACCEL_P](#RA_LAT_ACCEL_P) [-]: Proportional gain of the closed loop lateral acceleration controller.
-   The closed loop acceleration control will compare the lateral acceleration setpoint with the measured lateral acceleration and adapt the motor commands based on the error between them.
+2. [RO_YAW_RATE_P](#RO_YAW_RATE_P) [-]: Proportional gain of the closed loop yaw rate controller.
+   The closed loop acceleration control will compare the yaw rate setpoint with the measured yaw rate and adapt the motor commands based on the error between them.
    The proportional gain is multiplied with this error and that value is added to the motor command. This way disturbances like uneven grounds or external forces can be compensated.
 
    :::tip
    To tune this parameter:
 
    1. Put the rover in [Acro mode](../flight_modes_rover/ackermann.md#acro-mode) and hold the throttle stick and the right stick at a few different levels for a couple of seconds each.
-   2. Disarm the rover and from the flight log plot the `lateral_acceleration_setpoint` from [RoverAckermannSetpoint](../msg_docs/RoverAckermannSetpoint.md) and the `measured_lateral_acceleration` from [RoverAckermannStatus](../msg_docs/RoverAckermannStatus.md) over each other.
-   3. Increase [RA_LAT_ACCEL_P](#RA_LAT_ACCEL_P) if the measured value does not track the setpoint fast enough or decrease it if the measurement overshoots the setpoint by too much.
+   2. Disarm the rover and from the flight log plot the `adjusted_yaw_rate_setpoint` from [RoverRateStatus](../msg_docs/RoverRateStatus.md) and the `measured_yaw_rate` from [RoverRateStatus](../msg_docs/RoverRateStatus.md) over each other.
+   3. Increase [RO_YAW_RATE_P](#RO_YAW_RATE_P) if the measured value does not track the setpoint fast enough or decrease it if the measurement overshoots the setpoint by too much.
    4. Repeat until you are satisfied with the behaviour.
+      :::
 
-   Note that the lateral acceleration measurement is very noisy and therefore needs to be heavily filtered.
-   This means that the measurement is slightly delayed, so if you observe a slight offset in time between the setpoint and measurement, that is not something that can be fixed with tuning.
-   :::
-
-3. (Optional) [RA_LAT_ACCEL_I](#RA_LAT_ACCEL_I) [-]: Integral gain of the closed loop lateral acceleration controller.
-   The integral gain accumulates the error between the desired and actual lateral acceleration scaled by the integral gain over time and that value is added to the motor command.
+3. [RO_YAW_RATE_I](#RO_YAW_RATE_I) [-]: Integral gain of the closed loop yaw rate controller.
+   The integral gain accumulates the error between the desired and actual yaw rate scaled by the integral gain over time and that value is added to the motor command.
 
    ::: tip
-   The integrator gain is usually not necessary for the lateral acceleration setpoint as this is usually a fast changing value.
-   Leave this parameter at zero unless necessary, as it can have negative side effects such as overshooting or oscillating around the setpoint.
+   An integrator might not be neccessary at this stage, but it will become important for subsequent modes.
    :::
 
 The rover is now ready to drive in [Acro mode](../flight_modes_rover/ackermann.md#acro-mode).
 
+## Stabilized Mode
+
+::: warning
+For this mode to work properly [Acro mode](#acro-mode) must've already been configured!
+:::
+
+For [Stabilized mode](../flight_modes_rover/differential.md#stabilized-mode) the controller utilizes a closed loop yaw controller, which creates a yaw rate setpoint to control the yaw when it is active:
+
+![Cascaded PID for yaw control](../../assets/airframes/rover/rover_differential/cascaded_pid_for_yaw.png)
+
+Unlike the closed loop yaw rate, this controller has no feed-forward term.
+Therefore you only need to tune the closed loop gains:
+
+1. [RO_YAW_P](#RO_YAW_P) [-]: Proportional gain for the closed loop yaw controller.
+
+   ::: tip
+   In stabilized mode the closed loop yaw control is only active when driving a straight line (no yaw rate input).
+   To tune it start with a value of 1 for [RO_YAW_P](#RO_YAW_P).
+   Put the rover into stabilized mode and move the left stick of your controller up to drive forwards.
+   Disarm the rover and from the flight log plot the `measured_yaw` and the `adjusted_yaw_setpoint` from the [RoverAttitudeStatus](../msg_docs/RoverAttitudeStatus.md) message over each other.
+   Increase/Decrease the parameter until you are satisfied with the setpoint tracking.
+   :::
+
+::: tip
+For the closed loop yaw control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
+Since the yaw and yaw rate controllers are cascaded, there only needs to be one integrator which is in the yaw rate controller. If you observe a steady state error in the yaw setpoint increase the [RO_YAW_RATE_I](#RO_YAW_RATE_I) parameter.
+:::
+
+The rover is now ready to drive in [Stabilized mode](../flight_modes_rover/ackermann.md#stabilized-mode).
+
 ## Position Mode
 
 :::warning
-For this mode to work properly [Acro mode](#acro-mode) must already be configured!
+For this mode to work properly [Stabilized mode](#stabilized-mode) must already be configured!
 :::
 
-[Position mode](../flight_modes_rover/ackermann.md#position-mode) is the most advanced manual mode, utilizing closed loop lateral acceleration and speed control and leveraging position estimates.
+[Position mode](../flight_modes_rover/ackermann.md#position-mode) is the most advanced manual mode, utilizing closed loop yaw rate and speed control and leveraging position estimates.
 
 To configure set the following parameters:
 
-1. [RA_MAX_SPEED](#RA_MAX_SPEED) [m/s]: This is the maximum speed you want to allow for your rover.
+1. [RO_SPEED_LIM](#RO_SPEED_LIM) [m/s]: This is the maximum speed you want to allow for your rover.
    This will define the stick-to-speed mapping for position mode and set an upper limit for the speed setpoint for all [auto modes](#auto-modes).
-2. [RA_MAX_THR_SPEED](#RA_MAX_THR_SPEED) [m/s]: This parameter is used to calculate the feed-forward term of the closed loop speed control which linearly maps desired speeds to normalized motor commands.
+2. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: This parameter is used to calculate the feed-forward term of the closed loop speed control which linearly maps desired speeds to normalized motor commands.
    As mentioned in the [Manual mode](../flight_modes_rover/ackermann.md#manual-mode) configuration , a good starting point is the observed ground speed when the rover drives at maximum throttle in [Manual mode](../flight_modes_rover/ackermann.md#manual-mode).
 
    <a id="RA_SPEED_TUNING"></a>
@@ -169,11 +195,11 @@ To configure set the following parameters:
    ::: tip
    To further tune this parameter:
 
-   1. Set [RA_SPEED_P](#RA_SPEED_P) and [RA_SPEED_I](#RA_SPEED_I) to zero.
+   1. Set [RO_SPEED_P](#RO_SPEED_P) and [RO_SPEED_I](#RO_SPEED_I) to zero.
       This way the speed is only controlled by the feed-forward term, which makes it easier to tune.
    1. Put the rover in [Position mode](../flight_modes_rover/ackermann.md#position-mode) and then move the left stick of your controller up and/or down and hold it at a few different levels for a couple of seconds each.
-   1. Disarm the rover and from the flight log plot the `adjusted_forward_speed_setpoint` and the `measured_forward_speed` from the [RoverAckermannStatus](../msg_docs/RoverAckermannStatus.md) message over each other.
-   1. If the actual speed of the rover is higher than the speed setpoint, increase [RA_MAX_THR_SPEED](#RA_MAX_THR_SPEED).
+   1. Disarm the rover and from the flight log plot the `adjusted_speed_body_x_setpoint` and the `measured_speed_body_x` from the [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md) message over each other.
+   1. If the actual speed of the rover is higher than the speed setpoint, increase [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED).
       If it is the other way around decrease the parameter and repeat until you are satisfied with the setpoint tracking.
 
    :::
@@ -182,14 +208,14 @@ To configure set the following parameters:
    If your rover oscillates when driving a straight line in [Position mode](../flight_modes_rover/ackermann.md#position-mode), set this parameter to the observed ground speed at maximum throttle in [Manual mode](../flight_modes_rover/ackermann.md#manual-mode) and complete steps 5-7 first before continuing the tuning of the closed loop speed control (Steps 2-4).
    :::
 
-3. [RA_SPEED_P](#RA_SPEED_P) [-]: Proportional gain of the closed loop speed controller.
+3. [RO_SPEED_P](#RO_SPEED_P) [-]: Proportional gain of the closed loop speed controller.
 
    ::: tip
-   This parameter can be tuned the same way as [RA_MAX_THR_SPEED](#RA_SPEED_TUNING).
-   If you tuned [RA_MAX_THR_SPEED](#RA_MAX_THR_SPEED) well, you might only need a very small value.
+   This parameter can be tuned the same way as [RO_MAX_THR_SPEED](#RA_SPEED_TUNING).
+   If you tuned [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) well, you might only need a very small value.
    :::
 
-4. [RA_SPEED_I](#RA_SPEED_I) [-]: Integral gain for the closed loop speed controller.
+4. [RO_SPEED_I](#RO_SPEED_I) [-]: Integral gain for the closed loop speed controller.
 
    ::: tip
    For the closed loop speed control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
@@ -240,18 +266,18 @@ The required parameter configuration is discussed in the following sections.
 
 ### Speed
 
-1. [RA_MAX_DECEL](#RA_MAX_DECEL) [m/s^2] and [RA_MAX_JERK](#RA_MAX_JERK) [m/s^3] are used to calculate a speed trajectory such that the rover reaches the next waypoint with the correct [cornering speed](#cornering-speed).
+1. [RO_DECEL_LIM](#RO_DECEL_LIM) [m/s^2] and [RO_JERK_LIM](#RO_JERK_LIM) [m/s^3] are used to calculate a speed trajectory such that the rover reaches the next waypoint with the correct [cornering speed](#cornering-speed).
 
    ::: tip
    Plan a mission for the rover to drive a square and observe how it slows down when approaching a waypoint.
-   If the rover decelerates too quickly decrease the [RA_MAX_DECEL](#RA_MAX_DECEL) parameter, if it starts slowing down too early increase the parameter.
-   If you observe a jerking motion as the rover slows down, decrease the [RA_MAX_JERK](#RA_MAX_JERK) parameter otherwise increase it as much as possible as it can interfere with the tuning of [RA_MAX_DECEL](#RA_MAX_DECEL).
+   If the rover decelerates too quickly decrease the [RO_DECEL_LIM](#RO_DECEL_LIM) parameter, if it starts slowing down too early increase the parameter.
+   If you observe a jerking motion as the rover slows down, decrease the [RO_JERK_LIM](#RO_JERK_LIM) parameter otherwise increase it as much as possible as it can interfere with the tuning of [RO_DECEL_LIM](#RO_DECEL_LIM).
 
    These two parameters have to be tuned as a pair, repeat until you are satisfied with the behaviour.
    :::
 
-2. Plot the `adjusted_forward_speed_setpoint` and `measured_forward_speed` from the [RoverAckermannStatus](../msg_docs/RoverAckermannStatus.md) message over each other.
-   If the tracking of these setpoints is not satisfactory adjust the values for [RA_SPEED_P](#RA_SPEED_P) and [RA_SPEED_I](#RA_SPEED_I).
+2. Plot the `adjusted_speed_body_x_setpoint` and `measured_speed_body_x` from the [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md) message over each other.
+   If the tracking of these setpoints is not satisfactory adjust the values for [RO_SPEED_P](#RO_SPEED_P) and [RO_SPEED_I](#RO_SPEED_I).
 
 ### Corner Cutting
 
@@ -278,15 +304,17 @@ The corner cutting effect is a tradeoff between how close you get to the waypoin
 
 ### Path Following
 
-The [pure pursuit](#pure-pursuit-guidance-logic) algorithm is used to calculate a lateral acceleration setpoint for the vehicle that is then close loop controlled.
-The close loop lateral acceleration was tuned in the configuration of the [Acro mode](#acro-mode), and the pure pursuit was tuned when setting up the [Position mode](#position-mode).
+The [pure pursuit](#pure-pursuit-guidance-logic) algorithm is used to calculate a yaw rate setpoint for the vehicle that is then close loop controlled.
+The close loop yaw rate was tuned in the configuration of the [Acro mode](#acro-mode), and the pure pursuit was tuned when setting up the [Position mode](#position-mode).
 During any auto navigation task observe the behaviour of the rover.
 
 If you are unsatisfied with the path following, there are 2 steps to take:
 
-1. Plot the `lateral_acceleration_setpoint` from [RoverAckermannSetpoint](../msg_docs/RoverAckermannSetpoint.md) and the `measured_lateral_acceleration` from the [RoverAckermannStatus](../msg_docs/RoverAckermannStatus.md) over each other.
-   If the tracking of these setpoints is not satisfactory adjust the values for [RA_LAT_ACCEL_P](#RA_LAT_ACCEL_P) and [RA_LAT_ACCEL_I](#RA_LAT_ACCEL_I).
-2. Step 1 ensures accurate setpoint tracking, if the path following is still unsatisfactory you need to further tune the [pure pursuit](#pure-pursuit-guidance-logic) parameters.
+1. Plot the `adjusted_yaw_rate_setpoint` and the `measured_yaw_rate` from the [RoverRateStatus](../msg_docs/RoverRateStatus.md) over each other.
+   If the tracking of these setpoints is not satisfactory adjust the values for [RO_YAW_RATE_P](#RO_YAW_RATE_P) and [RO_YAW_RATE_I](#RO_YAW_RATE_I).
+2. Plot the `adjusted_yaw_setpoint` and the `measured_yaw` from the [RoverAttitudeStatus](../msg_docs/RoverAttitudeStatus.md) over each other.
+   If the tracking of these setpoints is not satisfactory adjust the value for [RO_YAW_P](#RO_YAW_RATE_P) and potentially further tune [RO_YAW_RATE_I](#RO_YAW_RATE_I).
+3. Steps 1 and 2 ensures accurate setpoint tracking, if the path following is still unsatisfactory you need to further tune the [pure pursuit](#pure-pursuit-guidance-logic) parameters.
 
 ## Pure Pursuit Guidance Logic
 
@@ -353,18 +381,18 @@ To smoothen the trajectory further and reduce the risk of the rover rolling over
 1. During cornering the rover drives at the following speed:
 
    <!-- prettier-ignore -->
-   $$ v_{cor, max} = \sqrt{r \cdot a_{lat, max}} $$
+   $$ v_{cor, max} = \dot{\psi}_{max} \cdot r $$
 
-   with $r:$ Turning radius for the upcoming corner and $a_{lat, max}:$ Maximum lateral acceleration ([RA_MAX_LAT_ACCEL](#RA_MAX_LAT_ACCEL)).
+   with $r:$ Turning radius for the upcoming corner and $\dot{\psi}_{max}:$ Maximum yaw rate ([RO_YAW_RATE_LIM](#RO_YAW_RATE_LIM)).
 
 2. In between waypoints (straight line) the rover speed is regulated such that it will arrive at the acceptance radius of the waypoint with the desired cornering speed.
 
-The rover is constrained between the maximum speed [RA_MAX_SPEED](#RA_MAX_SPEED) and the speed where the maximum steering angle does not cause the rover to exceed the lateral acceleration limit:
+The rover is constrained between the maximum speed [RO_SPEED_LIM](#RO_SPEED_LIM) and the speed where the maximum steering angle does not cause the rover to exceed the yaw rate limit:
 
 <!-- prettier-ignore -->
-$$ v_{min} = \sqrt{\frac{w_b \cdot a_{lat, max}}{tan(\theta_{max})}} $$
+$$ v_{min} = \frac{w_b \cdot \dot{\psi}_{max}}{tan(\delta_{max})} $$
 
-with $w_b:$ Wheel base ([RA_WHEEL_BASE](#RA_WHEEL_BASE)), $a_{lat, max}:$ Maximum lateral acceleration ([RA_MAX_LAT_ACCEL](#RA_MAX_LAT_ACCEL)) and $\theta_{max}:$ Maximum steering angle ([RA_MAX_STR_ANG](#RA_MAX_STR_ANG)).
+with $w_b:$ Wheel base ([RA_WHEEL_BASE](#RA_WHEEL_BASE)), $\dot{\psi}_{max}:$ Maximum yaw rate ([RO_YAW_RATE_LIM](#RO_YAW_RATE_LIM)) and $\delta_{max}:$ Maximum steering angle ([RA_MAX_STR_ANG](#RA_MAX_STR_ANG)).
 
 ## Parameter Overview
 
@@ -374,23 +402,24 @@ List of all parameters of the ackermann rover module:
 | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------- |
 | <a id="RA_WHEEL_BASE"></a>[RA_WHEEL_BASE](../advanced_config/parameter_reference.md#RA_WHEEL_BASE)          | Wheel base                                                            | m       |
 | <a id="RA_MAX_STR_ANG"></a>[RA_MAX_STR_ANG](../advanced_config/parameter_reference.md#RA_MAX_STR_ANG)       | Maximum steering angle                                                | deg     |
-| <a id="RA_MAX_THR_SPEED"></a>[RA_MAX_THR_SPEED](../advanced_config/parameter_reference.md#RA_MAX_THR_SPEED) | Speed the rover drives at maximum throttle                            | m/s     |
-| <a id="RA_MAX_ACCEL"></a>[RA_MAX_ACCEL](../advanced_config/parameter_reference.md#RA_MAX_ACCEL)             | Maximum allowed acceleration                                          | m/s^2   |
-| <a id="RA_MAX_DECEL"></a>[RA_MAX_DECEL](../advanced_config/parameter_reference.md#RA_MAX_DECEL)             | Maximum allowed deceleration                                          | m/s^2   |
-| <a id="RA_MAX_JERK"></a>[RA_MAX_JERK](../advanced_config/parameter_reference.md#RA_MAX_JERK)                | Maximum allowed jerk for the rover                                    | $m/s^3$ |
-| <a id="RA_MAX_STR_RATE"></a>[RA_MAX_STR_RATE](../advanced_config/parameter_reference.md#RA_MAX_STR_RATE)    | Maximum allowed steering rate                                         | deg/s   |
-| <a id="RA_MAX_LAT_ACCEL"></a>[RA_MAX_LAT_ACCEL](../advanced_config/parameter_reference.md#RA_MAX_LAT_ACCEL) | Maximum allowed lateral acceleration                                  | m/s^2   |
-| <a id="RA_LAT_ACCEL_P"></a>[RA_LAT_ACCEL_P](../advanced_config/parameter_reference.md#RA_LAT_ACCEL_P)       | Proportional gain for lateral acceleration controller                 | -       |
-| <a id="RA_LAT_ACCEL_I"></a>[RA_LAT_ACCEL_I](../advanced_config/parameter_reference.md#RA_LAT_ACCEL_I)       | Integral gain for lateral acceleration controller                     | -       |
-| <a id="RA_MAX_SPEED"></a>[RA_MAX_SPEED](../advanced_config/parameter_reference.md#RA_MAX_SPEED)             | Maximum allowed speed                                                 | m/s     |
-| <a id="RA_SPEED_P"></a>[RA_SPEED_P](../advanced_config/parameter_reference.md#RA_SPEED_P)                   | Proportional gain for speed controller                                | -       |
-| <a id="RA_SPEED_I"></a>[RA_SPEED_I](../advanced_config/parameter_reference.md#RA_SPEED_I)                   | Integral gain for speed controller                                    | -       |
+| <a id="RO_MAX_THR_SPEED"></a>[RO_MAX_THR_SPEED](../advanced_config/parameter_reference.md#RO_MAX_THR_SPEED) | Speed the rover drives at maximum throttle                            | m/s     |
+| <a id="RO_YAW_RATE_LIM"></a>[RO_YAW_RATE_LIM](../advanced_config/parameter_reference.md#RO_YAW_RATE_LIM)    | Maximum allowed yaw rate                                              | m/s^2   |
+| <a id="RO_YAW_RATE_P"></a>[RO_YAW_RATE_P](../advanced_config/parameter_reference.md#RO_YAW_RATE_P)          | Proportional gain for yaw rate controller                             | -       |
+| <a id="RO_YAW_RATE_I"></a>[RO_YAW_RATE_I](../advanced_config/parameter_reference.md#RO_YAW_RATE_I)          | Integral gain for yaw rate controller                                 | -       |
+| <a id="RO_YAW_P"></a>[RO_YAW_P](../advanced_config/parameter_reference.md#RO_YAW_P)                         | Proportional gain for yaw controller                                  | -       |
+| <a id="RO_SPEED_LIM"></a>[RO_SPEED_LIM](../advanced_config/parameter_reference.md#RO_SPEED_LIM)             | Maximum allowed speed                                                 | m/s     |
+| <a id="RO_SPEED_P"></a>[RO_SPEED_P](../advanced_config/parameter_reference.md#RO_SPEED_P)                   | Proportional gain for speed controller                                | -       |
+| <a id="RO_SPEED_I"></a>[RO_SPEED_I](../advanced_config/parameter_reference.md#RO_SPEED_I)                   | Integral gain for speed controller                                    | -       |
 | <a id="PP_LOOKAHD_GAIN"></a>[PP_LOOKAHD_GAIN](../advanced_config/parameter_reference.md#PP_LOOKAHD_GAIN)    | Main tuning parameter for pure pursuit                                | -       |
 | <a id="PP_LOOKAHD_MAX"></a>[PP_LOOKAHD_MAX](../advanced_config/parameter_reference.md#PP_LOOKAHD_MAX)       | Maximum value for the look ahead radius of the pure pursuit algorithm | m       |
 | <a id="PP_LOOKAHD_MIN"></a>[PP_LOOKAHD_MIN](../advanced_config/parameter_reference.md#PP_LOOKAHD_MIN)       | Minimum value for the look ahead radius of the pure pursuit algorithm | m       |
 | <a id="NAV_ACC_RAD"></a>[NAV_ACC_RAD](../advanced_config/parameter_reference.md#NAV_ACC_RAD)                | Default acceptance radius                                             | m       |
-| <a id="RA_ACC_RAD_MAX"></a>[RA_ACC_RAD_MAX](../advanced_config/parameter_reference.md#RA_ACC_RAD_MAX)       | Maximum radius the acceptance radius can be scaled to                 | m       |
-| <a id="RA_ACC_RAD_GAIN"></a>[RA_ACC_RAD_GAIN](../advanced_config/parameter_reference.md#RA_ACC_RAD_GAIN)    | Tuning parameter                                                      | -       |
+| <a id="RA_STR_RATE_LIM"></a>[RA_STR_RATE_LIM](../advanced_config/parameter_reference.md#RA_STR_RATE_LIM)    | (Optional) Maximum allowed steering rate                              | deg/s   |
+| <a id="RO_ACCEL_LIM"></a>[RO_ACCEL_LIM](../advanced_config/parameter_reference.md#RO_ACCEL_LIM)             | (Optional) Maximum allowed acceleration                               | m/s^2   |
+| <a id="RO_DECEL_LIM"></a>[RO_DECEL_LIM](../advanced_config/parameter_reference.md#RO_DECEL_LIM)             | (Optional) Maximum allowed deceleration                               | m/s^2   |
+| <a id="RO_JERK_LIM"></a>[RO_JERK_LIM](../advanced_config/parameter_reference.md#RO_JERK_LIM)                | (Optional) Maximum allowed jerk                                       | $m/s^3$ |
+| <a id="RA_ACC_RAD_MAX"></a>[RA_ACC_RAD_MAX](../advanced_config/parameter_reference.md#RA_ACC_RAD_MAX)       | (Optional) Maximum radius the acceptance radius can be scaled to      | m       |
+| <a id="RA_ACC_RAD_GAIN"></a>[RA_ACC_RAD_GAIN](../advanced_config/parameter_reference.md#RA_ACC_RAD_GAIN)    | (Optional) Tuning parameter for the acceptance radius scaling         | -       |
 
 ## See Also
 

--- a/en/config_rover/differential.md
+++ b/en/config_rover/differential.md
@@ -29,62 +29,115 @@ To configure the differential rover frame and outputs:
 
 ## Manual Mode
 
-The basic setup (above) is all that is required to use the rover in [Manual mode](../flight_modes_rover/differential.md#manual-mode).
-
-::: info
-In manual mode the stick inputs are directly mapped to motor commands.
-Especially moving the stick that controls the yaw rate all the way to one side will cause the wheels on the left and right to spin at full speed in opposite directions.
-Depending on the rover this can lead to a very aggressive rotation.
-The parameters [RD_MAX_YAW_RATE](#RD_MAX_YAW_RATE) and [RD_MAX_THR_YAW_R](#RD_MAX_THR_YAW_R) can be used to scale the manual input for the yaw rate.
-:::
-
-## Acro Mode
-
 ::: warning
 For this mode to work properly the [Basic Setup](#basic-setup) must've already been completed!
 :::
 
-To set up [Acro mode](../flight_modes_rover/differential.md#acro-mode) navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
+The basic setup already covers the minimum setup required to use the rover in [Manual mode](../flight_modes_rover/differential.md#manual-mode).
+
+However, this mode is also affected by acceleration/deceleration limits. This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
+Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
 
 1. [RD_WHEEL_TRACK](#RD_WHEEL_TRACK) [m]: Measure the distance from the centre of the right wheel to the centre of the left wheel.
 
-   ![Wheel track](../../assets/airframes/rover/rover_differential/wheel_track.png)
+   ![Wheel track](../../assets/airframes/rover/rover_differential/wheel_track.png)2. [RA_MAX_STR_ANG](#RA_MAX_STR_ANG) [deg]: Measure the maximum steering angle.
 
-2. [RD_MAX_YAW_RATE](#RD_MAX_YAW_RATE) [deg/s]: This is the maximum yaw rate you want to allow for your rover.
+2. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: Drive the rover at full throttle and set this parameter to the observed value of the ground speed.
+
+   :::info
+   This parameter is also used for the feed-forward term of the speed control. It will be further tuned in the configuration of [Position mode](#position-mode).
+   :::
+
+3. (Optional) [RO_ACCEL_LIM](#RO_ACCEL_LIM) [m/s^2]: Maximum acceleration you want to allow for your rover.
+
+   <a id="RO_ACCEL_LIM_CONSIDERATIONS"></a>
+
+   :::tip
+   Your rover has a maximum possible acceleration which is determined by the maximum torque the motor can supply.
+   This may or may not be appropriate for your vehicle and use case.
+
+   One approach to determine an appropriate value is:
+
+   1. From a standstill, give the rover full throttle until it reaches the maximum speed.
+   2. Disarm the rover and plot the `measured_speed_body_x` from [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md).
+   3. Divide the maximum speed by the time it took to reach it and set this as the value for [RO_ACCEL_LIM](#RO_ACCEL_LIM).
+
+   Some RC rovers have enough torque to lift up if the maximum acceleration is not limited.
+   If that is the case:
+
+   4. Set [RO_ACCEL_LIM](#RO_ACCEL_LIM) to a low value, give the rover full throttle from a standstill and observe its behaviour.
+   5. Increase [RO_ACCEL_LIM](#RO_ACCEL_LIM) until the rover starts to lift up during the acceleration.
+   6. Set [RO_ACCEL_LIM](#RO_ACCEL_LIM) to the highest value that does not cause the rover to lift up.
+      :::
+
+4. (Optional) [RO_DECEL_LIM](#RO_DECEL_LIM) [m/s^2]: Maximum deceleration you want to allow for your rover.
+
+   :::tip
+   The same [considerations](#RO_ACCEL_LIM_CONSIDERATIONS) as in the configuration of [RO_ACCEL_LIM](#RO_ACCEL_LIM) apply.
+   :::
+
+   :::info
+   This parameter is also used for the calculation of the speed setpoint during [Auto modes](#auto-modes).
+   :::
+
+## Acro Mode
+
+::: warning
+For this mode to work properly [Manual mode](#manual-mode) must've already been configured!
+:::
+
+To set up [Acro mode](../flight_modes_rover/differential.md#acro-mode) navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
+
+1. [RO_YAW_RATE_LIM](#RO_YAW_RATE_LIM) [deg/s]: This is the maximum yaw rate you want to allow for your rover.
    This will define the stick-to-yaw-rate mapping for all manual modes using closed loop yaw control and set an upper limit for the yaw rate setpoint for all [auto modes](#auto-modes).
-3. [RD_MAX_THR_YAW_R](#RD_MAX_YAW_RATE) [m/s]: This parameter is used to calculate the feed-forward term of the closed loop yaw rate control.
+1. [RD_MAX_THR_YAW_R](#RD_MAX_THR_YAW_R) [m/s]: This parameter is used to calculate the feed-forward term of the closed loop yaw rate control.
    The controller calculates the required speed difference between the left and right motor to achieve the desired yaw rate.
    This desired speed difference is then linearly mapped to normalized motor commands.
    To get a good starting value for this parameter drive the rover in manual mode forwards at full throttle and note the ground speed of the vehicle.
-   Then enter _twice_ this value for the parameter.
+   Then enter _half_ this value for the parameter.
    <a id="RD_YAW_RATE_P_TUNING"></a>
 
    ::: tip
-   To further tune this parameter, first make sure you set [RD_YAW_RATE_P](#RD_YAW_RATE_P) and [RD_YAW_RATE_I](#RD_YAW_RATE_I) to zero.
+   To further tune this parameter, first make sure you set [RO_YAW_RATE_P](#RO_YAW_RATE_P) and [RO_YAW_RATE_I](#RO_YAW_RATE_I) to zero.
    This way the yaw rate is only controlled by the feed-forward term, which makes it easier to tune.
    Now put the rover in [Acro mode](../flight_modes_rover/differential.md#acro-mode) and then move the right-stick of your controller to the right and/or left and hold it at a few different levels for a couple of seconds each.
-   Disarm the rover and from the flight log plot the _yaw_rate_setpoint_ and _actual_yaw_rate_ from the [RoverDifferentialStatus](../msg_docs/RoverDifferentialStatus.md) over each other.
-   If the actual yaw rate of the rover is higher than the yaw rate setpoint, increase [RD_MAX_THR_YAW_R](#RD_MAX_YAW_RATE).
+   Disarm the rover and from the flight log plot the `adjusted_yaw_rate_setpoint` from [RoverRateStatus](../msg_docs/RoverRateStatus.md) and the `measured_yaw_rate` from [RoverRateStatus](../msg_docs/RoverRateStatus.md) over each other.
+   If the actual yaw rate of the rover is higher than the yaw rate setpoint, increase [RD_MAX_THR_YAW_R](#RD_MAX_THR_YAW_R).
    If it is the other way around decrease the parameter and repeat until you are satisfied with the setpoint tracking.
    :::
 
-4. [RD_YAW_RATE_P](#RD_YAW_RATE_P) [-]: Proportional gain of the closed loop yaw rate controller.
+1. [RO_YAW_RATE_P](#RO_YAW_RATE_P) [-]: Proportional gain of the closed loop yaw rate controller.
    Unlike the feed-forward part of the controller, the closed loop yaw rate control will compare the yaw rate setpoint with the measured yaw rate and adapt to motor commands based on the error between them.
    The proportional gain is multiplied with this error and that value is added to the motor command.
    This way disturbances like uneven grounds or external forces can be compensated.
 
    ::: tip
    This parameter can be tuned the same way as [RD_MAX_THR_YAW_R](#RD_YAW_RATE_P_TUNING).
-   If you tuned [RD_MAX_THR_YAW_R](#RD_MAX_YAW_RATE) well, you might only need a very small value.
+   If you tuned [RD_MAX_THR_YAW_R](#RD_MAX_THR_YAW_R) well, you might only need a very small value.
    :::
 
-5. (Optional) [RD_YAW_RATE_I](#RD_YAW_RATE_I) [-]: Integral gain of the closed loop yaw controller.
+1. [RO_YAW_RATE_I](#RO_YAW_RATE_I) [-]: Integral gain of the closed loop yaw controller.
    The integral gain accumulates the error between the desired and actual yaw rate scaled by the integral gain over time and that value is added to the motor command.
 
    ::: tip
-   The integrator gain is usually not necessary for the yaw rate setpoint as this is usually a fast changing value.
-   Leave this parameter at zero unless necessary, as it can have negative side effects such as overshooting or oscillating around the setpoint.
+   An integrator might not be neccessary at this stage, but it will become important for subsequent modes.
    :::
+
+1. (Optional) [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM) and [RO_YAW_DECEL_LIM](#RO_YAW_DECEL_LIM) [deg/s^2]: This is the maximum yaw acceleration and deceleration you want to allow for your rover.
+   This can be used to smooth the `yaw_rate` setpoints and make their trajectory feasible based on the physical limitation on the rover to improve tracking and avoid integrator build up.
+
+   ::: tip
+   Your rover has a maximum possible yaw acceleration/deceleration which is determined by the maximum torque the motor can supply.
+   This may or may not be appropriate for your vehicle and use case.
+
+   One approach to determine an appropriate value is:
+
+   1. Put the rover into [Manual mode](../flight_modes_rover/differential.md#manual-mode).
+   2. From a standstill, move the right stick all the way to the right or left until the rover reaches the maximum yaw rate then return the right stick to the middle.
+   3. Disarm the rover and plot the `measured_yaw_rate` from [RoverRateStatus](../msg_docs/RoverRateStatus.md).
+   4. Divide the maximum yaw rate by the time it took to reach it and set this as the value for [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM).
+   5. Divide the maximum yaw rate by the time it took to return to a standstill and set this as the value for [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM).
+      :::
 
 The rover is now ready to drive in [Acro mode](../flight_modes_rover/differential.md#acro-mode).
 
@@ -101,63 +154,62 @@ For [Stabilized mode](../flight_modes_rover/differential.md#stabilized-mode) the
 Unlike the closed loop yaw rate, this controller has no feed-forward term.
 Therefore you only need to tune the closed loop gains:
 
-1. [RD_YAW_P](#RD_YAW_P) [-]: Proportional gain for the closed loop yaw controller.
+1. [RO_YAW_P](#RO_YAW_P) [-]: Proportional gain for the closed loop yaw controller.
 
    ::: tip
    In stabilized mode the closed loop yaw control is only active when driving a straight line (no yaw rate input).
-   To tune it set [RD_YAW_I](#RD_YAW_I) to zero and start with a value of 1 for [RD_YAW_P](#RD_YAW_P).
-   Put the rover into stabilized mode and move the left stick of your controller up and/or down to drive forwards/backwards.
-   Disarm the rover and from the flight log plot the _yaw_setpoint_ from the [RoverDifferentialSetpoint](../msg_docs/RoverDifferentialSetpoint.md) message and the _actual_yaw_ from the [RoverDifferentialStatus](../msg_docs/RoverDifferentialStatus.md) message over each other.
+   Start with a value of 1 for [RO_YAW_P](#RO_YAW_P). Put the rover into stabilized mode and move the left stick of your controller up and/or down to drive forwards/backwards.
+   Disarm the rover and from the flight log plot the `measured_yaw` and the `adjusted_yaw_setpoint` from the [RoverAttitudeStatus](../msg_docs/RoverAttitudeStatus.md) message over each other.
    Increase/Decrease the parameter until you are satisfied with the setpoint tracking.
    :::
 
-2. [RD_YAW_I](#RD_YAW_I) [-]: Integral gain for the closed loop yaw controller.
-
-   ::: tip
-   For the closed loop yaw control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
-   In [Auto Modes](#auto-modes) there will be a further elaboration on why an integrator is necessary for the yaw controller.
-   :::
+::: tip
+For the closed loop yaw control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
+Since the yaw and yaw rate controllers are cascaded, there only needs to be one integrator which is in the yaw rate controller. If you observe a steady state error in the yaw setpoint increase the [RO_YAW_RATE_I](#RO_YAW_RATE_I) parameter.
+:::
 
 The rover is now ready to drive in [Stabilized mode](../flight_modes_rover/differential.md#stabilized-mode).
 
 ## Position Mode
 
 :::warning
-For this mode to work properly [Acro mode](#acro-mode) and [Stabilized mode](#stabilized-mode) must already be configured!
+For this mode to work properly [Stabilized mode](#stabilized-mode) must already be configured!
 :::
 
 [Position mode](../flight_modes_rover/differential.md#position-mode) is the most advanced manual mode, utilizing closed loop yaw rate, yaw and speed control and leveraging position estimates.
 
 To configure set the following parameters:
 
-1. [RD_MAX_SPEED](#RD_MAX_SPEED) [m/s]: This is the maximum speed you want to allow for your rover.
+1. [RO_SPEED_LIM](#RO_SPEED_LIM) [m/s]: This is the maximum speed you want to allow for your rover.
    This will define the stick-to-speed mapping for position mode and set an upper limit for the speed setpoint for all [auto modes](#auto-modes).
-2. [RD_MAX_THR_SPD](#RD_MAX_THR_SPD) [m/s]: This parameter is used to calculate the feed-forward term of the closed loop speed control which linearly maps desired speeds to normalized motor commands.
+2. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: This parameter is used to calculate the feed-forward term of the closed loop speed control which linearly maps desired speeds to normalized motor commands.
    A good starting point is the observed ground speed when the rover drives at maximum throttle in [Manual mode](../flight_modes_rover/differential.md#manual-mode).
 
    <a id="RD_SPEED_P_TUNING"></a>
 
    ::: tip
-   To further tune this parameter, first make sure you set [RD_SPEED_P](#RD_SPEED_P) and [RD_SPEED_I](#RD_SPEED_I) to zero.
-   This way the speed is only controlled by the feed-forward term, which makes it easier to tune.
-   Now put the rover in [Position mode](../flight_modes_rover/differential.md#position-mode) and then move the left stick of your controller up and/or down and hold it at a few different levels for a couple of seconds each.
-   Disarm the rover and from the flight log plot the _forward_speed_setpoint_ from the [RoverDifferentialSetpoint](../msg_docs/RoverDifferentialSetpoint.md) message and the _actual_speed_ from the [RoverDifferentialStatus](../msg_docs/RoverDifferentialStatus.md) message over each other.
-   If the actual speed of the rover is higher than the speed setpoint, increase [RD_MAX_THR_SPD](#RD_MAX_THR_SPD).
-   If it is the other way around decrease the parameter and repeat until you are satisfied with the setpoint tracking.
-   :::
+   To further tune this parameter:
+
+   1. Set [RO_SPEED_P](#RO_SPEED_P) and [RO_SPEED_I](#RO_SPEED_I) to zero.
+      This way the speed is only controlled by the feed-forward term, which makes it easier to tune.
+   2. Put the rover in [Position mode](../flight_modes_rover/differential.md#position-mode) and then move the left stick of your controller up and/or down and hold it at a few different levels for a couple of seconds each.
+   3. Disarm the rover and from the flight log plot the `adjusted_speed_body_x_setpoint` and the `measured_speed_body_x` from the [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md) message over each other.
+   4. If the actual speed of the rover is higher than the speed setpoint, increase [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED).
+      If it is the other way around decrease the parameter and repeat until you are satisfied with the setpoint tracking.
+      :::
 
    ::: info
    If your rover oscillates when driving a straight line in [Position mode](../flight_modes_rover/differential.md#position-mode) just set this parameter to the observed ground speed at maximum throttle in [Manual mode](../flight_modes_rover/differential.md#manual-mode) and complete steps 5-7 first before continuing the tuning of the closed loop speed control (Steps 2-4).
    :::
 
-3. [RD_SPEED_P](#RD_SPEED_P) [-]: Proportional gain of the closed loop speed controller.
+3. [RO_SPEED_P](#RO_SPEED_P) [-]: Proportional gain of the closed loop speed controller.
 
    ::: tip
-   This parameter can be tuned the same way as [RD_MAX_THR_SPD](#RD_SPEED_P_TUNING).
-   If you tuned [RD_MAX_THR_SPD](#RD_MAX_THR_SPD) well, you might only need a very small value.
+   This parameter can be tuned the same way as [RO_MAX_THR_SPEED](#RD_SPEED_P_TUNING).
+   If you tuned [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) well, you might only need a very small value.
    :::
 
-4. [RD_SPEED_I](#RD_SPEED_I) [-]: Integral gain for the closed loop speed controller.
+4. [RO_SPEED_I](#RO_SPEED_I) [-]: Integral gain for the closed loop speed controller.
 
    ::: tip
    For the closed loop speed control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
@@ -168,10 +220,14 @@ To configure set the following parameters:
 
    ::: tip
    Decreasing the parameter makes it more aggressive but can lead to oscillations.
-   Start with a value of 1 for [PP_LOOKAHD_GAIN](#PP_LOOKAHD_GAIN), put the rover in [Position mode](../flight_modes_rover/differential.md#position-mode) and while driving a straight line at approximately half the maximum speed observe its behaviour.
-   If the rover does not drive in a straight line, reduce the value of the parameter, if it oscillates around the path increase the value.
-   Repeat until you are satisfied with the behaviour.
-   :::
+
+   To tune this:
+
+   1. Start with a value of 1 for [PP_LOOKAHD_GAIN](#PP_LOOKAHD_GAIN)
+   2. Put the rover in [Position mode](../flight_modes_rover/differential.md#position-mode) and while driving a straight line at approximately half the maximum speed observe its behaviour.
+   3. If the rover does not drive in a straight line, reduce the value of the parameter, if it oscillates around the path increase the value.
+   4. Repeat until you are satisfied with the behaviour.
+      :::
 
 6. [PP_LOOKAHD_MIN](#PP_LOOKAHD_MIN): Minimum threshold for the lookahead distance used by the [pure pursuit algorithm](#pure-pursuit-guidance-logic).
 
@@ -190,7 +246,7 @@ The rover is now ready to drive in [Position mode](../flight_modes_rover/differe
 ## Auto Modes
 
 ::: warning
-For this mode to work properly [Acro mode](#acro-mode), [Stabilized mode](#stabilized-mode) and [Position mode](#position-mode) must already be configured!
+For this mode to work properly [Position mode](#position-mode) must already be configured!
 :::
 
 <a id="pure_pursuit_controller"></a>
@@ -204,18 +260,17 @@ The required parameters are separated into the following sections:
 
 These parameters are used to calculate the speed setpoint in auto modes:
 
-1. [RD_MAX_SPEED](#RD_MAX_SPEED): Sets the default velocity ($m/s$) for the rover during the mission (as well as the maximum speed)..
-2. [RD_MAX_DECEL](#RD_MAX_DECEL) ($m/s^2$) and [RD_MAX_JERK](#RD_MAX_JERK) ($m/s^3$) are used to calculate a velocity trajectory such that the rover comes to a smooth stop as it reaches a waypoint.
+1. [RO_DECEL_LIM](#RO_DECEL_LIM) ($m/s^2$) and [RO_JERK_LIM](#RO_JERK_LIM) ($m/s^3$) are used to calculate a velocity trajectory such that the rover comes to a smooth stop as it reaches a waypoint.
 
    ::: tip
    Plan a mission for the rover to drive a square and observe how it slows down when approaching a waypoint.
-   If the rover decelerates too quickly decrease the [RD_MAX_DECEL](#RD_MAX_DECEL) parameter, if it starts slowing down too early increase the parameter.
-   If you observe a jerking motion as the rover slows down, decrease the [RD_MAX_JERK](#RD_MAX_JERK) parameter otherwise increase it as much as possible as it can interfere with the tuning of [RD_MAX_DECEL](#RD_MAX_DECEL).
+   If the rover decelerates too quickly decrease the [RO_DECEL_LIM](#RO_DECEL_LIM) parameter, if it starts slowing down too early increase the parameter.
+   If you observe a jerking motion as the rover slows down, decrease the [RO_JERK_LIM](#RO_JERK_LIM) parameter otherwise increase it as much as possible as it can interfere with the tuning of [RO_DECEL_LIM](#RO_DECEL_LIM).
    These two parameters have to be tuned as a pair, repeat until you are satisfied with the behaviour.
    :::
 
-3. Plot the _forward_speed_setpoint_ from the [RoverDifferentialSetpoint](../msg_docs/RoverDifferentialSetpoint.md) message and the _actual_speed_ from the [RoverDifferentialStatus](../msg_docs/RoverDifferentialStatus.md) message over each other.
-   If the tracking of these setpoints is not satisfactory adjust the values for [RD_SPEED_P](#RD_SPEED_P) and [RD_SPEED_I](#RD_SPEED_I).
+2. Plot the `adjusted_speed_body_x_setpoint` and `measured_speed_body_x` from the [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md) message over each other.
+   If the tracking of these setpoints is not satisfactory adjust the values for [RO_SPEED_P](#RO_SPEED_P) and [RO_SPEED_I](#RO_SPEED_I).
 
 The rover only slows down when approaching the waypoint if the angle between the line segment between the previous/current waypoint and current/next waypoint is smaller than 180° - [RD_TRANS_DRV_TRN](#RD_TRANS_DRV_TRN).
 In other words: The rover slows down only if the expected heading error towards the next waypoint when arriving at the current waypoint is below [RD_TRANS_DRV_TRN](#RD_TRANS_DRV_TRN).
@@ -239,11 +294,11 @@ The close loop yaw rate was tuned in the configuration of the [Stabilized mode](
 During any auto navigation task observe the behaviour of the rover.
 If you are unsatisfied with the path following, there are 3 steps to take:
 
-1. Plot the _yaw_rate_setpoint_ and _actual_yaw_rate_ from the [RoverDifferentialSetpoint](../msg_docs/RoverDifferentialStatus.md) over each other.
-   If the tracking of these setpoints is not satisfactory adjust the values for [RD_YAW_RATE_P](#RD_YAW_RATE_P) and [RD_YAW_RATE_I](#RD_YAW_RATE_I).
-2. Plot the _yaw_setpoint_ from the [RoverDifferentialSetpoint](../msg_docs/RoverDifferentialSetpoint.md) message and the _actual_yaw_ from the [RoverDifferentialStatus](../msg_docs/RoverDifferentialStatus.md) message over each other.
-   If the tracking of these setpoints is not satisfactory adjust the values for [RD_YAW_P](#RD_YAW_P) and [RD_YAW_I](#RD_YAW_P).
-3. Steps 1 and 2 ensure accurate setpoint tracking, if the path following is still unsatisfactory you need to further tune the [pure pursuit](#pure-pursuit-guidance-logic) parameters.
+1. Plot the `adjusted_yaw_rate_setpoint` and the `measured_yaw_rate` from the [RoverRateStatus](../msg_docs/RoverRateStatus.md) over each other.
+   If the tracking of these setpoints is not satisfactory adjust the values for [RO_YAW_RATE_P](#RO_YAW_RATE_P) and [RO_YAW_RATE_I](#RO_YAW_RATE_I).
+2. Plot the `adjusted_yaw_setpoint` and the `measured_yaw` from the [RoverAttitudeStatus](../msg_docs/RoverAttitudeStatus.md) over each other.
+   If the tracking of these setpoints is not satisfactory adjust the value for [RO_YAW_P](#RO_YAW_RATE_P) and potentially further tune [RO_YAW_RATE_I](#RO_YAW_RATE_I).
+3. Steps 1 and 2 ensures accurate setpoint tracking, if the path following is still unsatisfactory you need to further tune the [pure pursuit](#pure-pursuit-guidance-logic) parameters.
 
 ## Pure Pursuit Guidance Logic
 
@@ -282,24 +337,25 @@ List of all parameters of the differential rover module:
 | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------- |
 | <a id="RD_WHEEL_TRACK"></a>[RD_WHEEL_TRACK](../advanced_config/parameter_reference.md#RD_WHEEL_TRACK)       | Wheel track                                                            | m       |
 | <a id="RD_MAX_THR_YAW_R"></a>[RD_MAX_THR_YAW_R](../advanced_config/parameter_reference.md#RD_MAX_THR_YAW_R) | Yaw rate turning left/right wheels at max speed in opposite directions | m/s     |
-| <a id="RD_MAX_YAW_RATE"></a>[RD_MAX_YAW_RATE](../advanced_config/parameter_reference.md#RD_MAX_YAW_RATE)    | Maximum allowed yaw rate for the rover                                 | deg/s   |
-| <a id="RD_YAW_RATE_P"></a>[RD_YAW_RATE_P](../advanced_config/parameter_reference.md#RD_YAW_RATE_P)          | Proportional gain for yaw rate controller                              | -       |
-| <a id="RD_YAW_RATE_I"></a>[RD_YAW_RATE_I](../advanced_config/parameter_reference.md#RD_YAW_RATE_I)          | Integral gain for yaw rate controller                                  | -       |
-| <a id="RD_YAW_P"></a>[RD_YAW_P](../advanced_config/parameter_reference.md#RD_YAW_P)                         | Proportional gain for yaw controller                                   | -       |
-| <a id="RD_YAW_I"></a>[RD_YAW_I](../advanced_config/parameter_reference.md#RD_YAW_I)                         | Integral gain for yaw controller                                       | -       |
-| <a id="RD_MAX_SPEED"></a>[RD_MAX_SPEED](../advanced_config/parameter_reference.md#RD_MAX_SPEED)             | Maximum allowed speed for the rover                                    | m/s     |
-| <a id="RD_MAX_THR_SPD"></a>[RD_MAX_THR_SPD](../advanced_config/parameter_reference.md#RD_MAX_THR_SPD)       | Speed the rover drives at maximum throttle                             | m/s     |
-| <a id="RD_SPEED_P"></a>[RD_SPEED_P](../advanced_config/parameter_reference.md#RD_SPEED_P)                   | Proportional gain for speed controller                                 | -       |
-| <a id="RD_SPEED_I"></a>[RD_SPEED_I](../advanced_config/parameter_reference.md#RD_SPEED_I)                   | Integral gain for speed controller                                     | -       |
+| <a id="RD_TRANS_DRV_TRN"></a>[RD_TRANS_DRV_TRN](../advanced_config/parameter_reference.md#RD_TRANS_DRV_TRN) | Heading error threshold to switch from driving to spot turning         | deg     |
+| <a id="RD_TRANS_TRN_DRV"></a>[RD_TRANS_TRN_DRV](../advanced_config/parameter_reference.md#RD_TRANS_TRN_DRV) | Heading error threshold to switch from spot turning to driving         | deg     |
+| <a id="RD_MISS_SPD_GAIN"></a>[RD_MISS_SPD_GAIN](../advanced_config/parameter_reference.md#RD_MISS_SPD_GAIN) | Tuning parameter for the speed reduction during waypoint transition    | m/s     |
+| <a id="RO_YAW_RATE_LIM"></a>[RO_YAW_RATE_LIM](../advanced_config/parameter_reference.md#RO_YAW_RATE_LIM)    | Maximum allowed yaw rate for the rover                                 | deg/s   |
+| <a id="RO_YAW_RATE_P"></a>[RO_YAW_RATE_P](../advanced_config/parameter_reference.md#RO_YAW_RATE_P)          | Proportional gain for yaw rate controller                              | -       |
+| <a id="RO_YAW_RATE_I"></a>[RO_YAW_RATE_I](../advanced_config/parameter_reference.md#RO_YAW_RATE_I)          | Integral gain for yaw rate controller                                  | -       |
+| <a id="RO_YAW_P"></a>[RO_YAW_P](../advanced_config/parameter_reference.md#RO_YAW_P)                         | Proportional gain for yaw controller                                   | -       |
+| <a id="RO_MAX_THR_SPEED"></a>[RO_MAX_THR_SPEED](../advanced_config/parameter_reference.md#RO_MAX_THR_SPEED) | Speed the rover drives at maximum throttle                             | m/s     |
+| <a id="RO_SPEED_P"></a>[RO_SPEED_P](../advanced_config/parameter_reference.md#RO_SPEED_P)                   | Proportional gain for speed controller                                 | -       |
+| <a id="RO_SPEED_I"></a>[RO_SPEED_I](../advanced_config/parameter_reference.md#RO_SPEED_I)                   | Integral gain for speed controller                                     | -       |
+| <a id="RO_SPEED_LIM"></a>[RO_SPEED_LIM](../advanced_config/parameter_reference.md#RO_SPEED_LIM)             | Maximum allowed speed for the rover (and default mission speed).       | m/s     |
 | <a id="PP_LOOKAHD_GAIN"></a>[PP_LOOKAHD_GAIN](../advanced_config/parameter_reference.md#PP_LOOKAHD_GAIN)    | Main tuning parameter for pure pursuit                                 | -       |
 | <a id="PP_LOOKAHD_MAX"></a>[PP_LOOKAHD_MAX](../advanced_config/parameter_reference.md#PP_LOOKAHD_MAX)       | Maximum value for the look ahead radius of the pure pursuit algorithm  | m       |
 | <a id="PP_LOOKAHD_MIN"></a>[PP_LOOKAHD_MIN](../advanced_config/parameter_reference.md#PP_LOOKAHD_MIN)       | Minimum value for the look ahead radius of the pure pursuit algorithm  | m       |
-| <a id="RD_MAX_SPEED"></a>[RD_MAX_SPEED](../advanced_config/parameter_reference.md#RD_MAX_SPEED)             | Maximum allowed speed for the rover (and default mission speed).       | m/s     |
-| <a id="RD_MAX_ACCEL"></a>[RD_MAX_ACCEL](../advanced_config/parameter_reference.md#RD_MAX_ACCEL)             | Maximum acceleration for the rover                                     | $m/s^2$ |
-| <a id="RD_MAX_DECEL"></a>[RD_MAX_DECEL](../advanced_config/parameter_reference.md#RD_MAX_DECEL)             | Maximum deceleration for the rover                                     | $m/s^2$ |
-| <a id="RD_MAX_JERK"></a>[RD_MAX_JERK](../advanced_config/parameter_reference.md#RD_MAX_JERK)                | Maximum jerk for the rover                                             | $m/s^3$ |
-| <a id="RD_TRANS_DRV_TRN"></a>[RD_TRANS_DRV_TRN](../advanced_config/parameter_reference.md#RD_TRANS_DRV_TRN) | Heading error threshold to switch from driving to spot turning         | deg     |
-| <a id="RD_TRANS_TRN_DRV"></a>[RD_TRANS_TRN_DRV](../advanced_config/parameter_reference.md#RD_TRANS_TRN_DRV) | Heading error threshold to switch from spot turning to driving         | deg     |
+| <a id="RO_ACCEL_LIM"></a>[RO_ACCEL_LIM](../advanced_config/parameter_reference.md#RO_ACCEL_LIM)             | (Optional) Maximum allowed acceleration                                | m/s^2   |
+| <a id="RO_DECEL_LIM"></a>[RO_DECEL_LIM](../advanced_config/parameter_reference.md#RO_DECEL_LIM)             | (Optional) Maximum allowed deceleration                                | m/s^2   |
+| <a id="RO_JERK_LIM"></a>[RO_JERK_LIM](../advanced_config/parameter_reference.md#RO_JERK_LIM)                | (Optional) Maximum allowed jerk                                        | $m/s^3$ |
+| <a id="RO_YAW_ACCEL_LIM"></a>[RO_YAW_ACCEL_LIM](../advanced_config/parameter_reference.md#RO_YAW_ACCEL_LIM) | (Optional) Maximum allowed yaw acceleration                            | m/s^2   |
+| <a id="RO_YAW_DECEL_LIM"></a>[RO_YAW_DECEL_LIM](../advanced_config/parameter_reference.md#RO_YAW_DECEL_LIM) | (Optional) Maximum allowed yaw deceleration                            | m/s^2   |
 
 ## See Also
 

--- a/en/config_rover/differential.md
+++ b/en/config_rover/differential.md
@@ -40,7 +40,7 @@ Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and
 
 1. [RD_WHEEL_TRACK](#RD_WHEEL_TRACK) [m]: Measure the distance from the centre of the right wheel to the centre of the left wheel.
 
-   ![Wheel track](../../assets/airframes/rover/rover_differential/wheel_track.png)2. [RA_MAX_STR_ANG](#RA_MAX_STR_ANG) [deg]: Measure the maximum steering angle.
+   ![Wheel track](../../assets/airframes/rover/rover_differential/wheel_track.png)
 
 2. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: Drive the rover at full throttle and set this parameter to the observed value of the ground speed.
 

--- a/en/config_rover/differential.md
+++ b/en/config_rover/differential.md
@@ -35,8 +35,9 @@ For this mode to work properly the [Basic Setup](#basic-setup) must've already b
 
 The basic setup already covers the minimum setup required to use the rover in [Manual mode](../flight_modes_rover/differential.md#manual-mode).
 
-However, this mode is also affected by acceleration/deceleration limits.
-This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
+This mode is also affected by (optional) acceleration/deceleration limits.
+As configuration of these limits becomes mandatory for subsequent modes, we do this setup here.
+
 Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
 
 1. [RD_WHEEL_TRACK](#RD_WHEEL_TRACK) [m]: Measure the distance from the centre of the right wheel to the centre of the left wheel.
@@ -89,7 +90,7 @@ Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and
 For this mode to work properly [Manual mode](#manual-mode) must've already been configured!
 :::
 
-To set up [Acro mode](../flight_modes_rover/differential.md#acro-mode) navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
+To set up [Acro mode](../flight_modes_rover/differential.md#acro-mode), navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
 
 1. [RO_YAW_RATE_LIM](#RO_YAW_RATE_LIM) [deg/s]: This is the maximum yaw rate you want to allow for your rover.
    This will define the stick-to-yaw-rate mapping for all manual modes using closed loop yaw control and set an upper limit for the yaw rate setpoint for all [auto modes](#auto-modes).
@@ -112,7 +113,7 @@ To set up [Acro mode](../flight_modes_rover/differential.md#acro-mode) navigate 
 1. [RO_YAW_RATE_P](#RO_YAW_RATE_P) [-]: Proportional gain of the closed loop yaw rate controller.
    Unlike the feed-forward part of the controller, the closed loop yaw rate control will compare the yaw rate setpoint with the measured yaw rate and adapt to motor commands based on the error between them.
    The proportional gain is multiplied with this error and that value is added to the motor command.
-   This way disturbances like uneven grounds or external forces can be compensated.
+   This compensates for disturbances such as uneven ground and external forces.
 
    ::: tip
    This parameter can be tuned the same way as [RD_MAX_THR_YAW_R](#RD_YAW_RATE_P_TUNING).
@@ -126,8 +127,10 @@ To set up [Acro mode](../flight_modes_rover/differential.md#acro-mode) navigate 
    An integrator might not be neccessary at this stage, but it will become important for subsequent modes.
    :::
 
-1. (Optional) [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM) and [RO_YAW_DECEL_LIM](#RO_YAW_DECEL_LIM) [deg/s^2]: This is the maximum yaw acceleration and deceleration you want to allow for your rover.
-   This can be used to smooth the `yaw_rate` setpoints and make their trajectory feasible based on the physical limitation on the rover to improve tracking and avoid integrator build up.
+1. (Optional) [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM) and [RO_YAW_DECEL_LIM](#RO_YAW_DECEL_LIM) [deg/s^2]:
+   This is the maximum yaw acceleration and deceleration you want to allow for your rover.
+   This can be used to smooth the `yaw_rate` setpoints and make their trajectory feasible based on the physical limitations of the rover.
+   It also improves tracking and avoid integrator build up.
 
    ::: tip
    Your rover has a maximum possible yaw acceleration/deceleration which is determined by the maximum torque the motor can supply.
@@ -162,13 +165,14 @@ Therefore you only need to tune the closed loop gains:
 
    ::: tip
    In stabilized mode the closed loop yaw control is only active when driving a straight line (no yaw rate input).
-   Start with a value of 1 for [RO_YAW_P](#RO_YAW_P).
-   Put the rover into stabilized mode and move the left stick of your controller up and/or down to drive forwards/backwards.
-   Disarm the rover and from the flight log plot the `measured_yaw` and the `adjusted_yaw_setpoint` from the [RoverAttitudeStatus](../msg_docs/RoverAttitudeStatus.md) message over each other.
-   Increase/Decrease the parameter until you are satisfied with the setpoint tracking.
-   :::
 
-::: tip
+   1. Start with a value of 1 for [RO_YAW_P](#RO_YAW_P).
+   2. Put the rover into stabilized mode and move the left stick of your controller up and/or down to drive forwards/backwards.
+   3. Disarm the rover and from the flight log plot the `measured_yaw` and the `adjusted_yaw_setpoint` from the [RoverAttitudeStatus](../msg_docs/RoverAttitudeStatus.md) message over each other.
+   4. Increase/Decrease the parameter until you are satisfied with the setpoint tracking.
+      :::
+
+::: info
 For the closed loop yaw control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
 Since the yaw and yaw rate controllers are cascaded, there only needs to be one integrator which is in the yaw rate controller.
 If you observe a steady state error in the yaw setpoint increase the [RO_YAW_RATE_I](#RO_YAW_RATE_I) parameter.
@@ -271,9 +275,11 @@ These parameters are used to calculate the speed setpoint in auto modes:
 1. [RO_DECEL_LIM](#RO_DECEL_LIM) ($m/s^2$) and [RO_JERK_LIM](#RO_JERK_LIM) ($m/s^3$) are used to calculate a velocity trajectory such that the rover comes to a smooth stop as it reaches a waypoint.
 
    ::: tip
-   Plan a mission for the rover to drive a square and observe how it slows down when approaching a waypoint.
-   If the rover decelerates too quickly decrease the [RO_DECEL_LIM](#RO_DECEL_LIM) parameter, if it starts slowing down too early increase the parameter.
-   If you observe a jerking motion as the rover slows down, decrease the [RO_JERK_LIM](#RO_JERK_LIM) parameter otherwise increase it as much as possible as it can interfere with the tuning of [RO_DECEL_LIM](#RO_DECEL_LIM).
+   Plan a mission for the rover to drive a square and observe how it slows down when approaching a waypoint:
+
+   - If the rover decelerates too quickly decrease the [RO_DECEL_LIM](#RO_DECEL_LIM) parameter, if it starts slowing down too early increase the parameter.
+   - If you observe a jerking motion as the rover slows down, decrease the [RO_JERK_LIM](#RO_JERK_LIM) parameter otherwise increase it as much as possible as it can interfere with the tuning of [RO_DECEL_LIM](#RO_DECEL_LIM).
+
    These two parameters have to be tuned as a pair, repeat until you are satisfied with the behaviour.
    :::
 

--- a/en/config_rover/differential.md
+++ b/en/config_rover/differential.md
@@ -35,7 +35,8 @@ For this mode to work properly the [Basic Setup](#basic-setup) must've already b
 
 The basic setup already covers the minimum setup required to use the rover in [Manual mode](../flight_modes_rover/differential.md#manual-mode).
 
-However, this mode is also affected by acceleration/deceleration limits. This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
+However, this mode is also affected by acceleration/deceleration limits.
+This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
 Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
 
 1. [RD_WHEEL_TRACK](#RD_WHEEL_TRACK) [m]: Measure the distance from the centre of the right wheel to the centre of the left wheel.
@@ -45,7 +46,8 @@ Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and
 2. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: Drive the rover at full throttle and set this parameter to the observed value of the ground speed.
 
    :::info
-   This parameter is also used for the feed-forward term of the speed control. It will be further tuned in the configuration of [Position mode](#position-mode).
+   This parameter is also used for the feed-forward term of the speed control.
+   It will be further tuned in the configuration of [Position mode](#position-mode).
    :::
 
 3. (Optional) [RO_ACCEL_LIM](#RO_ACCEL_LIM) [m/s^2]: Maximum acceleration you want to allow for your rover.
@@ -68,7 +70,8 @@ Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and
    4. Set [RO_ACCEL_LIM](#RO_ACCEL_LIM) to a low value, give the rover full throttle from a standstill and observe its behaviour.
    5. Increase [RO_ACCEL_LIM](#RO_ACCEL_LIM) until the rover starts to lift up during the acceleration.
    6. Set [RO_ACCEL_LIM](#RO_ACCEL_LIM) to the highest value that does not cause the rover to lift up.
-      :::
+
+   :::
 
 4. (Optional) [RO_DECEL_LIM](#RO_DECEL_LIM) [m/s^2]: Maximum deceleration you want to allow for your rover.
 
@@ -137,7 +140,8 @@ To set up [Acro mode](../flight_modes_rover/differential.md#acro-mode) navigate 
    3. Disarm the rover and plot the `measured_yaw_rate` from [RoverRateStatus](../msg_docs/RoverRateStatus.md).
    4. Divide the maximum yaw rate by the time it took to reach it and set this as the value for [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM).
    5. Divide the maximum yaw rate by the time it took to return to a standstill and set this as the value for [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM).
-      :::
+
+   :::
 
 The rover is now ready to drive in [Acro mode](../flight_modes_rover/differential.md#acro-mode).
 
@@ -158,14 +162,16 @@ Therefore you only need to tune the closed loop gains:
 
    ::: tip
    In stabilized mode the closed loop yaw control is only active when driving a straight line (no yaw rate input).
-   Start with a value of 1 for [RO_YAW_P](#RO_YAW_P). Put the rover into stabilized mode and move the left stick of your controller up and/or down to drive forwards/backwards.
+   Start with a value of 1 for [RO_YAW_P](#RO_YAW_P).
+   Put the rover into stabilized mode and move the left stick of your controller up and/or down to drive forwards/backwards.
    Disarm the rover and from the flight log plot the `measured_yaw` and the `adjusted_yaw_setpoint` from the [RoverAttitudeStatus](../msg_docs/RoverAttitudeStatus.md) message over each other.
    Increase/Decrease the parameter until you are satisfied with the setpoint tracking.
    :::
 
 ::: tip
 For the closed loop yaw control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
-Since the yaw and yaw rate controllers are cascaded, there only needs to be one integrator which is in the yaw rate controller. If you observe a steady state error in the yaw setpoint increase the [RO_YAW_RATE_I](#RO_YAW_RATE_I) parameter.
+Since the yaw and yaw rate controllers are cascaded, there only needs to be one integrator which is in the yaw rate controller.
+If you observe a steady state error in the yaw setpoint increase the [RO_YAW_RATE_I](#RO_YAW_RATE_I) parameter.
 :::
 
 The rover is now ready to drive in [Stabilized mode](../flight_modes_rover/differential.md#stabilized-mode).
@@ -196,7 +202,8 @@ To configure set the following parameters:
    3. Disarm the rover and from the flight log plot the `adjusted_speed_body_x_setpoint` and the `measured_speed_body_x` from the [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md) message over each other.
    4. If the actual speed of the rover is higher than the speed setpoint, increase [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED).
       If it is the other way around decrease the parameter and repeat until you are satisfied with the setpoint tracking.
-      :::
+
+   :::
 
    ::: info
    If your rover oscillates when driving a straight line in [Position mode](../flight_modes_rover/differential.md#position-mode) just set this parameter to the observed ground speed at maximum throttle in [Manual mode](../flight_modes_rover/differential.md#manual-mode) and complete steps 5-7 first before continuing the tuning of the closed loop speed control (Steps 2-4).
@@ -227,7 +234,8 @@ To configure set the following parameters:
    2. Put the rover in [Position mode](../flight_modes_rover/differential.md#position-mode) and while driving a straight line at approximately half the maximum speed observe its behaviour.
    3. If the rover does not drive in a straight line, reduce the value of the parameter, if it oscillates around the path increase the value.
    4. Repeat until you are satisfied with the behaviour.
-      :::
+
+   :::
 
 6. [PP_LOOKAHD_MIN](#PP_LOOKAHD_MIN): Minimum threshold for the lookahead distance used by the [pure pursuit algorithm](#pure-pursuit-guidance-logic).
 

--- a/en/config_rover/mecanum.md
+++ b/en/config_rover/mecanum.md
@@ -40,7 +40,7 @@ Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and
 
 1. [RM_WHEEL_TRACK](#RM_WHEEL_TRACK) [m]: Measure the distance from the centre of the right wheel to the centre of the left wheel.
 
-   ![Wheel track](../../assets/airframes/rover/rover_differential/wheel_track.png)2. [RA_MAX_STR_ANG](#RA_MAX_STR_ANG) [deg]: Measure the maximum steering angle.
+   ![Wheel track](../../assets/airframes/rover/rover_differential/wheel_track.png)
 
 2. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: Drive the rover at full throttle and set this parameter to the observed value of the ground speed.
 
@@ -350,7 +350,7 @@ List of all parameters of the mecanum rover module:
 | <a id="RO_YAW_RATE_I"></a>[RO_YAW_RATE_I](../advanced_config/parameter_reference.md#RO_YAW_RATE_I)          | Integral gain for yaw rate controller                                  | -       |
 | <a id="RO_YAW_P"></a>[RO_YAW_P](../advanced_config/parameter_reference.md#RO_YAW_P)                         | Proportional gain for yaw controller                                   | -       |
 | <a id="RO_SPEED_LIM"></a>[RO_SPEED_LIM](../advanced_config/parameter_reference.md#RO_SPEED_LIM)             | Maximum allowed speed for the rover (and default mission speed).       | m/s     |
-| <a id="RO_MAX_THR_SPD"></a>[RO_MAX_THR_SPD](../advanced_config/parameter_reference.md#RO_MAX_THR_SPD)       | Speed the rover drives at maximum throttle                             | m/s     |
+| <a id="RO_MAX_THR_SPEED"></a>[RO_MAX_THR_SPEED](../advanced_config/parameter_reference.md#RO_MAX_THR_SPEED) | Speed the rover drives at maximum throttle                             | m/s     |
 | <a id="RO_SPEED_P"></a>[RO_SPEED_P](../advanced_config/parameter_reference.md#RO_SPEED_P)                   | Proportional gain for speed controller                                 | -       |
 | <a id="RO_SPEED_I"></a>[RO_SPEED_I](../advanced_config/parameter_reference.md#RO_SPEED_I)                   | Integral gain for speed controller                                     | -       |
 | <a id="PP_LOOKAHD_GAIN"></a>[PP_LOOKAHD_GAIN](../advanced_config/parameter_reference.md#PP_LOOKAHD_GAIN)    | Main tuning parameter for pure pursuit                                 | -       |

--- a/en/config_rover/mecanum.md
+++ b/en/config_rover/mecanum.md
@@ -35,8 +35,9 @@ For this mode to work properly the [Basic Setup](#basic-setup) must've already b
 
 The basic setup already covers the minimum setup required to use the rover in [Manual mode](../flight_modes_rover/mecanum.md#manual-mode).
 
-However, this mode is also affected by acceleration/deceleration limits
-This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
+This mode is also affected by (optional) acceleration/deceleration limits.
+As configuration of these limits becomes mandatory for subsequent modes, we do this setup here.
+
 Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
 
 1. [RM_WHEEL_TRACK](#RM_WHEEL_TRACK) [m]: Measure the distance from the centre of the right wheel to the centre of the left wheel.
@@ -112,7 +113,7 @@ To set up [Acro mode](../flight_modes_rover/mecanum.md#acro-mode) navigate to [P
 1. [RO_YAW_RATE_P](#RO_YAW_RATE_P) [-]: Proportional gain of the closed loop yaw rate controller.
    Unlike the feed-forward part of the controller, the closed loop yaw rate control will compare the yaw rate setpoint with the measured yaw rate and adapt to motor commands based on the error between them.
    The proportional gain is multiplied with this error and that value is added to the motor command.
-   This way disturbances like uneven grounds or external forces can be compensated.
+   This compensates for disturbances such as uneven ground and external forces.
 
    ::: tip
    This parameter can be tuned the same way as [RM_MAX_THR_YAW_R](#RM_YAW_RATE_P_TUNING).
@@ -168,7 +169,7 @@ Therefore you only need to tune the closed loop gains:
    Increase/Decrease the parameter until you are satisfied with the setpoint tracking.
    :::
 
-::: tip
+::: info
 For the closed loop yaw control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
 Since the yaw and yaw rate controllers are cascaded, there only needs to be one integrator which is in the yaw rate controller.
 If you observe a steady state error in the yaw setpoint increase the [RO_YAW_RATE_I](#RO_YAW_RATE_I) parameter.

--- a/en/config_rover/mecanum.md
+++ b/en/config_rover/mecanum.md
@@ -35,7 +35,8 @@ For this mode to work properly the [Basic Setup](#basic-setup) must've already b
 
 The basic setup already covers the minimum setup required to use the rover in [Manual mode](../flight_modes_rover/mecanum.md#manual-mode).
 
-However, this mode is also affected by acceleration/deceleration limits. This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
+However, this mode is also affected by acceleration/deceleration limits
+This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
 Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
 
 1. [RM_WHEEL_TRACK](#RM_WHEEL_TRACK) [m]: Measure the distance from the centre of the right wheel to the centre of the left wheel.
@@ -45,7 +46,8 @@ Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and
 2. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: Drive the rover at full throttle and set this parameter to the observed value of the ground speed.
 
    :::info
-   This parameter is also used for the feed-forward term of the speed control. It will be further tuned in the configuration of [Position mode](#position-mode).
+   This parameter is also used for the feed-forward term of the speed control.
+   It will be further tuned in the configuration of [Position mode](#position-mode).
    :::
 
 3. (Optional) [RO_ACCEL_LIM](#RO_ACCEL_LIM) [m/s^2]: Maximum acceleration you want to allow for your rover.
@@ -68,7 +70,8 @@ Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and
    4. Set [RO_ACCEL_LIM](#RO_ACCEL_LIM) to a low value, give the rover full throttle from a standstill and observe its behaviour.
    5. Increase [RO_ACCEL_LIM](#RO_ACCEL_LIM) until the rover starts to lift up during the acceleration.
    6. Set [RO_ACCEL_LIM](#RO_ACCEL_LIM) to the highest value that does not cause the rover to lift up.
-      :::
+
+   :::
 
 4. (Optional) [RO_DECEL_LIM](#RO_DECEL_LIM) [m/s^2]: Maximum deceleration you want to allow for your rover.
 
@@ -137,7 +140,8 @@ To set up [Acro mode](../flight_modes_rover/mecanum.md#acro-mode) navigate to [P
    3. Disarm the rover and plot the `measured_yaw_rate` from [RoverRateStatus](../msg_docs/RoverRateStatus.md).
    4. Divide the maximum yaw rate by the time it took to reach it and set this as the value for [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM).
    5. Divide the maximum yaw rate by the time it took to return to a standstill and set this as the value for [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM).
-      :::
+
+   :::
 
 The rover is now ready to drive in [Acro mode](../flight_modes_rover/mecanum.md#acro-mode).
 
@@ -158,14 +162,16 @@ Therefore you only need to tune the closed loop gains:
 
    ::: tip
    In stabilized mode the closed loop yaw control is only active when driving a straight line (no yaw rate input).
-   Start with a value of 1 for [RO_YAW_P](#RO_YAW_P). Put the rover into stabilized mode and move the left stick of your controller up and/or down to drive forwards/backwards.
+   Start with a value of 1 for [RO_YAW_P](#RO_YAW_P).
+   Put the rover into stabilized mode and move the left stick of your controller up and/or down to drive forwards/backwards.
    Disarm the rover and from the flight log plot the `measured_yaw` and the `adjusted_yaw_setpoint` from the [RoverAttitudeStatus](../msg_docs/RoverAttitudeStatus.md) message over each other.
    Increase/Decrease the parameter until you are satisfied with the setpoint tracking.
    :::
 
 ::: tip
 For the closed loop yaw control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
-Since the yaw and yaw rate controllers are cascaded, there only needs to be one integrator which is in the yaw rate controller. If you observe a steady state error in the yaw setpoint increase the [RO_YAW_RATE_I](#RO_YAW_RATE_I) parameter.
+Since the yaw and yaw rate controllers are cascaded, there only needs to be one integrator which is in the yaw rate controller.
+If you observe a steady state error in the yaw setpoint increase the [RO_YAW_RATE_I](#RO_YAW_RATE_I) parameter.
 :::
 
 The rover is now ready to drive in [Stabilized mode](../flight_modes_rover/mecanum.md#stabilized-mode).
@@ -201,7 +207,8 @@ The speed control in longitudinal and lateral direction use the same tuning para
    3. Disarm the rover and from the flight log plot the `adjusted_speed_body_x_setpoint` and the `measured_speed_body_x` from the [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md) message over each other.
    4. If the actual speed of the rover is higher than the speed setpoint, increase [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED).
       If it is the other way around decrease the parameter and repeat until you are satisfied with the setpoint tracking.
-      :::
+
+   :::
 
    ::: info
    If your rover oscillates when driving a straight line in [Position mode](../flight_modes_rover/mecanum.md#position-mode) just set this parameter to the observed ground speed at maximum throttle in [Manual mode](../flight_modes_rover/mecanum.md#manual-mode) and complete steps 5-7 first before continuing the tuning of the closed loop speed control (Steps 2-4).
@@ -232,7 +239,8 @@ The speed control in longitudinal and lateral direction use the same tuning para
    2. Put the rover in [Position mode](../flight_modes_rover/mecanum.md#position-mode) and while driving a straight line at approximately half the maximum speed observe its behaviour.
    3. If the rover does not drive in a straight line, reduce the value of the parameter, if it oscillates around the path increase the value.
    4. Repeat until you are satisfied with the behaviour.
-      :::
+
+   :::
 
 6. [PP_LOOKAHD_MIN](#PP_LOOKAHD_MIN): Minimum threshold for the lookahead distance used by the [pure pursuit algorithm](#pure-pursuit-guidance-logic).
 
@@ -287,7 +295,7 @@ These parameters are used to calculate the velocity setpoint in auto modes:
     v_{transition} = v_{max} \cdot (1 - \theta_{normalized} * k)
    $$
 
-   with
+   with:
 
    - $v_{transition}:$ Transition speed
    - $v_{max}:$ Maximum speed ([RO_SPEED_LIM](#RO_SPEED_LIM))

--- a/en/config_rover/mecanum.md
+++ b/en/config_rover/mecanum.md
@@ -29,86 +29,115 @@ To start using the mecanum rover:
 
 ## Manual Mode
 
-The basic setup (above) is all that is required to use the rover in [Manual mode](../flight_modes_rover/mecanum.md#manual-mode).
-
-::: info
-In manual mode the stick inputs are directly mapped to motor commands.
-Especially moving the stick that controls the yaw rate all the way to one side will cause the wheels on the left and right to spin at full speed in opposite directions.
-Depending on the rover this can lead to a very aggressive rotation.
-The parameters [RM_MAX_YAW_RATE](#RM_MAX_YAW_RATE) and [RM_MAX_THR_YAW_R](#RM_MAX_THR_YAW_R) can be used to scale the manual input for the yaw rate.
+::: warning
+For this mode to work properly the [Basic Setup](#basic-setup) must've already been completed!
 :::
 
-## Acro Mode
+The basic setup already covers the minimum setup required to use the rover in [Manual mode](../flight_modes_rover/mecanum.md#manual-mode).
 
-To set up [Acro mode](../flight_modes_rover/mecanum.md#acro-mode) navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
+However, this mode is also affected by acceleration/deceleration limits. This configuration becomes mandatory for subsequent modes, which is why we do this setup here.
+Navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
 
 1. [RM_WHEEL_TRACK](#RM_WHEEL_TRACK) [m]: Measure the distance from the centre of the right wheel to the centre of the left wheel.
 
-   ![Wheel track](../../assets/airframes/rover/rover_differential/wheel_track.png)
+   ![Wheel track](../../assets/airframes/rover/rover_differential/wheel_track.png)2. [RA_MAX_STR_ANG](#RA_MAX_STR_ANG) [deg]: Measure the maximum steering angle.
 
-2. [RM_MAX_YAW_RATE](#RM_MAX_YAW_RATE) [deg/s]: This is the maximum yaw rate you want to allow for your rover.
-   This will define the stick-to-yaw-rate mapping for all manual modes using closed loop yaw control and set an upper limit for the yaw rate setpoint for all [auto modes](#auto-modes).
+2. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: Drive the rover at full throttle and set this parameter to the observed value of the ground speed.
 
-   This value is set to your preference, there is no general rule of thumb since it depends entirely on your rover and use case.
-
-   :::tip
-   A rover has a maximum possible yaw rate which is determined by the rover geometry and the maximum torque the motors can supply.
-   If you have no reason to limit the yaw rate of your rover, you can set this parameter equal to the highest yaw rate observed in testing:
-
-   2. In [Manual Mode](../flight_modes_rover/mecanum.md#manual-mode) move the right-stick of your controller all the way to the left or right.
-      Disarm the rover and from the flight log plot the `actual_yaw_rate` from the [RoverMecanumSetpoint](../msg_docs/RoverMecanumStatus.md).
-   3. Set `RM_MAX_YAW_RATE` to the highest observed yaw rate.
-      Note that in the log the yaw rate is given in rad/s but the parameter is in deg/s, so you need to transform the value first.
-
-   If the rover turns are too aggressive for your use case:
-
-   4. Switch to [Acro Mode](../flight_modes_rover/mecanum.md#acro-mode).
-   5. Move the right-stick of your controller all the way to the left or right and observe the behaviour of the rover.
-      Keep reducing the value of [RM_MAX_YAW_RATE](#RM_MAX_YAW_RATE) until you are satisfied with the maximum turn rate.
-
+   :::info
+   This parameter is also used for the feed-forward term of the speed control. It will be further tuned in the configuration of [Position mode](#position-mode).
    :::
 
-3. [RM_MAX_THR_YAW_R](#RM_MAX_THR_YAW_R) [m/s]: This parameter is used to calculate the feed-forward term of the closed loop yaw rate control.
+3. (Optional) [RO_ACCEL_LIM](#RO_ACCEL_LIM) [m/s^2]: Maximum acceleration you want to allow for your rover.
+
+   <a id="RO_ACCEL_LIM_CONSIDERATIONS"></a>
+
+   :::tip
+   Your rover has a maximum possible acceleration which is determined by the maximum torque the motor can supply.
+   This may or may not be appropriate for your vehicle and use case.
+
+   One approach to determine an appropriate value is:
+
+   1. From a standstill, give the rover full throttle until it reaches the maximum speed.
+   2. Disarm the rover and plot the `measured_speed_body_x` from [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md).
+   3. Divide the maximum speed by the time it took to reach it and set this as the value for [RO_ACCEL_LIM](#RO_ACCEL_LIM).
+
+   Some RC rovers have enough torque to lift up if the maximum acceleration is not limited.
+   If that is the case:
+
+   4. Set [RO_ACCEL_LIM](#RO_ACCEL_LIM) to a low value, give the rover full throttle from a standstill and observe its behaviour.
+   5. Increase [RO_ACCEL_LIM](#RO_ACCEL_LIM) until the rover starts to lift up during the acceleration.
+   6. Set [RO_ACCEL_LIM](#RO_ACCEL_LIM) to the highest value that does not cause the rover to lift up.
+      :::
+
+4. (Optional) [RO_DECEL_LIM](#RO_DECEL_LIM) [m/s^2]: Maximum deceleration you want to allow for your rover.
+
+   :::tip
+   The same [considerations](#RO_ACCEL_LIM_CONSIDERATIONS) as in the configuration of [RO_ACCEL_LIM](#RO_ACCEL_LIM) apply.
+   :::
+
+   :::info
+   This parameter is also used for the calculation of the speed setpoint during [Auto modes](#auto-modes).
+   :::
+
+## Acro Mode
+
+::: warning
+For this mode to work properly [Manual mode](#manual-mode) must've already been configured!
+:::
+
+To set up [Acro mode](../flight_modes_rover/mecanum.md#acro-mode) navigate to [Parameters](../advanced_config/parameters.md) in QGroundControl and set the following parameters:
+
+1. [RO_YAW_RATE_LIM](#RO_YAW_RATE_LIM) [deg/s]: This is the maximum yaw rate you want to allow for your rover.
+   This will define the stick-to-yaw-rate mapping for all manual modes using closed loop yaw control and set an upper limit for the yaw rate setpoint for all [auto modes](#auto-modes).
+1. [RM_MAX_THR_YAW_R](#RM_MAX_THR_YAW_R) [m/s]: This parameter is used to calculate the feed-forward term of the closed loop yaw rate control.
    The controller calculates the required speed difference between the left and right motor to achieve the desired yaw rate.
    This desired speed difference is then linearly mapped to normalized motor commands.
-
    To get a good starting value for this parameter drive the rover in manual mode forwards at full throttle and note the ground speed of the vehicle.
-   Then enter _twice_ this value for the parameter.
+   Then enter _half_ this value for the parameter.
+   <a id="RM_YAW_RATE_P_TUNING"></a>
 
    ::: tip
-   To further tune this parameter, first make sure you set [RM_YAW_RATE_P](#RM_YAW_RATE_P) and [RM_YAW_RATE_I](#RM_YAW_RATE_I) to zero.
+   To further tune this parameter, first make sure you set [RO_YAW_RATE_P](#RO_YAW_RATE_P) and [RO_YAW_RATE_I](#RO_YAW_RATE_I) to zero.
    This way the yaw rate is only controlled by the feed-forward term, which makes it easier to tune.
    Now put the rover in [Acro mode](../flight_modes_rover/mecanum.md#acro-mode) and then move the right-stick of your controller to the right and/or left and hold it at a few different levels for a couple of seconds each.
-   Disarm the rover and from the flight log plot the _yaw_rate_setpoint_ and _actual_yaw_rate_ from the [RoverMecanumSetpoint](../msg_docs/RoverMecanumStatus.md) over each other.
-   If the actual yaw rate of the rover is higher than the yaw rate setpoint, increase [RM_MAX_THR_YAW_R](#RM_MAX_YAW_RATE).
+   Disarm the rover and from the flight log plot the `adjusted_yaw_rate_setpoint` from [RoverRateStatus](../msg_docs/RoverRateStatus.md) and the `measured_yaw_rate` from [RoverRateStatus](../msg_docs/RoverRateStatus.md) over each other.
+   If the actual yaw rate of the rover is higher than the yaw rate setpoint, increase [RM_MAX_THR_YAW_R](#RM_MAX_THR_YAW_R).
    If it is the other way around decrease the parameter and repeat until you are satisfied with the setpoint tracking.
    :::
 
-4. [RM_YAW_RATE_P](#RM_YAW_RATE_P) [-]: Proportional gain of the closed loop yaw rate controller.
+1. [RO_YAW_RATE_P](#RO_YAW_RATE_P) [-]: Proportional gain of the closed loop yaw rate controller.
    Unlike the feed-forward part of the controller, the closed loop yaw rate control will compare the yaw rate setpoint with the measured yaw rate and adapt to motor commands based on the error between them.
    The proportional gain is multiplied with this error and that value is added to the motor command.
-   This compensates for disturbances such as uneven ground and external forces.
+   This way disturbances like uneven grounds or external forces can be compensated.
 
    ::: tip
-   When tuning this parameter consider that increasing the value improves the disturbance rejection but can lead to an overshoot or oscillations around the setpoint.
-
-   To tune the value:
-
-   1. Set [RM_YAW_RATE_P](#RM_YAW_RATE_P) to `0.1`.
-   2. Put the rover in [Acro mode](../flight_modes_rover/mecanum.md#acro-mode) and then move the right-stick of your controller to the right and/or left and hold it at a few different levels for a couple of seconds each.
-   3. Disarm the rover and from the flight log plot the `yaw_rate_setpoint` and `actual_yaw_rate` from the [RoverMecanumSetpoint](../msg_docs/RoverMecanumStatus.md) over each other.
-   4. If the `actual_yaw_rate` overshoots the `yaw_rate_setpoint` or oscillates around it, reduce the value of [RM_YAW_RATE_P](#RM_YAW_RATE_P). Otherwise you _can_ increase this value.
-
-   Note that if you drive on flat ground you might not observe an improvement in setpoint tracking by increasing this value, since its main purpose is disturbance rejection (which is generally more effective with a higher value for [RM_YAW_RATE_P](#RM_YAW_RATE_P)).
+   This parameter can be tuned the same way as [RM_MAX_THR_YAW_R](#RM_YAW_RATE_P_TUNING).
+   If you tuned [RM_MAX_THR_YAW_R](#RM_MAX_THR_YAW_R) well, you might only need a very small value.
    :::
 
-5. (Optional) [RM_YAW_RATE_I](#RM_YAW_RATE_I) [-]: Integral gain of the closed loop yaw controller.
-   The integral gain accumulates the error between the desired and actual yaw rate over time and that value is added to the motor command.
+1. [RO_YAW_RATE_I](#RO_YAW_RATE_I) [-]: Integral gain of the closed loop yaw controller.
+   The integral gain accumulates the error between the desired and actual yaw rate scaled by the integral gain over time and that value is added to the motor command.
 
    ::: tip
-   The integrator gain is usually not necessary for the yaw rate setpoint as this is usually a fast changing value.
-   Leave this parameter at zero unless necessary, as it can have negative side effects such as overshooting or oscillating around the setpoint.
+   An integrator might not be neccessary at this stage, but it will become important for subsequent modes.
    :::
+
+1. (Optional) [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM) and [RO_YAW_DECEL_LIM](#RO_YAW_DECEL_LIM) [deg/s^2]: This is the maximum yaw acceleration and deceleration you want to allow for your rover.
+   This can be used to smooth the `yaw_rate` setpoints and make their trajectory feasible based on the physical limitation on the rover to improve tracking and avoid integrator build up.
+
+   ::: tip
+   Your rover has a maximum possible yaw acceleration/deceleration which is determined by the maximum torque the motor can supply.
+   This may or may not be appropriate for your vehicle and use case.
+
+   One approach to determine an appropriate value is:
+
+   1. Put the rover into [Manual mode](../flight_modes_rover/mecanum.md#manual-mode).
+   2. From a standstill, move the right stick all the way to the right or left until the rover reaches the maximum yaw rate then return the right stick to the middle.
+   3. Disarm the rover and plot the `measured_yaw_rate` from [RoverRateStatus](../msg_docs/RoverRateStatus.md).
+   4. Divide the maximum yaw rate by the time it took to reach it and set this as the value for [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM).
+   5. Divide the maximum yaw rate by the time it took to return to a standstill and set this as the value for [RO_YAW_ACCEL_LIM](#RO_YAW_ACCEL_LIM).
+      :::
 
 The rover is now ready to drive in [Acro mode](../flight_modes_rover/mecanum.md#acro-mode).
 
@@ -118,136 +147,100 @@ The rover is now ready to drive in [Acro mode](../flight_modes_rover/mecanum.md#
 For this mode to work properly [Acro mode](#acro-mode) must've already been configured!
 :::
 
-For [Stabilized mode](../flight_modes_rover/mecanum.md#stabilized-mode) the controller utilizes a closed loop yaw controller, which creates a yaw rate setpoint to control the yaw when driving in a straight line (no yaw rate input).
+For [Stabilized mode](../flight_modes_rover/mecanum.md#stabilized-mode) the controller utilizes a closed loop yaw controller, which creates a yaw rate setpoint to control the yaw when it is active:
 
 ![Cascaded PID for yaw control](../../assets/airframes/rover/rover_differential/cascaded_pid_for_yaw.png)
 
 Unlike the closed loop yaw rate, this controller has no feed-forward term.
 Therefore you only need to tune the closed loop gains:
 
-<a id="RM_YAW_TUNING"></a>
-
-1. [RM_YAW_P](#RM_YAW_P) and [RM_YAW_I](#RM_YAW_I) [-]: Proportional and integral gain for the closed loop yaw controller.
+1. [RO_YAW_P](#RO_YAW_P) [-]: Proportional gain for the closed loop yaw controller.
 
    ::: tip
    In stabilized mode the closed loop yaw control is only active when driving a straight line (no yaw rate input).
-
-   To tune it:
-
-   1. Set [RM_YAW_I](#RM_YAW_I) to zero and start with a value of 1 for [RM_YAW_P](#RM_YAW_P).
-   2. Put the rover into stabilized mode and move the left stick of your controller up and/or down to drive forwards/backwards.
-   3. Disarm the rover and from the flight log plot the _yaw_setpoint_ from the [RoverMecanumSetpoint](../msg_docs/RoverMecanumSetpoint.md) message and the _actual_yaw_ from the [RoverMecanumStatus](../msg_docs/RoverMecanumStatus.md) message over each other.
-   4. Increase/Decrease [RM_YAW_P](#RM_YAW_P) until you are satisfied with the setpoint tracking.
-
-      If you observe a constant offset between the _yaw_setpoint_ and _actual_yaw_ you might need the integrator term [RM_YAW_I](#RM_YAW_I).
-
-   For the closed loop yaw control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint:
-
-   1. First set [RM_YAW_I](#RM_YAW_I) to 0.01 and observe the setpoint tracking again.
-   2. If the _actual_yaw_ starts to overshoot the setpoint, reduce the value of [RM_YAW_I](#RM_YAW_I).
-      Otherwise you _can_ increase the value until you are satisfied with the setpoint tracking.
-
+   Start with a value of 1 for [RO_YAW_P](#RO_YAW_P). Put the rover into stabilized mode and move the left stick of your controller up and/or down to drive forwards/backwards.
+   Disarm the rover and from the flight log plot the `measured_yaw` and the `adjusted_yaw_setpoint` from the [RoverAttitudeStatus](../msg_docs/RoverAttitudeStatus.md) message over each other.
+   Increase/Decrease the parameter until you are satisfied with the setpoint tracking.
    :::
+
+::: tip
+For the closed loop yaw control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
+Since the yaw and yaw rate controllers are cascaded, there only needs to be one integrator which is in the yaw rate controller. If you observe a steady state error in the yaw setpoint increase the [RO_YAW_RATE_I](#RO_YAW_RATE_I) parameter.
+:::
 
 The rover is now ready to drive in [Stabilized mode](../flight_modes_rover/mecanum.md#stabilized-mode).
 
 ## Position Mode
 
 :::warning
-For this mode to work properly [Acro mode](#acro-mode) and [Stabilized mode](#stabilized-mode) must already be configured!
+For this mode to work properly [Stabilized mode](#stabilized-mode) must already be configured!
 :::
 
 [Position mode](../flight_modes_rover/mecanum.md#position-mode) is the most advanced manual mode, utilizing closed loop yaw rate, yaw and speed control and leveraging position estimates.
 
 To configure set the following parameters:
 
-1. [RM_MAX_SPEED](#RM_MAX_SPEED) [m/s]: This is the maximum speed you want to allow for your rover.
+::: info
+The speed control in longitudinal and lateral direction use the same tuning parameters.
+:::
+
+1. [RO_SPEED_LIM](#RO_SPEED_LIM) [m/s]: This is the maximum speed you want to allow for your rover.
    This will define the stick-to-speed mapping for position mode and set an upper limit for the speed setpoint for all [auto modes](#auto-modes).
-
-   :::tip
-   This value is set to your preference, there is no general rule of thumb since it depends entirely on your rover and use case.
-
-   The most straightforward approach is the following: Your rover has a maximum possible speed which is determined by the maximum torque the motors can supply.
-   In [Manual Mode](../flight_modes_rover/mecanum.md#manual-mode) move the left-stick of your controller all the way up or down.
-   Disarm the rover and from the flight log plot the _forward_speed_setpoint_ from the [RoverMecanumSetpoint](../msg_docs/RoverMecanumSetpoint.md) message and the _measured_forward_speed_ from the [RoverMecanumStatus](../msg_docs/RoverMecanumStatus.md) message over each other.
-   If you have no reason to limit the speed of your rover, simply set this parameter equal to the highest observed speed.
-
-   If you want to limit the maximum speed, you need to first complete Step 2.
-   After that in [Position Mode](../flight_modes_rover/mecanum.md#position-mode) move the left-stick of your controller all the way up or down and observe the behaviour of the rover.
-   Keep reducing the value of [RM_MAX_SPEED](#RM_MAX_SPEED) until you are satisfied with the maximum speed.
-   :::
-
-2. [RM_MAX_THR_SPD](#RM_MAX_THR_SPD) [m/s]: This parameter is used to calculate the feed-forward term of the closed loop speed control which linearly maps desired speeds to normalized motor commands.
+   For mecanum rovers the speed is defined in the direction of travel (magnitude of the velocity vector consisting of the longitudinal and lateral speed).
+2. [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) [m/s]: This parameter is used to calculate the feed-forward term of the closed loop speed control which linearly maps desired speeds to normalized motor commands.
    A good starting point is the observed ground speed when the rover drives at maximum throttle in [Manual mode](../flight_modes_rover/mecanum.md#manual-mode).
 
-   <a id="RM_SPEED_P_TUNING"></a>
+   <a id="RD_SPEED_P_TUNING"></a>
 
    ::: tip
    To further tune this parameter:
 
-   1. First make sure you set [RM_SPEED_P](#RM_YAW_RATE_P) and [RM_SPEED_I](#RM_SPEED_I) to zero.
-      This ensures the speed is only controlled by the feed-forward term, which makes it easier to tune.
-   2. Now put the rover in [Position mode](../flight_modes_rover/mecanum.md#position-mode) and then move the left stick of your controller up and/or down and hold it at a few different levels for a couple of seconds each.
-   3. Disarm the rover and from the flight log plot the _forward_speed_setpoint_ from the [RoverMecanumSetpoint](../msg_docs/RoverMecanumSetpoint.md) message and the _measured_forward_speed_ from the [RoverMecanumStatus](../msg_docs/RoverMecanumStatus.md) message over each other.
-
-      If the actual speed of the rover is higher than the speed setpoint, increase [RM_MAX_THR_SPD](#RM_MAX_THR_SPD).
+   1. Set [RO_SPEED_P](#RO_SPEED_P) and [RO_SPEED_I](#RO_SPEED_I) to zero.
+      This way the speed is only controlled by the feed-forward term, which makes it easier to tune.
+   2. Put the rover in [Position mode](../flight_modes_rover/mecanum.md#position-mode) and then move the left stick of your controller up and/or down and hold it at a few different levels for a couple of seconds each.
+   3. Disarm the rover and from the flight log plot the `adjusted_speed_body_x_setpoint` and the `measured_speed_body_x` from the [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md) message over each other.
+   4. If the actual speed of the rover is higher than the speed setpoint, increase [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED).
       If it is the other way around decrease the parameter and repeat until you are satisfied with the setpoint tracking.
-
-   :::
+      :::
 
    ::: info
    If your rover oscillates when driving a straight line in [Position mode](../flight_modes_rover/mecanum.md#position-mode) just set this parameter to the observed ground speed at maximum throttle in [Manual mode](../flight_modes_rover/mecanum.md#manual-mode) and complete steps 5-7 first before continuing the tuning of the closed loop speed control (Steps 2-4).
    :::
 
-3. [RM_SPEED_P](#RM_SPEED_P) and [RM_SPEED_I](#RM_SPEED_I) [-]: Proportional and integral gain of the closed loop speed controller.
+3. [RO_SPEED_P](#RO_SPEED_P) [-]: Proportional gain of the closed loop speed controller.
 
    ::: tip
-   When tuning this parameter we need to consider the following trade-off: Increasing the value of this parameter improves the disturbance rejection but can lead to an overshoot or oscillations around the setpoint.
-   To tune:
-
-   1. Start with a value of 0.1 for [RM_SPEED_P](#RM_SPEED_P).
-   2. Put the rover in [Position mode](../flight_modes_rover/mecanum.md#position-mode) and then move the left-stick of your controller up/down and hold it at a few different levels for a couple of seconds each.
-   3. Disarm the rover and from the flight log plot the _forward_speed_setpoint_ from the [RoverMecanumSetpoint](../msg_docs/RoverMecanumSetpoint.md) message and the _measured_forward_speed_ from the [RoverMecanumStatus](../msg_docs/RoverMecanumStatus.md) message over each other.
-
-      If the _measured_forward_speed_ overshoots the _forward_speed_setpoint_ or oscillates around it, reduce the value of [RM_SPEED_P](#RM_SPEED_P).
-      Otherwise you _can_ increase this value.
-
-      Note that if you drive on flat ground you might not observe an improvement in setpoint tracking by increasing this value, since its main purpose is disturbance rejection (which is generally more effective with a higher value for [RM_SPEED_P](#RM_SPEED_P)).
-
-      If you observe a constant offset between the _measured_forward_speed_ and _forward_speed_setpoint_ you might need the integrator term [RM_SPEED_I](#RM_SPEED_I).
-
-   For the closed loop speed control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint:
-
-   1. First set [RM_SPEED_I](#RM_SPEED_I) to 0.01 and observe the setpoint tracking again.
-   2. If the _measured_forward_speed_ starts to overshoot the setpoint, reduce the value of [RM_SPEED_I](#RM_SPEED_I).
-      Otherwise you _can_ increase the value until you are satisfied with the setpoint tracking.
-
+   This parameter can be tuned the same way as [RO_MAX_THR_SPEED](#RD_SPEED_P_TUNING).
+   If you tuned [RO_MAX_THR_SPEED](#RO_MAX_THR_SPEED) well, you might only need a very small value.
    :::
 
-4. [PP_LOOKAHD_GAIN](#PP_LOOKAHD_GAIN): When driving in a straight line (no yaw rate input) position mode leverages the same path following algorithm used in [auto modes](#auto-modes) called [pure pursuit](#pure-pursuit-guidance-logic) to achieve the best possible straight line driving behaviour ([Illustration of control architecture](#pure_pursuit_controller)).
+4. [RO_SPEED_I](#RO_SPEED_I) [-]: Integral gain for the closed loop speed controller.
+
+   ::: tip
+   For the closed loop speed control an integrator gain is useful because this setpoint is often constant for a while and an integrator eliminates steady state errors that can cause the rover to never reach the setpoint.
+   :::
+
+5. [PP_LOOKAHD_GAIN](#PP_LOOKAHD_GAIN): When driving in a straight line (no yaw rate input) position mode leverages the same path following algorithm used in [auto modes](#auto-modes) called [pure pursuit](#pure-pursuit-guidance-logic) to achieve the best possible straight line driving behaviour ([Illustration of control architecture](#pure_pursuit_controller)).
    This parameter determines how aggressive the controller will steer towards the path.
 
    ::: tip
-   Decreasing the parameter makes it more aggressive but can lead to oscillations:
+   Decreasing the parameter makes it more aggressive but can lead to oscillations.
+
+   To tune this:
 
    1. Start with a value of 1 for [PP_LOOKAHD_GAIN](#PP_LOOKAHD_GAIN)
    2. Put the rover in [Position mode](../flight_modes_rover/mecanum.md#position-mode) and while driving a straight line at approximately half the maximum speed observe its behaviour.
+   3. If the rover does not drive in a straight line, reduce the value of the parameter, if it oscillates around the path increase the value.
+   4. Repeat until you are satisfied with the behaviour.
+      :::
 
-      If the rover does not drive in a straight line, reduce the value of the parameter, if it oscillates around the path increase the value.
-
-   3. Repeat until you are satisfied with the behaviour.
-
-   Note that by increasing/decreasing the value of this parameter you change the _yaw_setpoint_ the control system attempts to track.
-   Make sure you check whether the system is actually able to track that setpoint, otherwise you need to further tune the closed loop yaw controller (this was initially done in the setup of [Stabilized Mode](#RM_YAW_TUNING)).
-   :::
-
-5. [PP_LOOKAHD_MIN](#PP_LOOKAHD_MIN): Minimum threshold for the lookahead distance used by the [pure pursuit algorithm](#pure-pursuit-guidance-logic).
+6. [PP_LOOKAHD_MIN](#PP_LOOKAHD_MIN): Minimum threshold for the lookahead distance used by the [pure pursuit algorithm](#pure-pursuit-guidance-logic).
 
    ::: tip
    Put the rover in [Position mode](../flight_modes_rover/mecanum.md#position-mode) and drive at very low speeds, if the rover starts to oscillate even though the tuning of [PP_LOOKAHD_GAIN](#PP_LOOKAHD_GAIN) was good for medium speeds, then increase the value of [PP_LOOKAHD_MIN](#PP_LOOKAHD_MIN).
    :::
 
-6. [PP_LOOKAHD_MAX](#PP_LOOKAHD_MAX): Maximum threshold for the lookahead distance used by [pure pursuit](#pure-pursuit-guidance-logic).
+7. [PP_LOOKAHD_MAX](#PP_LOOKAHD_MAX): Maximum threshold for the lookahead distance used by [pure pursuit](#pure-pursuit-guidance-logic).
 
    ::: tip
    Put the rover in [Position mode](../flight_modes_rover/mecanum.md#position-mode) and drive at very high speeds, if the rover does not drive in a straight line even though the tuning of [PP_LOOKAHD_GAIN](#PP_LOOKAHD_GAIN) was good for medium speeds, then decrease the value of [PP_LOOKAHD_MAX](#PP_LOOKAHD_MAX).
@@ -258,7 +251,7 @@ The rover is now ready to drive in [Position mode](../flight_modes_rover/mecanum
 ## Auto Modes
 
 ::: warning
-For this mode to work properly [Acro mode](#acro-mode), [Stabilized mode](#stabilized-mode) and [Position mode](#position-mode) must already be configured!
+For this mode to work properly [Position mode](#position-mode) must already be configured!
 :::
 
 <a id="pure_pursuit_controller"></a>
@@ -270,24 +263,24 @@ The mecanum module fully leverages the omnidirectionality of this type of rover 
 
 The required parameters are separated into the following sections:
 
-### Velocity
+### Speed
 
 These parameters are used to calculate the velocity setpoint in auto modes:
 
-1. [RM_MAX_SPEED](#RM_MAX_SPEED): Sets the default speed ($m/s$) for the rover during the mission (as well as the maximum speed).
-   For mecanum rovers the speed is defined in the direction of travel (magnitude of the velocity vector consisting of the forward and lateral speed).
-2. [RM_MAX_DECEL](#RM_MAX_DECEL) ($m/s^2$) and [RM_MAX_JERK](#RM_MAX_JERK) ($m/s^3$) are used to calculate a velocity trajectory such that the rover comes to a smooth stop as it reaches a waypoint.
+1. [RO_SPEED_LIM](#RO_SPEED_LIM): Sets the default speed ($m/s$) for the rover during the mission (as well as the maximum speed).
+   For mecanum rovers the speed is defined in the direction of travel (magnitude of the velocity vector consisting of the longitudinal and lateral speed).
+2. [RO_DECEL_LIM](#RO_DECEL_LIM) ($m/s^2$) and [RO_JERK_LIM](#RO_JERK_LIM) ($m/s^3$) are used to calculate a velocity trajectory such that the rover comes to a smooth stop as it reaches a waypoint.
 
    ::: tip
    Plan a mission for the rover to drive a square and observe how it slows down when approaching a waypoint:
 
-   - If the rover decelerates too quickly decrease the [RM_MAX_DECEL](#RM_MAX_DECEL) parameter, if it starts slowing down too early increase the parameter.
-   - If you observe a jerking motion as the rover slows down, decrease the [RM_MAX_JERK](#RM_MAX_JERK) parameter otherwise increase it as much as possible as it can interfere with the tuning of [RM_MAX_DECEL](#RM_MAX_DECEL).
+   - If the rover decelerates too quickly decrease the [RO_DECEL_LIM](#RO_DECEL_LIM) parameter, if it starts slowing down too early increase the parameter.
+   - If you observe a jerking motion as the rover slows down, decrease the [RO_JERK_LIM](#RO_JERK_LIM) parameter otherwise increase it as much as possible as it can interfere with the tuning of [RO_DECEL_LIM](#RO_DECEL_LIM).
 
    These two parameters have to be tuned as a pair, repeat until you are satisfied with the behaviour.
    :::
 
-3. [RM_MISS_VEL_GAIN](#RM_MISS_VEL_GAIN): The rover slows down when approaching a waypoint based on the angle between the line segment from the previous to current waypoint and current to next waypoint.
+3. [RM_MISS_SPD_GAIN](#RM_MISS_SPD_GAIN): The rover slows down when approaching a waypoint based on the angle between the line segment from the previous to current waypoint and current to next waypoint.
    How much the rover slows down can be tuned with this parameter:
 
    $$
@@ -297,29 +290,25 @@ These parameters are used to calculate the velocity setpoint in auto modes:
    with
 
    - $v_{transition}:$ Transition speed
-   - $v_{max}:$ Maximum speed ([RM_MAX_SPEED](#RM_MAX_SPEED))
+   - $v_{max}:$ Maximum speed ([RO_SPEED_LIM](#RO_SPEED_LIM))
    - $\theta_{normalized}:$ Angle between the line segment of the prev-current and current-next waypoints, normalized from $[0\degree, 180\degree]$ to $[0, 1]$
-   - $k:$ Tuning parameter ([RM_MISS_VEL_GAIN](#RM_MISS_VEL_GAIN)).
+   - $k:$ Tuning parameter ([RM_MISS_SPD_GAIN](#RM_MISS_SPD_GAIN)).
 
-4. Plot the _forward_speed_setpoint_ from the [RoverMecanumSetpoint](../msg_docs/RoverMecanumSetpoint.md) message and the _measured_forward_speed_ from the [RoverMecanumStatus](../msg_docs/RoverMecanumStatus.md) message over each other.
-   If the tracking of these setpoints is not satisfactory adjust the values for [RM_SPEED_P](#RM_SPEED_P) and [RM_SPEED_I](#RM_SPEED_I).
+4. Plot the `adjusted_speed_body_x_setpoint` and `measured_speed_body_x` from the [RoverVelocityStatus](../msg_docs/RoverVelocityStatus.md) message over each other.
+   If the tracking of these setpoints is not satisfactory adjust the values for [RO_SPEED_P](#RO_SPEED_P) and [RO_SPEED_I](#RO_SPEED_I).
 
 ### Path Following
 
-The [pure pursuit](#pure-pursuit-guidance-logic) algorithm is used to calculate a desired yaw for the vehicle that is then close loop controlled.
-The close loop yaw rate was tuned in the configuration of the [Stabilized mode](#stabilized-mode) and the pure pursuit was tuned when setting up the [Position mode](#position-mode).
-During any auto navigation task observe the behaviour of the rover.
-If you are unsatisfied with the path following, there are 3 steps to take:
+The [pure pursuit](#pure-pursuit-guidance-logic) algorithm is used to calculate a desired bearing for the vehicle that is then close loop controlled.
+For mecanum rovers the path following is achieved by directly controlling the velocity of the rover in direction of the desired bearing.
+During any auto navigation task observe the behaviour of the rover:
 
-1. Plot the _yaw_rate_setpoint_ and _actual_yaw_rate_ from the [RoverMecanumSetpoint](../msg_docs/RoverMecanumStatus.md) over each other.
-   If the tracking of these setpoints is not satisfactory adjust the values for [RM_YAW_RATE_P](#RM_YAW_RATE_P) and [RM_YAW_RATE_I](#RM_YAW_RATE_I).
-2. Plot the _yaw_setpoint_ from the [RoverMecanumSetpoint](../msg_docs/RoverMecanumSetpoint.md) message and the _actual_yaw_ from the [RoverMecanumStatus](../msg_docs/RoverMecanumStatus.md) message over each other.
-   If the tracking of these setpoints is not satisfactory adjust the values for [RM_YAW_P](#RM_YAW_P) and [RM_YAW_I](#RM_YAW_P).
-3. Steps 1 and 2 ensure accurate setpoint tracking, if the path following is still unsatisfactory you need to further tune the [pure pursuit](#pure-pursuit-guidance-logic) parameters.
+1. If you are unsatisfied with the path following you need to further tune the [pure pursuit](#pure-pursuit-guidance-logic) parameters.
+2. If the rover does not maintain its initial heading well enough, adjust the value for [RO_YAW_P](#RO_YAW_RATE_P) and potentially further tune [RO_YAW_RATE_I](#RO_YAW_RATE_I).
 
 ## Pure Pursuit Guidance Logic
 
-The desired yaw setpoints are generated using a pure pursuit algorithm:
+The desired bearing setpoints are generated using a pure pursuit algorithm:
 The controller takes the intersection point between a circle around the vehicle and a line segment.
 In mission mode this line is usually constructed by connecting the previous and current waypoint:
 
@@ -354,23 +343,25 @@ List of all parameters of the mecanum rover module:
 | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------- |
 | <a id="RM_WHEEL_TRACK"></a>[RM_WHEEL_TRACK](../advanced_config/parameter_reference.md#RM_WHEEL_TRACK)       | Wheel track                                                            | m       |
 | <a id="RM_MAX_THR_YAW_R"></a>[RM_MAX_THR_YAW_R](../advanced_config/parameter_reference.md#RM_MAX_THR_YAW_R) | Yaw rate turning left/right wheels at max speed in opposite directions | m/s     |
-| <a id="RM_MAX_YAW_RATE"></a>[RM_MAX_YAW_RATE](../advanced_config/parameter_reference.md#RM_MAX_YAW_RATE)    | Maximum allowed yaw rate for the rover                                 | deg/s   |
-| <a id="RM_YAW_RATE_P"></a>[RM_YAW_RATE_P](../advanced_config/parameter_reference.md#RM_YAW_RATE_P)          | Proportional gain for yaw rate controller                              | -       |
-| <a id="RM_YAW_RATE_I"></a>[RM_YAW_RATE_I](../advanced_config/parameter_reference.md#RM_YAW_RATE_I)          | Integral gain for yaw rate controller                                  | -       |
-| <a id="RM_YAW_P"></a>[RM_YAW_P](../advanced_config/parameter_reference.md#RM_YAW_P)                         | Proportional gain for yaw controller                                   | -       |
-| <a id="RM_YAW_I"></a>[RM_YAW_I](../advanced_config/parameter_reference.md#RM_YAW_I)                         | Integral gain for yaw controller                                       | -       |
-| <a id="RM_MAX_SPEED"></a>[RM_MAX_SPEED](../advanced_config/parameter_reference.md#RM_MAX_SPEED)             | Maximum allowed speed for the rover (and default mission speed).       | m/s     |
-| <a id="RM_MAX_THR_SPD"></a>[RM_MAX_THR_SPD](../advanced_config/parameter_reference.md#RM_MAX_THR_SPD)       | Speed the rover drives at maximum throttle                             | m/s     |
-| <a id="RM_SPEED_P"></a>[RM_SPEED_P](../advanced_config/parameter_reference.md#RM_SPEED_P)                   | Proportional gain for speed controller                                 | -       |
-| <a id="RM_SPEED_I"></a>[RM_SPEED_I](../advanced_config/parameter_reference.md#RM_SPEED_I)                   | Integral gain for speed controller                                     | -       |
+| <a id="RM_MISS_SPD_GAIN"></a>[RM_MISS_SPD_GAIN](../advanced_config/parameter_reference.md#RM_MISS_SPD_GAIN) | Tuning parameter for the velocity reduction during waypoint transition | -       |
+| <a id="RM_COURSE_CTL_TH"></a>[RM_COURSE_CTL_TH](../advanced_config/parameter_reference.md#RM_COURSE_CTL_TH) | Threshold to update course control in manual position mode             | rad     |
+| <a id="RO_YAW_RATE_LIM"></a>[RO_YAW_RATE_LIM](../advanced_config/parameter_reference.md#RO_YAW_RATE_LIM)    | Maximum allowed yaw rate for the rover                                 | deg/s   |
+| <a id="RO_YAW_RATE_P"></a>[RO_YAW_RATE_P](../advanced_config/parameter_reference.md#RO_YAW_RATE_P)          | Proportional gain for yaw rate controller                              | -       |
+| <a id="RO_YAW_RATE_I"></a>[RO_YAW_RATE_I](../advanced_config/parameter_reference.md#RO_YAW_RATE_I)          | Integral gain for yaw rate controller                                  | -       |
+| <a id="RO_YAW_P"></a>[RO_YAW_P](../advanced_config/parameter_reference.md#RO_YAW_P)                         | Proportional gain for yaw controller                                   | -       |
+| <a id="RO_SPEED_LIM"></a>[RO_SPEED_LIM](../advanced_config/parameter_reference.md#RO_SPEED_LIM)             | Maximum allowed speed for the rover (and default mission speed).       | m/s     |
+| <a id="RO_MAX_THR_SPD"></a>[RO_MAX_THR_SPD](../advanced_config/parameter_reference.md#RO_MAX_THR_SPD)       | Speed the rover drives at maximum throttle                             | m/s     |
+| <a id="RO_SPEED_P"></a>[RO_SPEED_P](../advanced_config/parameter_reference.md#RO_SPEED_P)                   | Proportional gain for speed controller                                 | -       |
+| <a id="RO_SPEED_I"></a>[RO_SPEED_I](../advanced_config/parameter_reference.md#RO_SPEED_I)                   | Integral gain for speed controller                                     | -       |
 | <a id="PP_LOOKAHD_GAIN"></a>[PP_LOOKAHD_GAIN](../advanced_config/parameter_reference.md#PP_LOOKAHD_GAIN)    | Main tuning parameter for pure pursuit                                 | -       |
 | <a id="PP_LOOKAHD_MAX"></a>[PP_LOOKAHD_MAX](../advanced_config/parameter_reference.md#PP_LOOKAHD_MAX)       | Maximum value for the look ahead radius of the pure pursuit algorithm  | m       |
 | <a id="PP_LOOKAHD_MIN"></a>[PP_LOOKAHD_MIN](../advanced_config/parameter_reference.md#PP_LOOKAHD_MIN)       | Minimum value for the look ahead radius of the pure pursuit algorithm  | m       |
-| <a id="RM_MAX_ACCEL"></a>[RM_MAX_ACCEL](../advanced_config/parameter_reference.md#RM_MAX_ACCEL)             | Maximum acceleration for the rover                                     | $m/s^2$ |
-| <a id="RM_MAX_DECEL"></a>[RM_MAX_DECEL](../advanced_config/parameter_reference.md#RM_MAX_DECEL)             | Maximum deceleration for the rover                                     | $m/s^2$ |
-| <a id="RM_MAX_JERK"></a>[RM_MAX_JERK](../advanced_config/parameter_reference.md#RM_MAX_JERK)                | Maximum jerk for the rover                                             | $m/s^3$ |
-| <a id="RM_MISS_VEL_GAIN"></a>[RM_MISS_VEL_GAIN](../advanced_config/parameter_reference.md#RM_MISS_VEL_GAIN) | Tuning parameter for the velocity reduction during waypoint transition | -       |
+| <a id="RO_ACCEL_LIM"></a>[RO_ACCEL_LIM](../advanced_config/parameter_reference.md#RO_ACCEL_LIM)             | (Optional) Maximum allowed acceleration                                | m/s^2   |
+| <a id="RO_DECEL_LIM"></a>[RO_DECEL_LIM](../advanced_config/parameter_reference.md#RO_DECEL_LIM)             | (Optional) Maximum allowed deceleration                                | m/s^2   |
+| <a id="RO_JERK_LIM"></a>[RO_JERK_LIM](../advanced_config/parameter_reference.md#RO_JERK_LIM)                | (Optional) Maximum allowed jerk                                        | $m/s^3$ |
+| <a id="RO_YAW_ACCEL_LIM"></a>[RO_YAW_ACCEL_LIM](../advanced_config/parameter_reference.md#RO_YAW_ACCEL_LIM) | (Optional) Maximum allowed yaw acceleration                            | m/s^2   |
+| <a id="RO_YAW_DECEL_LIM"></a>[RO_YAW_DECEL_LIM](../advanced_config/parameter_reference.md#RO_YAW_DECEL_LIM) | (Optional) Maximum allowed yaw deceleration                            | m/s^2   |
 
 ## See Also
 
-- [Drive Modes (Mecanum Rover)](../flight_modes_rover/differential.md).
+- [Drive Modes (Mecanum Rover)](../flight_modes_rover/mecanum.md).

--- a/en/flight_modes_rover/ackermann.md
+++ b/en/flight_modes_rover/ackermann.md
@@ -19,23 +19,23 @@ Manual modes require stick inputs from the user to drive the vehicle.
 The sticks provide the same "high level" control effects over direction and rate of movement in all manual modes:
 
 - `Left stick up/down`: Drive the rover forwards/backwards (controlling speed)
-- `Right stick left/right`: Make a left/right turn (controlling steering angle ([Manual mode](#manual-mode)) or lateral acceleration ([Acro](#acro-mode) and [Position](#position-mode))).
+- `Right stick left/right`: Make a left/right turn (controlling steering angle ([Manual mode](#manual-mode)) or yaw rate ([Acro](#acro-mode) and [Position](#position-mode))).
 
 The manual modes provide progressively increasing levels of autopilot support for maintaining a course, speed, and rate of turn, compensating for external factors such as slopes or uneven terrain.
 
-| Mode                       | Features                                                                                                                                                                                  |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Manual](#manual-mode)     | No autopilot support. User is responsible for keeping the rover on the desired course and maintaining speed and rate of turn.                                                             |
-| [Acro](#acro-mode)         | + Maintains the lateral acceleration (This makes it feel more like driving a car than manual mode). <br>+ Allows maximum lateral acceleration to be limited (Protects against roll over). |
-| [Position](#position-mode) | + Maintains the course (Best mode for driving a straight line).<br>+ Maintains speed against disturbances, e.g. when driving up a hill.<br>+ Allows maximum speed to be limited.          |
+| Mode                       | Features                                                                                                                                                                         |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Manual](#manual-mode)     | No autopilot support. User is responsible for keeping the rover on the desired course and maintaining speed and rate of turn.                                                    |
+| [Acro](#acro-mode)         | + Maintains the yaw rate (This makes it feel more like driving a car than manual mode). <br>+ Allows maximum yaw rate to be limited (Protects against roll over).                |
+| [Position](#position-mode) | + Maintains the course (Best mode for driving a straight line).<br>+ Maintains speed against disturbances, e.g. when driving up a hill.<br>+ Allows maximum speed to be limited. |
 
 ::: details Overview mode mapping to control effect
 
-| Mode                       | Forward/backwards speed                                                       | Steering angle/lateral acceleration                                                                                                                                                                     | Required measurements                                       |
-| -------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| [Manual](#manual-mode)     | Directly map stick input to motor command.                               | Directly map stick input to steering angle.                                                                                                                                                             | None.                                                       |
-| [Acro](#acro-mode)         | Directly map stick input to motor command.                               | Stick input creates a lateral acceleration setpoint for the control system to regulate.                                                                                                                 | Lateral acceleration.                                       |
-| [Position](#position-mode) | Stick input creates a speed setpoint for the control system to regulate. | Stick input creates a lateral acceleration setpoint for the control system to regulate. If this setpoint is zero (stick is centered) the control system will keep the rover driving in a straight line. | Lateral acceleration, yaw, speed and global position (GPS). |
+| Mode                       | Forward/backwards speed                                                  | Steering angle/yaw rate                                                                                                                                                                     | Required measurements                           |
+| -------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| [Manual](#manual-mode)     | Directly map stick input to motor command.                               | Directly map stick input to steering angle.                                                                                                                                                 | None.                                           |
+| [Acro](#acro-mode)         | Directly map stick input to motor command.                               | Stick input creates a yaw rate setpoint for the control system to regulate.                                                                                                                 | yaw rate.                                       |
+| [Position](#position-mode) | Stick input creates a speed setpoint for the control system to regulate. | Stick input creates a yaw rate setpoint for the control system to regulate. If this setpoint is zero (stick is centered) the control system will keep the rover driving in a straight line. | yaw rate, yaw, speed and global position (GPS). |
 
 :::
 
@@ -54,53 +54,70 @@ For the configuration/tuning of this mode see [Manual mode](../config_rover/acke
 ### Acro Mode
 
 ::: info
-This mode requires a lateral acceleration measurement.
+This mode requires a yaw rate measurement.
 :::
 
-In this mode the vehicle regulates its lateral acceleration to a setpoint (but does not stabilize heading or regulate speed).
+In this mode the vehicle regulates its yaw rate to a setpoint (but does not stabilize heading or regulate speed).
 
-Lateral acceleration can be directly mapped to a steering input based on the forward speed of the rover:
+Yaw rate can be directly mapped to a steering input based on the forward speed of the rover:
 
 <!-- prettier-ignore -->
-$$ \theta = \arctan(\frac{w_b \cdot a_{lat}}{ v^2}) $$
+$$ \delta = \arctan(\frac{w_b \cdot \dot{\psi}}{v}) $$
 
 with
 
 - $w_b:$ Wheel base,
-- $\theta:$ Steering angle,
+- $\delta:$ Steering angle,
+- $\dot{\psi}:$ Yaw rate
 - $v:$ Forward speed.
 
 For driving this means that the same right hand stick input will cause a different steering angle based on how fast you are driving.
-By limiting the maximum lateral acceleration, we can restrict the steering angle based on the speed, which can prevent the rover from rolling over.
+By limiting the maximum yaw rate, we can restrict the steering angle based on the speed, which can prevent the rover from rolling over.
 This mode will feel more like "driving a car" than [Manual mode](#manual-mode).
 
 ::: info
-The lateral acceleration is only close loop controlled when driving forwards. When driving backwards the lateral acceleration setpoint is directly mapped to a steering angle using the equation above.
-This is due to the fact that rear wheel steering (driving a car with front-wheel steering backwards) is non-minimum-phase w.r.t to the lateral acceleration which leads to instabilities when doing closed loop control.
+The yaw rate is only close loop controlled when driving forwards. When driving backwards the yaw rate setpoint is directly mapped to a steering angle using the equation above.
+This is due to the fact that rear wheel steering (driving a car with front-wheel steering backwards) is non-minimum-phase w.r.t to the yaw rate which leads to instabilities when doing closed loop control.
 :::
 
-| Stick                  | Effect                                                                                                                                                                                                   |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Left stick up/down     | Drive the rover forwards/backwards.                                                                                                                                                                      |
-| Right stick left/right | Create a lateral acceleration setpoint for the control system to regulate. If this input is zero the control system will attempt to maintain a zero lateral acceleration (minimal disturbance rejection) |
+| Stick                  | Effect                                                                                                                                                                           |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Left stick up/down     | Drive the rover forwards/backwards.                                                                                                                                              |
+| Right stick left/right | Create a yaw rate setpoint for the control system to regulate. If this input is zero the control system will attempt to maintain a zero yaw rate (minimal disturbance rejection) |
 
 For the configuration/tuning of this mode see [Acro mode](../config_rover/ackermann.md#acro-mode).
+
+### Stabilized Mode
+
+::: info
+This mode requires a yaw rate and yaw estimate.
+:::
+
+In this mode the vehicle regulates its yaw rate to a setpoint and will maintain its heading if this setpoint is zero (but does not regulate speed).
+Compared to [Acro mode](#acro-mode), this mode is much better at driving in a straight line as it can more effectively reject disturbances.
+
+| Stick                  | Effect                                                                                                                                 |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Left stick up/down     | Drive the rover forwards/backwards.                                                                                                    |
+| Right stick left/right | Create a yaw rate setpoint for the control system to regulate. If this input is zero the control system will maintain the current yaw. |
+
+For the configuration/tuning of this mode see [Stabilized mode](../config_rover/ackermann.md#stabilized-mode).
 
 ### Position Mode
 
 ::: info
-This mode requires a lateral acceleration, yaw, speed and global position estimate.
+This mode requires a yaw rate, yaw, speed and global position estimate.
 :::
 
-This is the manual mode with the most autopilot support. The vehicle regulates its lateral acceleration and speed to a setpoint. If the lateral acceleration setpoint is zero, the controller will remember the gps coordinates and yaw (heading) of the vehicle and use those to construct a line that the rover will then follow (course control).
+This is the manual mode with the most autopilot support. The vehicle regulates its yaw rate and speed to a setpoint. If the yaw rate setpoint is zero, the controller will remember the gps coordinates and yaw (heading) of the vehicle and use those to construct a line that the rover will then follow (course control).
 This offers the highest amount of disturbance rejection, which leads to the best straight line driving behavior.
 
-| Stick                  | Effect                                                                                                                                                     |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Left stick up/down     | Stick position sets a forward/back speed setpoint. The vehicle attempts to maintain this speed on slopes etc.                                              |
-| Right stick left/right | Create a lateral acceleration setpoint for the control system to regulate. If this input is zero the control system will maintain the course of the rover. |
+| Stick                  | Effect                                                                                                                                         |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Left stick up/down     | Stick position sets a forward/back speed setpoint. The vehicle attempts to maintain this speed on slopes etc.                                  |
+| Right stick left/right | Create a yaw rate setpoint for the control system to regulate. If this input is zero the control system will maintain the course of the rover. |
 
-For the configuration/tuning of this mode see [Position mode](../config_rover/differential.md#position-mode).
+For the configuration/tuning of this mode see [Position mode](../config_rover/ackermann.md#position-mode).
 
 ## Auto Modes
 
@@ -116,24 +133,20 @@ The mission is typically created and uploaded with a Ground Control Station (GCS
 
 The following commands can be used in missions at time of writing (`main(PX4 v1.16+)`):
 
-| QGC mission item    | Command                                                                        | Description                                                      |
-| ------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| Mission start       | [MAV_CMD_MISSION_START](MAV_CMD_MISSION_START)                                 | Starts the mission.                                              |
-| Waypoint            | [MAV_CMD_NAV_WAYPOINT](MAV_CMD_NAV_WAYPOINT)                                   | Navigate to waypoint.                                            |
-| Return to launch    | [MAV_CMD_NAV_RETURN_TO_LAUNCH][MAV_CMD_NAV_RETURN_TO_LAUNCH]                   | Return to the launch location.                                   |
-| Delay until         | [MAV_CMD_NAV_DELAY](MAV_CMD_NAV_DELAY)                                         | The rover will stop for a specified amount of time.              |
-| Change speed        | [MAV_CMD_DO_CHANGE_SPEED][MAV_CMD_DO_CHANGE_SPEED]                             | Change the speed setpoint                                        |
-| Set launch location | [MAV_CMD_DO_SET_HOME](MAV_CMD_DO_SET_HOME)                                     | Changes launch location to specified coordinates.                |
-| Jump to item (all)  | [MAV_CMD_DO_JUMP][MAV_CMD_DO_JUMP] (and other jump commands)                   | Jump to specified mission item.                                  |
-| Loiter (all)        | [MAV_CMD_NAV_LOITER_TIME][MAV_CMD_NAV_LOITER_TIME] (and other loiter commands) | Stop the rover for given time. Other commands stop indefinitely. |
+| QGC mission item    | Command                                                      | Description                                       |
+| ------------------- | ------------------------------------------------------------ | ------------------------------------------------- |
+| Mission start       | [MAV_CMD_MISSION_START](MAV_CMD_MISSION_START)               | Starts the mission.                               |
+| Waypoint            | [MAV_CMD_NAV_WAYPOINT](MAV_CMD_NAV_WAYPOINT)                 | Navigate to waypoint.                             |
+| Return to launch    | [MAV_CMD_NAV_RETURN_TO_LAUNCH][MAV_CMD_NAV_RETURN_TO_LAUNCH] | Return to the launch location.                    |
+| Change speed        | [MAV_CMD_DO_CHANGE_SPEED][MAV_CMD_DO_CHANGE_SPEED]           | Change the speed setpoint                         |
+| Set launch location | [MAV_CMD_DO_SET_HOME](MAV_CMD_DO_SET_HOME)                   | Changes launch location to specified coordinates. |
+| Jump to item (all)  | [MAV_CMD_DO_JUMP][MAV_CMD_DO_JUMP] (and other jump commands) | Jump to specified mission item.                   |
 
 [MAV_CMD_MISSION_START]: https://mavlink.io/en/messages/common.html#MAV_CMD_MISSION_START
 [MAV_CMD_NAV_WAYPOINT]: https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_WAYPOINT
 [MAV_CMD_NAV_RETURN_TO_LAUNCH]: https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_RETURN_TO_LAUNCH
-[MAV_CMD_NAV_DELAY]: https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_DELAY
 [MAV_CMD_DO_CHANGE_SPEED]: https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED
 [MAV_CMD_DO_SET_HOME]: https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_HOME
-[MAV_CMD_NAV_LOITER_TIME]: https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_TIME
 [MAV_CMD_DO_JUMP]: https://mavlink.io/en/messages/common.html#MAV_CMD_DO_JUMP
 
 ### Return Mode

--- a/en/flight_modes_rover/ackermann.md
+++ b/en/flight_modes_rover/ackermann.md
@@ -41,7 +41,8 @@ The manual modes provide progressively increasing levels of autopilot support fo
 
 ### Manual Mode
 
-In this mode the stick inputs are directly mapped to motor commands. The rover does not attempt to maintain a specific orientation or compensate for external factors like slopes or uneven terrain!
+In this mode the stick inputs are directly mapped to motor commands.
+The rover does not attempt to maintain a specific orientation or compensate for external factors like slopes or uneven terrain!
 The user is responsible for making the necessary adjustments to the stick inputs to keep the rover on the desired course.
 
 | Stick                  | Effect                                     |
@@ -76,7 +77,8 @@ By limiting the maximum yaw rate, we can restrict the steering angle based on th
 This mode will feel more like "driving a car" than [Manual mode](#manual-mode).
 
 ::: info
-The yaw rate is only close loop controlled when driving forwards. When driving backwards the yaw rate setpoint is directly mapped to a steering angle using the equation above.
+The yaw rate is only close loop controlled when driving forwards.
+When driving backwards the yaw rate setpoint is directly mapped to a steering angle using the equation above.
 This is due to the fact that rear wheel steering (driving a car with front-wheel steering backwards) is non-minimum-phase w.r.t to the yaw rate which leads to instabilities when doing closed loop control.
 :::
 
@@ -109,7 +111,9 @@ For the configuration/tuning of this mode see [Stabilized mode](../config_rover/
 This mode requires a yaw rate, yaw, speed and global position estimate.
 :::
 
-This is the manual mode with the most autopilot support. The vehicle regulates its yaw rate and speed to a setpoint. If the yaw rate setpoint is zero, the controller will remember the gps coordinates and yaw (heading) of the vehicle and use those to construct a line that the rover will then follow (course control).
+This is the manual mode with the most autopilot support.
+The vehicle regulates its yaw rate and speed to a setpoint.
+If the yaw rate setpoint is zero, the controller will remember the GPS coordinates and yaw (heading) of the vehicle and use those to construct a line that the rover will then follow (course control).
 This offers the highest amount of disturbance rejection, which leads to the best straight line driving behavior.
 
 | Stick                  | Effect                                                                                                                                         |

--- a/en/frames_rover/index.md
+++ b/en/frames_rover/index.md
@@ -49,6 +49,7 @@ Rovers use a custom build that must be flashed onto your flight controller inste
 ## Simulation
 
 [Gazebo](../sim_gazebo_gz/index.md) provides simulations for ackermann and differential rovers:
+
 - [Ackermann rover](../sim_gazebo_gz/vehicles.md#ackermann-rover)
 - [Differential rover](../sim_gazebo_gz/vehicles.md#differential-rover)
 

--- a/en/frames_rover/index.md
+++ b/en/frames_rover/index.md
@@ -33,7 +33,7 @@ Rovers use a custom build that must be flashed onto your flight controller inste
    ```
 
    ::: info
-   You can also enable the modules in default builds by adding the respective line to your [board configuration](../hardware/porting_guide_config.md) (e.g. for fmu-v6x you might add one of these lines to [`main/boards/px4/fmu-v6x/default.px4board`](https://github.com/PX4/PX4-Autopilot/blob/main/boards/px4/fmu-v6x/default.px4board)):
+   You can also enable the modules in default builds by adding these lines to your [board configuration](../hardware/porting_guide_config.md) (e.g. for fmu-v6x you might add them to [`main/boards/px4/fmu-v6x/default.px4board`](https://github.com/PX4/PX4-Autopilot/blob/main/boards/px4/fmu-v6x/default.px4board)):
 
    ```sh
    CONFIG_MODULES_ROVER_ACKERMANN=y
@@ -41,14 +41,14 @@ Rovers use a custom build that must be flashed onto your flight controller inste
    CONFIG_MODULES_ROVER_MECANUM=y
    ```
 
-   Note that adding the rover module may lead to flash overflow, in which case you will need to disable modules that you do not plan to use (such as those related to multicopter or fixed wing).
+   Note that adding the rover modules may lead to flash overflow, in which case you will need to disable modules that you do not plan to use (such as those related to multicopter or fixed wing).
    :::
 
 2. Load the **custom firmware** that you just built onto your flight controller (see [Loading Firmware > Installing PX4 Main, Beta or Custom Firmware](../config/firmware.md#installing-px4-main-beta-or-custom-firmware)).
 
 ## Simulation
 
-[Gazebo](../sim_gazebo_gz/index.md) provides simulations for both types of steering:
+[Gazebo](../sim_gazebo_gz/index.md) provides simulations for ackermann and differential rovers:
 - [Ackermann rover](../sim_gazebo_gz/vehicles.md#ackermann-rover)
 - [Differential rover](../sim_gazebo_gz/vehicles.md#differential-rover)
 


### PR DESCRIPTION
Update rover docs:. The following PRs refactored all the rover modules to a common code architecture:

- [ ] https://github.com/PX4/PX4-Autopilot/pull/24285, 
- [ ] https://github.com/PX4/PX4-Autopilot/pull/24318 
- [ ] https://github.com/PX4/PX4-Autopilot/pull/24403 

This included combining parameters and uORB messages that are shared among the modules under common names.
(i.e. `RA_MAX_THR_SPD`, `RD_MAX_THR_SPD` and `RM_MAX_THR_SPD` to `RO_MAX_THR_SPD`. )
This PR updates the parameter names and any references to the uORB messages in the documentation.

Additionally https://github.com/PX4/PX4-Autopilot/pull/24285 changed the rate control for ackermann rovers from `lateral acceleration` to `yaw rate` to bring in line with the other modules. It also added support for the manual `stabilized` mode for ackermann modules.
This PR adds documentation for these changes and additions for ackermann rovers.

Further includes other minor updates and improvements to rover related documentation.