### PR TITLE
book.json - update version switcher for v1.16

### DIFF
--- a/book.json
+++ b/book.json
@@ -80,8 +80,12 @@
                     "text": "main"
                 },
                 {
-                    "value": "https://docs.px4.io/v1.15/en/",
+                    "value": "https://docs.px4.io/v1.16/en/",
                     "text": "v1.15 - stable"
+                },
+                {
+                    "value": "https://docs.px4.io/v1.15/en/",
+                    "text": "v1.15"
                 },
                 {
                     "value": "https://docs.px4.io/v1.14/en/",
@@ -105,4 +109,5 @@
     }
 
 }
+
 


### PR DESCRIPTION
This updates versions for older releases that use gitbook legacy. The particular change is to add v1.16.