### PR TITLE
updated docs for holybro as now you need to configure actuators

### DIFF
--- a/en/frames_multicopter/holybro_x500V2_pixhawk5x.md
+++ b/en/frames_multicopter/holybro_x500V2_pixhawk5x.md
@@ -218,6 +218,7 @@ First update the firmware, airframe, and actuator mappings:
 
 Then perform the mandatory setup/calibration:
 
+- [Actuator Assignment](../config/actuators.md#actuator-outputs)
 - [Sensor Orientation](../config/flight_controller_orientation.md)
 - [Compass](../config/compass.md)
 - [Accelerometer](../config/accelerometer.md)

--- a/en/frames_multicopter/holybro_x500_pixhawk4.md
+++ b/en/frames_multicopter/holybro_x500_pixhawk4.md
@@ -237,6 +237,7 @@ First update the firmware, airframe, and actuator mappings:
 
 Then perform the mandatory setup/calibration:
 
+- [Actuator Assignment](../config/actuators.md#actuator-outputs)
 - [Sensor Orientation](../config/flight_controller_orientation.md)
 - [Compass](../config/compass.md)
 - [Accelerometer](../config/accelerometer.md)

--- a/en/frames_multicopter/holybro_x500v2_pixhawk6c.md
+++ b/en/frames_multicopter/holybro_x500v2_pixhawk6c.md
@@ -189,6 +189,7 @@ First update the firmware, airframe, and actuator mappings:
 
 Then perform the mandatory setup/calibration:
 
+- [Actuator Assignment](../config/actuators.md#actuator-outputs)
 - [Sensor Orientation](../config/flight_controller_orientation.md)
 - [Compass](../config/compass.md)
 - [Accelerometer](../config/accelerometer.md)


### PR DESCRIPTION
I updated the holybro vehicle file on mainline because of issue: https://github.com/PX4/PX4-Autopilot/issues/24449

Now, whoever is setting up the holybro x500 will have to map actuator output. I wanted the docs to reflect that

- [ ] https://github.com/PX4/PX4-Autopilot/issues/24449
- [ ] https://github.com/PX4/PX4-Autopilot/pull/24459