### PR TITLE
Mark PX4 v.16+ as planned

### DIFF
--- a/en/flight_modes_rover/ackermann.md
+++ b/en/flight_modes_rover/ackermann.md
@@ -135,7 +135,7 @@ The mission is typically created and uploaded with a Ground Control Station (GCS
 
 #### Mission commands
 
-The following commands can be used in missions at time of writing (`main(PX4 v1.16+)`):
+The following commands can be used in missions at time of writing (`main`/planned for `PX4 v1.16+`):
 
 | QGC mission item    | Command                                                      | Description                                       |
 | ------------------- | ------------------------------------------------------------ | ------------------------------------------------- |

--- a/en/flight_modes_rover/differential.md
+++ b/en/flight_modes_rover/differential.md
@@ -114,7 +114,7 @@ The mission is typically created and uploaded with a Ground Control Station (GCS
 
 #### Mission commands
 
-The following commands can be used in missions at time of writing (`main(PX4 v1.16+)`):
+The following commands can be used in missions at time of writing (`main`/planned for `PX4 v1.16+`):
 
 | QGC mission item    | Command                                                                        | Description                                                      |
 | ------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------- |

--- a/en/flight_modes_rover/mecanum.md
+++ b/en/flight_modes_rover/mecanum.md
@@ -139,7 +139,7 @@ The mission is typically created and uploaded with a Ground Control Station (GCS
 
 #### Mission commands
 
-The following commands can be used in missions at time of writing (`main(PX4 v1.16+)`):
+The following commands can be used in missions at time of writing (`main`/planned for `PX4 v1.16+`):
 
 | QGC mission item    | Command                                                                        | Description                                                      |
 | ------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------- |

--- a/en/frames_rover/ackermann.md
+++ b/en/frames_rover/ackermann.md
@@ -1,6 +1,6 @@
 # Ackermann Rovers
 
-<Badge type="tip" text="main (PX4 v1.16+)" /> <Badge type="warning" text="Experimental" />
+<Badge type="tip" text="main (planned for: PX4 v1.16+)" /> <Badge type="warning" text="Experimental" />
 
 An _Ackermann rover_ controls its direction by pointing the front wheels in the direction of travel — the [Ackermann steering geometry](https://en.wikipedia.org/wiki/Ackermann_steering_geometry) compensates for the fact that wheels on the inside and outside of the turn move at different rates.
 This kind of steering is used on most commercial vehicles, including cars, trucks etc.

--- a/en/frames_rover/differential.md
+++ b/en/frames_rover/differential.md
@@ -1,6 +1,6 @@
 # Differential Rovers
 
-<Badge type="tip" text="main (PX4 v1.16+)" /> <Badge type="warning" text="Experimental" />
+<Badge type="tip" text="main (planned for: PX4 v1.16+)" /> <Badge type="warning" text="Experimental" />
 
 A differential rover's motion is controlled using a differential drive mechanism, where the left and right wheel speeds are adjusted independently to achieve the desired forward speed and yaw rate.
 Forward motion is achieved by driving both wheels at the same speed in the same direction.

--- a/en/frames_rover/mecanum.md
+++ b/en/frames_rover/mecanum.md
@@ -1,6 +1,6 @@
 # Mecanum Rovers
 
-<Badge type="tip" text="main (PX4 v1.16+)" /> <Badge type="warning" text="Experimental" />
+<Badge type="tip" text="main (planned for: PX4 v1.16+)" /> <Badge type="warning" text="Experimental" />
 
 A Mecanum rover is a type of mobile robot that uses Mecanum wheels to achieve omnidirectional movement. These wheels are unique because they have rollers mounted at a 45-degree angle around their circumference, allowing the rover to move not only forward and backward but also side-to-side and diagonally without needing to rotate first.
 Each wheel is driven by its own motor, and by controlling the speed and direction of each motor, the rover can move in any direction or spin in place.

--- a/en/middleware/uorb.md
+++ b/en/middleware/uorb.md
@@ -116,9 +116,9 @@ As there are external tools using uORB messages from log files, such as [Flight 
 
 ## Message Versioning
 
-<Badge type="tip" text="main (PX4 v1.16+)" />
+<Badge type="tip" text="main (planned for: PX4 v1.16+)" />
 
-Optional message versioning was introduced in the main branch (PX4 v1.16+) to make it easier to maintain compatibility between PX4 and ROS 2 versions compiled against different message definitions.
+Optional message versioning was introduced in the `main` branch (planned for PX4 v1.16+) to make it easier to maintain compatibility between PX4 and ROS 2 versions compiled against different message definitions.
 Versioned messages are designed to remain more stable over time compared to their non-versioned counterparts, as they are intended to be used across multiple releases of PX4 and external systems, ensuring greater compatibility over longer periods.
 
 Versioned messages include an additional field `uint32 MESSAGE_VERSION = x`, where `x` corresponds to the current version of the message.

--- a/en/ros2/px4_ros2_msg_translation_node.md
+++ b/en/ros2/px4_ros2_msg_translation_node.md
@@ -1,6 +1,6 @@
 # PX4 ROS 2 Message Translation Node
 
-<Badge type="tip" text="main (PX4 v1.16+)" /> <Badge type="warning" text="Experimental" />
+<Badge type="tip" text="main (planned for: PX4 v1.16+)" /> <Badge type="warning" text="Experimental" />
 
 The message translation node allows ROS 2 applications that were compiled against different versions of the PX4 messages to interwork with newer versions of PX4, and vice versa, without having to change either the application or the PX4 side.
 

--- a/en/ros2/user_guide.md
+++ b/en/ros2/user_guide.md
@@ -367,7 +367,7 @@ accelerometer_integral_dt: 4739
 
 #### (Optional) Starting the Translation Node
 
-<Badge type="tip" text="main (PX4 v1.16+)" /> <Badge type="tip" />  <Badge type="warning" text="Experimental" />
+<Badge type="tip" text="main (planned for: PX4 v1.16+)" /> <Badge type="tip" />  <Badge type="warning" text="Experimental" />
 
 This example is built with PX4 and ROS2 versions that use the same message definitions.
 If you were to use incompatible [message versions](../middleware/uorb.md#message-versioning) you would need to install and run the [Message Translation Node](./px4_ros2_msg_translation_node.md) as well, before running the example:


### PR DESCRIPTION
At least user found the reference to PX4 v1.16+ as confusing because there is no such release yet. This modifies that as "Planned for: PX4 v1.16" to reduce the chance of confusion.

Fixes #3587

