### PR TITLE
Update ssd size in Jetson baseboard documentation

### DIFF
--- a/en/companion_computer/holybro_pixhawk_jetson_baseboard.md
+++ b/en/companion_computer/holybro_pixhawk_jetson_baseboard.md
@@ -81,7 +81,7 @@ This information comes from the [Holybro Pixhawk-Jetson Baseboard Documentation]
 
   - USB-C
 
-- 2 Key M 2242 for NVMe SSD
+- 2 Key M 2242/2280 for NVMe SSD
 
   - PCIEx4
 


### PR DESCRIPTION
The official documentation only specifies the 2242 size, which is wrong. It also supports the 2280 size, which is also shown on images on the same page.

I have notified Holybro of the issue as well.